### PR TITLE
feat-001: Core contracts & Agent orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Mypy strict
         run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src
       - name: Bandit
-        run: uv run bandit -q -r packages/agentforge-core/src packages/agentforge/src
+        # -c pyproject.toml so [tool.bandit] (skips B101) is honoured;
+        # without it, the conformance suite's asserts in
+        # agentforge_core.testing.conformance trip B101.
+        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,16 +71,19 @@ repos:
         types: [python]
         pass_filenames: false
 
+      # pytest exit 5 means "no tests collected"; we tolerate it during
+      # the early phase of feat-001 when integration / conformance dirs
+      # are still empty. Real failures (1, 2, 3, 4) still block.
       - id: pytest-unit
         name: pytest unit
-        entry: uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests tests/unit
+        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
         language: system
         always_run: true
         pass_filenames: false
 
       - id: pytest-integration
         name: pytest integration (excludes live)
-        entry: uv run pytest -q -x -m "not live" tests/integration
+        entry: bash -c 'uv run pytest -q -x -m "not live" tests/integration; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
         language: system
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,8 @@ repos:
 
       - id: bandit
         name: bandit security lint
-        entry: uv run bandit -q -r packages/agentforge-core/src packages/agentforge/src
+        # -c pyproject.toml so bandit reads [tool.bandit] (skips B101 etc.)
+        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src
         language: system
         types: [python]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,10 +43,12 @@ repos:
           - "revert"
 
   # ----------------------------------------------------------------------
-  # Python — ruff (format + lint)
+  # Python — ruff (format + lint).
+  # Pinned to match the uv-managed venv version so pre-commit and CI
+  # (which runs `uv run ruff`) agree on the format.
   # ----------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.12
     hooks:
       - id: ruff-format
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,27 @@ release tag bumps every workspace member to the same minor version.
 - Repository bootstrap: uv workspace, ruff/mypy/pytest/coverage tooling,
   GitHub Actions CI, pre-commit hook, Apache 2.0 license, AGENTS.md,
   README, member package skeletons (`agentforge-core`, `agentforge`).
+- **feat-001 (in progress)** — production-rails primitives and value
+  types in `agentforge-core`:
+  - `BudgetPolicy` with USD / token / iteration / error-streak caps and
+    reserve / commit / release semantics (per ADR-0010).
+  - `RunContext` + `current_run()` ContextVar + `RunIdFilter` for
+    structured-logging correlation across async tasks.
+  - Full exception hierarchy: `AgentForgeError` + `BudgetExceeded`,
+    `GuardrailViolation`, `ModuleError`, `ProviderError`,
+    `CapabilityNotSupported`.
+  - Frozen Pydantic v2 value types: `Message`, `ToolCall`, `ToolSpec`,
+    `TokenUsage`, `LLMResponse`, `Step`, `AgentState`, `RunResult`,
+    `Claim`.
+  - 100 unit tests + 1 Hypothesis property test; 99.22% coverage.
 
-[Unreleased]: https://github.com/.../agentforge-py/compare/HEAD...HEAD
+### Fixed
+
+- Repository placeholder URLs replaced with the live remote
+  (`github.com/Scaffoldic/agentforge-py`).
+- Workspace `pyproject.toml` migrated from deprecated
+  `[tool.uv] dev-dependencies` to `[dependency-groups] dev`; root
+  declares workspace members as dependencies so `uv sync` installs
+  them into the shared venv.
+
+[Unreleased]: https://github.com/Scaffoldic/agentforge-py/compare/HEAD...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,46 @@ release tag bumps every workspace member to the same minor version.
 - Repository bootstrap: uv workspace, ruff/mypy/pytest/coverage tooling,
   GitHub Actions CI, pre-commit hook, Apache 2.0 license, AGENTS.md,
   README, member package skeletons (`agentforge-core`, `agentforge`).
-- **feat-001 (in progress)** — production-rails primitives and value
-  types in `agentforge-core`:
-  - `BudgetPolicy` with USD / token / iteration / error-streak caps and
-    reserve / commit / release semantics (per ADR-0010).
-  - `RunContext` + `current_run()` ContextVar + `RunIdFilter` for
-    structured-logging correlation across async tasks.
-  - Full exception hierarchy: `AgentForgeError` + `BudgetExceeded`,
-    `GuardrailViolation`, `ModuleError`, `ProviderError`,
-    `CapabilityNotSupported`.
-  - Frozen Pydantic v2 value types: `Message`, `ToolCall`, `ToolSpec`,
-    `TokenUsage`, `LLMResponse`, `Step`, `AgentState`, `RunResult`,
-    `Claim`.
-  - 100 unit tests + 1 Hypothesis property test; 99.22% coverage.
+
+- **feat-001 — Core contracts & `Agent` orchestrator.** The
+  foundational layer of AgentForge.
+
+  *agentforge-core (Tier 1):*
+  - **Locked contracts (ABCs + Protocol):** `LLMClient`, `Tool`,
+    `ReasoningStrategy`, `MemoryStore`, `Evaluator` ABCs plus the
+    `Finding` Protocol. Adding a method to any of these is a major
+    version bump (per ADR-0007).
+  - **Locked value types (frozen Pydantic v2):** `Message`,
+    `ToolCall`, `ToolSpec`, `TokenUsage`, `LLMResponse`, `Step`,
+    `AgentState`, `RunResult`, `Claim`, `EvalResult`. Closed
+    `Literal` enums for `MessageRole`, `StopReason`, `StepKind`,
+    `FinishReason`. ULID-defaulted `Claim.id` and run ids.
+  - **Production rails:** `BudgetPolicy` (USD / token / iteration /
+    error-streak caps with `reserve` / `commit` / `release_reservation`
+    semantics), `RunContext` + `current_run()` ContextVar +
+    `bind_run` / `reset_run` lifecycle, `RunIdFilter` (idempotent
+    install / uninstall) for stdlib-logging correlation, full
+    exception hierarchy.
+  - **Resolver:** in-process module registry (`Resolver`,
+    `@register` decorator) and `parse_model_string` for the
+    `<provider>:<model_id>` syntax.
+  - **Testing utilities:** `agentforge_core.testing.run_memory_conformance`
+    — the shared conformance suite every memory driver must pass.
+
+  *agentforge (Tier 2 — default runtime):*
+  - **`Agent` orchestrator** with the locked constructor surface
+    per feat-001 §4.2 and the lifecycle defined in ADR-0010
+    (bind run_id → strategy.run → fire on_finish → produce
+    RunResult). Async context manager.
+  - **`InMemoryStore`** — process-local `MemoryStore` reference impl
+    used by default when no persistence module is configured.
+  - **Configuration loader** with env-var interpolation
+    (`${VAR}`, `${VAR:default}`, `${VAR:?error}`, `$$` → `$`),
+    Pydantic schema validation, and `extra="forbid"` rejection of
+    unknown sections (per ADR-0013).
+
+  *Tests:* 192 unit + integration + conformance + Hypothesis
+  property tests. 94.28% line + branch coverage on the diff.
 
 ### Fixed
 
@@ -36,5 +63,8 @@ release tag bumps every workspace member to the same minor version.
   `[tool.uv] dev-dependencies` to `[dependency-groups] dev`; root
   declares workspace members as dependencies so `uv sync` installs
   them into the shared venv.
+- Pre-commit `bandit` hook now passes `-c pyproject.toml` so it
+  reads `[tool.bandit]` (skips B101 — assert is the legitimate
+  conformance-suite mechanism).
 
 [Unreleased]: https://github.com/Scaffoldic/agentforge-py/compare/HEAD...HEAD

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ AgentForge
 Copyright 2026 The AgentForge Authors
 
 This product includes software developed at the AgentForge project
-(https://github.com/).
+(https://github.com/Scaffoldic/agentforge-py).
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agentforge-py
 
-Python implementation of [AgentForge](https://github.com/) — an open-source,
+Python implementation of [AgentForge](https://github.com/Scaffoldic/agentforge-py) — an open-source,
 plug-and-play framework for building production AI agents.
 
 > **Status:** v0.0 — pre-alpha. The repo is bootstrapped; no features

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -31,13 +31,15 @@ classifiers = [
 
 dependencies = [
     "pydantic>=2.10",
+    "python-ulid>=3.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/"
-Repository = "https://github.com/"
-Documentation = "https://github.com/"
-Changelog = "https://github.com/"
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Documentation = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Scaffoldic/agentforge-py/issues"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -4,13 +4,22 @@ Per ADR-0007, this package's public surface is the framework's locked
 contract layer. Adding a method to an ABC is a major version bump.
 
 This module re-exports every public symbol so consumers can import
-from `agentforge_core` directly. Submodules (`agentforge_core.values`,
-`agentforge_core.production`, etc.) remain part of the public surface
-for granular imports.
+from `agentforge_core` directly. Submodules (`agentforge_core.contracts`,
+`agentforge_core.values`, `agentforge_core.production`) remain part of
+the public surface for granular imports.
 """
 
 from __future__ import annotations
 
+from agentforge_core.contracts import (
+    EvalResult,
+    Evaluator,
+    Finding,
+    LLMClient,
+    MemoryStore,
+    ReasoningStrategy,
+    Tool,
+)
 from agentforge_core.production import (
     AgentForgeError,
     BudgetExceeded,
@@ -47,20 +56,25 @@ from agentforge_core.values import (
 __version__ = "0.0.0"
 
 __all__ = [
-    # Errors
     "AgentForgeError",
     "AgentState",
     "BudgetExceeded",
     "BudgetPolicy",
     "CapabilityNotSupported",
     "Claim",
+    "EvalResult",
+    "Evaluator",
+    "Finding",
     "FinishReason",
     "GuardrailViolation",
+    "LLMClient",
     "LLMResponse",
+    "MemoryStore",
     "Message",
     "MessageRole",
     "ModuleError",
     "ProviderError",
+    "ReasoningStrategy",
     "RunContext",
     "RunIdFilter",
     "RunResult",
@@ -68,6 +82,7 @@ __all__ = [
     "StepKind",
     "StopReason",
     "TokenUsage",
+    "Tool",
     "ToolCall",
     "ToolSpec",
     "__version__",

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -37,6 +37,11 @@ from agentforge_core.production import (
     reset_run,
     uninstall_run_id_filter,
 )
+from agentforge_core.resolver import (
+    Resolver,
+    parse_model_string,
+    register,
+)
 from agentforge_core.values import (
     AgentState,
     Claim,
@@ -75,6 +80,7 @@ __all__ = [
     "ModuleError",
     "ProviderError",
     "ReasoningStrategy",
+    "Resolver",
     "RunContext",
     "RunIdFilter",
     "RunResult",
@@ -90,6 +96,8 @@ __all__ = [
     "current_run",
     "install_run_id_filter",
     "new_run",
+    "parse_model_string",
+    "register",
     "reset_run",
     "uninstall_run_id_filter",
 ]

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -1,11 +1,80 @@
 """AgentForge core — stable contracts (ABCs, value types).
 
-This package is the locked contract layer of the AgentForge framework.
-It ships ABCs, Protocols, and value types that every module implements.
+Per ADR-0007, this package's public surface is the framework's locked
+contract layer. Adding a method to an ABC is a major version bump.
 
-See `agentforge-core/README.md` and `docs/features/feat-001-*.md` for
-the full design.
+This module re-exports every public symbol so consumers can import
+from `agentforge_core` directly. Submodules (`agentforge_core.values`,
+`agentforge_core.production`, etc.) remain part of the public surface
+for granular imports.
 """
 
+from __future__ import annotations
+
+from agentforge_core.production import (
+    AgentForgeError,
+    BudgetExceeded,
+    BudgetPolicy,
+    CapabilityNotSupported,
+    GuardrailViolation,
+    ModuleError,
+    ProviderError,
+    RunContext,
+    RunIdFilter,
+    bind_run,
+    current_run,
+    install_run_id_filter,
+    new_run,
+    reset_run,
+    uninstall_run_id_filter,
+)
+from agentforge_core.values import (
+    AgentState,
+    Claim,
+    FinishReason,
+    LLMResponse,
+    Message,
+    MessageRole,
+    RunResult,
+    Step,
+    StepKind,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    ToolSpec,
+)
+
 __version__ = "0.0.0"
-__all__: list[str] = []
+
+__all__ = [
+    # Errors
+    "AgentForgeError",
+    "AgentState",
+    "BudgetExceeded",
+    "BudgetPolicy",
+    "CapabilityNotSupported",
+    "Claim",
+    "FinishReason",
+    "GuardrailViolation",
+    "LLMResponse",
+    "Message",
+    "MessageRole",
+    "ModuleError",
+    "ProviderError",
+    "RunContext",
+    "RunIdFilter",
+    "RunResult",
+    "Step",
+    "StepKind",
+    "StopReason",
+    "TokenUsage",
+    "ToolCall",
+    "ToolSpec",
+    "__version__",
+    "bind_run",
+    "current_run",
+    "install_run_id_filter",
+    "new_run",
+    "reset_run",
+    "uninstall_run_id_filter",
+]

--- a/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
@@ -1,0 +1,25 @@
+"""Locked contracts — ABCs and the `Finding` Protocol.
+
+Per ADR-0007, these are the framework's stable surface. Adding a method
+to an ABC is a major version bump. Modules implement these; the runtime
+consumes them by reference to the abstraction, never the implementation.
+"""
+
+from __future__ import annotations
+
+from agentforge_core.contracts.evaluator import EvalResult, Evaluator
+from agentforge_core.contracts.finding import Finding
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.contracts.tool import Tool
+
+__all__ = [
+    "EvalResult",
+    "Evaluator",
+    "Finding",
+    "LLMClient",
+    "MemoryStore",
+    "ReasoningStrategy",
+    "Tool",
+]

--- a/packages/agentforge-core/src/agentforge_core/contracts/evaluator.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/evaluator.py
@@ -1,0 +1,56 @@
+"""`Evaluator` — the locked post-run evaluator ABC, plus `EvalResult`.
+
+feat-001 ships only the contract and the result type. feat-006 ships
+deterministic graders (coverage, consistency, regression-vs-baseline,
+format-compliance) and LLM-judge graders (correctness, faithfulness,
+groundedness, hallucination, relevance, helpfulness) via the
+`agentforge-eval-geval` module.
+
+Evaluators run *after* the reasoning loop completes and score the
+agent's output (per `docs/features/feat-006-evaluators-and-benchmarks.md`).
+This is distinct from real-time validators (feat-018) which block /
+redact at the moment a violation happens.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EvalResult(BaseModel):
+    """The outcome of evaluating one finding (or output)."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    evaluator: str
+    score: float
+    """Conventionally in [0, 1]; NaN allowed for "not applicable"."""
+
+    label: str | None = None
+    """Optional discrete label such as "pass" / "fail" / "warn"."""
+
+    reasoning: str | None = None
+    """LLM-judge rationale or rule-based explanation."""
+
+    raw: dict[str, Any] = Field(default_factory=dict)
+    """Driver-specific extra detail — never required, never relied on."""
+
+
+class Evaluator(ABC):
+    """Post-run quality scorer.
+
+    Subclasses declare:
+
+        name: str                   — identifier surfaced in EvalResult
+        cost_estimate_usd: float    — per-evaluation cost (0 for non-LLM)
+    """
+
+    name: ClassVar[str]
+    cost_estimate_usd: ClassVar[float] = 0.0
+
+    @abstractmethod
+    async def evaluate(self, finding: Any, context: dict[str, Any]) -> EvalResult:
+        """Score `finding` against this evaluator's rubric."""

--- a/packages/agentforge-core/src/agentforge_core/contracts/finding.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/finding.py
@@ -1,0 +1,39 @@
+"""`Finding` — structural Protocol the agent's output items satisfy.
+
+Per feat-008 / ADR-0012, `Finding` is a `runtime_checkable` Protocol
+rather than a single dataclass. Shipped variants (`SimpleFinding`,
+`PatchFinding`, `NarrativeFinding`, `MultiSpanFinding`) live in the
+runtime package; they satisfy this Protocol structurally without
+needing to inherit from anything.
+
+Custom variants from agent code or third-party packages also satisfy
+the Protocol simply by declaring the required attributes — no
+registration ceremony.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Finding(Protocol):
+    """Minimum shape any pipeline / agent output item satisfies.
+
+    The runtime checks `isinstance(x, Finding)` opportunistically (e.g.
+    when storing as a `Claim.payload`); the check is structural and
+    tolerant.
+    """
+
+    severity: str
+    """One of "critical" | "warning" | "suggestion" | "info"."""
+
+    category: str
+    """Free-form categorisation: "style", "security", "answer", etc."""
+
+    message: str
+    """Short human-readable summary (one or two sentences)."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict for persistence / transport."""
+        ...

--- a/packages/agentforge-core/src/agentforge_core/contracts/llm.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/llm.py
@@ -1,0 +1,60 @@
+"""`LLMClient` — the locked LLM provider abstraction.
+
+feat-001 ships the minimum surface: `call`, `close`, and capability
+introspection. feat-003 extends with `call_with_cache`,
+`call_with_thinking`, `stream`, and the `EmbeddingClient` ABC, all
+behind capability flags so the surface stays additive (per ADR-0009).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from agentforge_core.values.messages import LLMResponse, Message, ToolSpec
+
+
+class LLMClient(ABC):
+    """Provider-agnostic chat-completion client.
+
+    Every provider module implements this ABC. Reasoning strategies
+    consume `LLMClient` (not the concrete provider type) so a string-id
+    swap (`"anthropic:..."` → `"bedrock:..."`) requires no code change.
+    """
+
+    @abstractmethod
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        """Issue a single chat-completion request.
+
+        Args:
+            system: System prompt.
+            messages: Conversation turns to date.
+            tools: Optional tool catalogue exposed to the LLM.
+
+        Returns:
+            The provider's response, normalised to `LLMResponse`.
+        """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release any resources (HTTP clients, connection pools)."""
+
+    def capabilities(self) -> set[str]:
+        """Optional capabilities this provider supports.
+
+        Default empty set. Subclasses override to declare capabilities
+        from the closed vocabulary (per ADR-0009): "caching", "thinking",
+        "streaming", "tools", "json_mode", "vision", "parallel_tools".
+
+        Returns:
+            Set of capability names.
+        """
+        return set()
+
+    def supports(self, capability: str) -> bool:
+        """True if this client declares the given capability."""
+        return capability in self.capabilities()

--- a/packages/agentforge-core/src/agentforge_core/contracts/memory.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/memory.py
@@ -1,0 +1,92 @@
+"""`MemoryStore` — the locked persistence ABC.
+
+feat-001 ships the contract plus an `InMemoryStore` reference impl in
+the runtime package. feat-005 adds drivers for SQLite, PostgreSQL,
+SurrealDB, and Neo4j (all passing the same conformance suite per
+ADR-0007 and feat-016's `run_memory_conformance`).
+
+Per feat-005's design (`docs/design/persistence-and-orm.md`), every
+driver implements `MemoryStore`; graph-capable drivers additionally
+implement `GraphStore` (deferred to feat-005).
+
+Cross-agent isolation: every query is scoped by `(project, agent)` by
+default. Cross-scope access requires explicit `None` filters — a
+deliberate verb, not an accident.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+
+from agentforge_core.values.claim import Claim
+
+
+class MemoryStore(ABC):
+    """Persistent store of `Claim`s with `(project, agent)` namespacing."""
+
+    @abstractmethod
+    async def put(self, claim: Claim) -> str:
+        """Persist `claim`. Returns its id (the claim's own ULID by default)."""
+
+    @abstractmethod
+    async def get(self, claim_id: str) -> Claim | None:
+        """Fetch a claim by id, or None if not present."""
+
+    @abstractmethod
+    async def query(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+        limit: int = 100,
+    ) -> list[Claim]:
+        """Query claims with the given filters.
+
+        Filters are conjunctive. Passing `None` for `project` or `agent`
+        explicitly broadens the scope (cross-scope access is a verb).
+        """
+
+    @abstractmethod
+    async def supersede(self, old_id: str, new_claim: Claim) -> str:
+        """Replace `old_id` with `new_claim`; preserves history.
+
+        Sets `new_claim.supersedes = old_id` if not already set; returns
+        the new claim's id.
+        """
+
+    @abstractmethod
+    def stream(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+    ) -> AsyncIterator[Claim]:
+        """Stream all matching claims as an async iterator.
+
+        Required even on backends with paged queries — drivers paginate
+        internally and yield `Claim`s as they arrive.
+        """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release backing resources (connections, file handles)."""
+
+    def capabilities(self) -> set[str]:
+        """Optional capabilities this driver supports.
+
+        Default empty set. Subclasses declare capabilities from the
+        closed vocabulary: "graph", "vector", "fts", "transactions",
+        "ttl", "encryption_at_rest". Per ADR-0009, declarations must be
+        honest — a nightly conformance test exercises every declared
+        capability against the real backend.
+        """
+        return set()
+
+    def supports(self, capability: str) -> bool:
+        """True if this driver declares the given capability."""
+        return capability in self.capabilities()

--- a/packages/agentforge-core/src/agentforge_core/contracts/strategy.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/strategy.py
@@ -1,0 +1,35 @@
+"""`ReasoningStrategy` — the locked reasoning-loop ABC.
+
+feat-001 ships only the contract. feat-002 ships `ReActLoop` (the stable
+default) and three experimental loops (`PlanExecuteLoop`,
+`TreeOfThoughts`, `MultiAgentSupervisor`).
+
+Every concrete strategy honours these invariants (enforced by the
+conformance suite in feat-002):
+
+  - Guardrails (`BudgetPolicy.check`) are called before every LLM call.
+  - All state flows through one shared `AgentState` — no module globals.
+  - Every reasoning step is appended to `state.steps`.
+  - Termination is one of: finish signal, max_iterations, guardrail trip.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from agentforge_core.values.state import AgentState
+
+
+class ReasoningStrategy(ABC):
+    """Drives the agent from initial task to terminal state."""
+
+    @abstractmethod
+    async def run(self, state: AgentState) -> AgentState:
+        """Execute the reasoning loop until termination.
+
+        Args:
+            state: The mutable per-run state.
+
+        Returns:
+            The same `AgentState` instance with `steps` populated.
+        """

--- a/packages/agentforge-core/src/agentforge_core/contracts/tool.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/tool.py
@@ -1,0 +1,71 @@
+"""`Tool` — the locked tool ABC.
+
+feat-001 ships the explicit-`input_schema` form. feat-004 layers a
+`@tool` decorator on top that infers the schema from a typed function's
+signature; the resulting object is still a `Tool` subclass under the
+hood.
+"""
+
+from __future__ import annotations
+
+import inspect
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from pydantic import BaseModel
+
+from agentforge_core.values.messages import ToolSpec
+
+
+class Tool(ABC):
+    """A typed callable the agent can invoke.
+
+    Subclasses declare three class attributes:
+
+        name: str                   — unique identifier the LLM sees
+        description: str            — human-readable usage description
+        input_schema: type[BaseModel]
+                                    — Pydantic v2 model for inputs
+
+    Plus override `run`. The decorator-based path in feat-004 builds
+    these attributes automatically from a typed function.
+    """
+
+    name: ClassVar[str]
+    description: ClassVar[str]
+    input_schema: ClassVar[type[BaseModel]]
+    capabilities: ClassVar[frozenset[str]] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if inspect.isabstract(cls):
+            return
+        # Concrete subclasses must declare the three class attributes.
+        for attr in ("name", "description", "input_schema"):
+            if attr not in cls.__dict__ and not _inherited_attr(cls, attr):
+                raise TypeError(
+                    f"{cls.__name__} must declare class attribute '{attr}' (see Tool docstring)."
+                )
+
+    @abstractmethod
+    async def run(self, **kwargs: Any) -> Any:
+        """Execute the tool with kwargs validated against `input_schema`."""
+
+    def to_spec(self) -> ToolSpec:
+        """Provider-agnostic JSON-schema description for the LLM."""
+        return ToolSpec(
+            name=type(self).name,
+            description=type(self).description,
+            schema=type(self).input_schema.model_json_schema(),
+        )
+
+
+def _inherited_attr(cls: type, attr: str) -> bool:
+    """Walk the MRO (excluding `cls` itself and the abstract `Tool`)
+    looking for a non-`Tool` ancestor that declared `attr`."""
+    for base in cls.__mro__[1:]:
+        if base is Tool or base is object:
+            continue
+        if attr in base.__dict__:
+            return True
+    return False

--- a/packages/agentforge-core/src/agentforge_core/production/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/production/__init__.py
@@ -1,0 +1,49 @@
+"""Production-rails primitives.
+
+Owned by the framework (per ADR-0010): every agent has these wired by
+default. Includes per-run cost guarding (`BudgetPolicy`), correlation
+context (`RunContext`, `current_run`), structured logging filter
+(`RunIdFilter`), and the framework's exception hierarchy.
+"""
+
+from __future__ import annotations
+
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import (
+    AgentForgeError,
+    BudgetExceeded,
+    CapabilityNotSupported,
+    GuardrailViolation,
+    ModuleError,
+    ProviderError,
+)
+from agentforge_core.production.log_filter import (
+    RunIdFilter,
+    install_run_id_filter,
+    uninstall_run_id_filter,
+)
+from agentforge_core.production.run_context import (
+    RunContext,
+    bind_run,
+    current_run,
+    new_run,
+    reset_run,
+)
+
+__all__ = [
+    "AgentForgeError",
+    "BudgetExceeded",
+    "BudgetPolicy",
+    "CapabilityNotSupported",
+    "GuardrailViolation",
+    "ModuleError",
+    "ProviderError",
+    "RunContext",
+    "RunIdFilter",
+    "bind_run",
+    "current_run",
+    "install_run_id_filter",
+    "new_run",
+    "reset_run",
+    "uninstall_run_id_filter",
+]

--- a/packages/agentforge-core/src/agentforge_core/production/budget.py
+++ b/packages/agentforge-core/src/agentforge_core/production/budget.py
@@ -1,0 +1,134 @@
+"""`BudgetPolicy` — per-run cost cap (per ADR-0010).
+
+Every reasoning strategy must call `BudgetPolicy.check` before every
+LLM call. Branching strategies (Tree-of-Thoughts, Multi-Agent
+Supervisor in feat-002) call `reserve` before fanning out so collective
+spend across parallel branches cannot exceed the cap.
+
+The policy aggregates spend across every provider used in a run. A
+multi-provider agent (e.g. reasoning model + cheap judge + embedding
+model per ADR-0018) shares one policy.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentforge_core.production.exceptions import (
+    BudgetExceeded,
+    GuardrailViolation,
+)
+
+
+class BudgetPolicy(BaseModel):
+    """Per-run cost and resource cap.
+
+    Attributes:
+        usd: Maximum spend in USD across all LLM/embedding providers
+            used during the run. Default $1.00 — small enough that the
+            naive 3-line agent never racks up surprise bills, large
+            enough for a meaningful exploration.
+        max_tokens: Maximum total tokens (input + output) consumed in
+            the run.
+        max_iterations: Maximum reasoning loop iterations.
+        error_streak_limit: Maximum consecutive tool/observation errors
+            before the loop aborts.
+    """
+
+    model_config = ConfigDict(strict=True, validate_assignment=True)
+
+    usd: float = Field(default=1.0, ge=0.0)
+    max_tokens: int = Field(default=200_000, ge=0)
+    max_iterations: int = Field(default=25, ge=1)
+    error_streak_limit: int = Field(default=3, ge=1)
+
+    spent_usd: float = Field(default=0.0, ge=0.0)
+    reserved_usd: float = Field(default=0.0, ge=0.0)
+    consumed_tokens: int = Field(default=0, ge=0)
+    iteration: int = Field(default=0, ge=0)
+    error_streak: int = Field(default=0, ge=0)
+
+    def remaining_usd(self) -> float:
+        """USD budget left after committed spend and reservations."""
+        return max(0.0, self.usd - self.spent_usd - self.reserved_usd)
+
+    def check(self) -> None:
+        """Raise if any cap is breached. Called before every LLM call.
+
+        Raises:
+            BudgetExceeded: USD or token cap exhausted.
+            GuardrailViolation: iteration or error-streak limit reached.
+        """
+        if self.spent_usd >= self.usd:
+            raise BudgetExceeded(
+                f"USD budget exhausted: spent ${self.spent_usd:.4f} of ${self.usd:.4f}"
+            )
+        if self.consumed_tokens >= self.max_tokens:
+            raise BudgetExceeded(
+                f"Token budget exhausted: {self.consumed_tokens} of {self.max_tokens}"
+            )
+        if self.iteration >= self.max_iterations:
+            raise GuardrailViolation(
+                f"Iteration cap reached: {self.iteration} of {self.max_iterations}"
+            )
+        if self.error_streak >= self.error_streak_limit:
+            raise GuardrailViolation(
+                f"Error streak limit hit: {self.error_streak} consecutive errors"
+            )
+
+    def reserve(self, usd: float) -> None:
+        """Pre-reserve USD budget for a planned spend.
+
+        Used by branching strategies that fan out: each branch reserves
+        before issuing the LLM call so the sum of reservations cannot
+        exceed the cap.
+
+        Raises:
+            ValueError: `usd` is negative.
+            BudgetExceeded: reservation would exceed remaining budget.
+        """
+        if usd < 0:
+            raise ValueError(f"Cannot reserve negative budget: {usd}")
+        if self.spent_usd + self.reserved_usd + usd > self.usd:
+            raise BudgetExceeded(
+                f"Cannot reserve ${usd:.4f}; only ${self.remaining_usd():.4f} "
+                f"of ${self.usd:.4f} remains"
+            )
+        self.reserved_usd += usd
+
+    def commit(self, actual_usd: float, tokens: int = 0) -> None:
+        """Record actual cost after a call completes.
+
+        Reservations are released by `release_reservation` separately;
+        commit only records spend.
+
+        Raises:
+            ValueError: negative cost or token count.
+        """
+        if actual_usd < 0:
+            raise ValueError(f"Cannot commit negative cost: {actual_usd}")
+        if tokens < 0:
+            raise ValueError(f"Cannot commit negative tokens: {tokens}")
+        self.spent_usd += actual_usd
+        self.consumed_tokens += tokens
+
+    def release_reservation(self, usd: float) -> None:
+        """Release a previously-reserved budget (e.g. on cancellation).
+
+        Idempotent at zero — releasing more than reserved clamps to 0.
+        """
+        if usd < 0:
+            raise ValueError(f"Cannot release negative reservation: {usd}")
+        self.reserved_usd = max(0.0, self.reserved_usd - usd)
+
+    def increment_iteration(self) -> None:
+        """Record one strategy iteration. Called by the strategy loop."""
+        self.iteration += 1
+
+    def record_error(self) -> None:
+        """Increment the error streak counter."""
+        self.error_streak += 1
+
+    def record_success(self) -> None:
+        """Reset the error streak counter."""
+        self.error_streak = 0

--- a/packages/agentforge-core/src/agentforge_core/production/exceptions.py
+++ b/packages/agentforge-core/src/agentforge_core/production/exceptions.py
@@ -1,0 +1,66 @@
+"""AgentForge exception hierarchy.
+
+Every exception the framework raises is a subclass of `AgentForgeError`.
+This is the only place new top-level exception classes are defined; per
+.claude/standards/coding.md, modules subclass these for their own
+errors but never `raise Exception(...)`.
+"""
+
+from __future__ import annotations
+
+
+class AgentForgeError(Exception):
+    """Base exception for all AgentForge errors.
+
+    Catch this to handle any framework-raised error generically.
+    Production code should narrow to a more specific subclass.
+    """
+
+
+# Locked names per the framework's public API; suppress N818 globally
+# in this file so individual classes don't need per-line noqa.
+# ruff: noqa: N818
+
+
+class BudgetExceeded(AgentForgeError):
+    """Raised when `BudgetPolicy.check` detects a USD or token cap breach.
+
+    The agent run terminates immediately; partial state is preserved on
+    `RunResult`.
+    """
+
+
+class GuardrailViolation(AgentForgeError):
+    """Raised when a non-budget guardrail trips.
+
+    Examples: iteration cap reached, error streak limit hit. Distinct
+    from `BudgetExceeded` so callers can branch on the cause.
+    """
+
+
+class ModuleError(AgentForgeError):
+    """Raised at agent construction when the resolver cannot find a
+    registered module by name.
+
+    Surfaced at startup (P11 — fail at startup, not at runtime), with a
+    clear message telling the developer which package to install or
+    which entry point is missing.
+    """
+
+
+class ProviderError(AgentForgeError):
+    """Base for errors originating in an LLM / embedding provider.
+
+    Concrete subclasses (`RateLimitError`, etc.) ship in feat-003 with
+    the provider abstraction.
+    """
+
+
+class CapabilityNotSupported(AgentForgeError):
+    """Raised when an optional capability is invoked on a driver that
+    does not declare it.
+
+    Per ADR-0009, capability negotiation is honest — drivers declare
+    their supported set and this exception fires if a consumer skipped
+    the `supports(...)` check.
+    """

--- a/packages/agentforge-core/src/agentforge_core/production/log_filter.py
+++ b/packages/agentforge-core/src/agentforge_core/production/log_filter.py
@@ -1,0 +1,49 @@
+"""`RunIdFilter` — attach `run_id` to every log record.
+
+Auto-installed on the root logger by `Agent.__init__` (per ADR-0010,
+P4). Idempotent — multiple installs do not accumulate filters.
+
+Disable via `logging.run_id_filter: false` in `agentforge.yaml`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agentforge_core.production.run_context import _current_run
+
+_FILTER_NAME = "agentforge.run_id_filter"
+
+
+class RunIdFilter(logging.Filter):
+    """Attach `run_id` from the active `RunContext` (or `"-"`) to records."""
+
+    def __init__(self) -> None:
+        super().__init__(name=_FILTER_NAME)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        ctx = _current_run.get()
+        record.run_id = ctx.run_id if ctx is not None else "-"
+        return True
+
+
+def install_run_id_filter(logger: logging.Logger | None = None) -> RunIdFilter:
+    """Install `RunIdFilter` on `logger` (root by default), idempotent.
+
+    Returns the live filter (the existing one if already installed).
+    """
+    target = logger if logger is not None else logging.getLogger()
+    for existing in target.filters:
+        if isinstance(existing, RunIdFilter):
+            return existing
+    new_filter = RunIdFilter()
+    target.addFilter(new_filter)
+    return new_filter
+
+
+def uninstall_run_id_filter(logger: logging.Logger | None = None) -> None:
+    """Remove `RunIdFilter` from `logger` (root by default), if present."""
+    target = logger if logger is not None else logging.getLogger()
+    for existing in list(target.filters):
+        if isinstance(existing, RunIdFilter):
+            target.removeFilter(existing)

--- a/packages/agentforge-core/src/agentforge_core/production/run_context.py
+++ b/packages/agentforge-core/src/agentforge_core/production/run_context.py
@@ -1,0 +1,108 @@
+"""`RunContext` and the `current_run()` ContextVar.
+
+Per ADR-0010, every agent run carries a `run_id` propagated through
+async tasks via `contextvars.ContextVar`. Every log line, every span,
+every tool call, every claim record carries this id — there is no path
+to a log line without one.
+
+Generation: ULID (sortable, monotonic, 26 chars). Imported from
+`python-ulid`.
+
+Idempotency keys are derived from the run's `idempotency_seed` plus
+caller-supplied parts. Same parts within the same run produce the same
+key; different parts produce different keys; different runs produce
+different keys for the same parts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from ulid import ULID
+
+
+class RunContext(BaseModel):
+    """Per-run correlation primitive bound to the current async task."""
+
+    model_config = ConfigDict(strict=True, validate_assignment=True)
+
+    run_id: str
+    parent_run_id: str | None = None
+    started_at: datetime
+    idempotency_seed: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def idempotency_key_for(self, *parts: object) -> str:
+        """Stable key derived from `(idempotency_seed, *parts)`.
+
+        Tools that mutate external state read this to safely retry within
+        a single run. Same `parts` → same key; different `parts` →
+        different key; different run → different key.
+
+        Returns:
+            64-hex-character SHA-256 digest.
+        """
+        joined = self.idempotency_seed
+        for part in parts:
+            joined += "|" + str(part)
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+_current_run: ContextVar[RunContext | None] = ContextVar("agentforge_current_run", default=None)
+
+
+def current_run() -> RunContext:
+    """Return the live `RunContext` bound to this async task.
+
+    Raises:
+        RuntimeError: no run is active. `current_run()` is only callable
+            from within an `Agent.run()` invocation.
+    """
+    ctx = _current_run.get()
+    if ctx is None:
+        raise RuntimeError(
+            "No active RunContext. current_run() can only be called inside "
+            "Agent.run() (or a tool / hook invoked from one)."
+        )
+    return ctx
+
+
+def new_run(
+    *,
+    parent_run_id: str | None = None,
+    task: str | None = None,
+) -> RunContext:
+    """Create a new `RunContext` with a fresh ULID `run_id`.
+
+    Does NOT bind it to the ContextVar — call `bind_run` for that.
+    """
+    run_id = str(ULID())
+    seed_input = f"{run_id}|{task or ''}"
+    seed = hashlib.sha256(seed_input.encode("utf-8")).hexdigest()[:32]
+    return RunContext(
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+        started_at=datetime.now(UTC),
+        idempotency_seed=seed,
+    )
+
+
+def bind_run(ctx: RunContext) -> Token[RunContext | None]:
+    """Bind a `RunContext` to the current async scope.
+
+    Returns the `Token` that `reset_run` consumes. Always pair with
+    `reset_run` in a try/finally to avoid leaking context across runs.
+    """
+    return _current_run.set(ctx)
+
+
+def reset_run(token: Token[RunContext | None]) -> None:
+    """Reset the ContextVar to its prior value.
+
+    Pair with `bind_run`; safe to call exactly once per token.
+    """
+    _current_run.reset(token)

--- a/packages/agentforge-core/src/agentforge_core/resolver/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/resolver/__init__.py
@@ -1,0 +1,28 @@
+"""Module resolver — maps name → registered class.
+
+Per ADR-0004, modules normally register via Python entry points
+(loaded by feat-010). For feat-001 we ship the in-process registry
+that the entry-point loader will populate. Anyone can register a
+class manually with `@register("strategies", "my-loop")` for an
+in-repo or test-only module.
+
+A model identifier string `"<provider>:<model_id>"` is parsed by
+`parse_model_string`; the leading provider is looked up as an entry
+in `agentforge.providers`, the trailing piece is treated as the
+model id and passed through to the provider constructor (per
+feat-003).
+"""
+
+from __future__ import annotations
+
+from agentforge_core.resolver.resolve import (
+    Resolver,
+    parse_model_string,
+    register,
+)
+
+__all__ = [
+    "Resolver",
+    "parse_model_string",
+    "register",
+]

--- a/packages/agentforge-core/src/agentforge_core/resolver/resolve.py
+++ b/packages/agentforge-core/src/agentforge_core/resolver/resolve.py
@@ -1,0 +1,102 @@
+"""In-process module registry + model-string parsing.
+
+feat-010 will extend `Resolver` to scan `importlib.metadata` entry
+points; until then, anything in this registry was put there by an
+explicit `register(...)` call. The two-phase design lets us write
+integration tests in feat-001 without entry-point machinery.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from agentforge_core.production.exceptions import ModuleError
+
+T = TypeVar("T", bound=type)
+
+
+class Resolver:
+    """Maps `(category, name) -> registered class`.
+
+    A single global instance is shared by `register()` and `Agent`.
+    Tests reset it via `Resolver.global_().clear()`.
+    """
+
+    def __init__(self) -> None:
+        self._registry: dict[tuple[str, str], type] = {}
+
+    @classmethod
+    def global_(cls) -> Resolver:
+        global _GLOBAL_RESOLVER  # noqa: PLW0603 — singleton intentional
+        if _GLOBAL_RESOLVER is None:
+            _GLOBAL_RESOLVER = cls()
+        return _GLOBAL_RESOLVER
+
+    def register(self, category: str, name: str, cls: type) -> None:
+        key = (category, name)
+        if key in self._registry and self._registry[key] is not cls:
+            raise ModuleError(
+                f"Cannot register {cls.__name__} as {category}:{name}; "
+                f"already registered to {self._registry[key].__name__}."
+            )
+        self._registry[key] = cls
+
+    def resolve(self, category: str, name: str) -> type:
+        key = (category, name)
+        if key not in self._registry:
+            available = sorted(n for c, n in self._registry if c == category)
+            raise ModuleError(
+                f"No module registered for {category}:{name!r}. "
+                f"Registered {category}: {available or '(none)'}. "
+                f"Install the relevant agentforge-* package or register "
+                f"a custom class with @register('{category}', '{name}')."
+            )
+        return self._registry[key]
+
+    def list_(self, category: str | None = None) -> list[tuple[str, str, type]]:
+        items = [(c, n, cls) for (c, n), cls in self._registry.items()]
+        if category is not None:
+            items = [item for item in items if item[0] == category]
+        return sorted(items, key=lambda item: (item[0], item[1]))
+
+    def clear(self) -> None:
+        self._registry.clear()
+
+
+_GLOBAL_RESOLVER: Resolver | None = None
+
+
+def register(category: str, name: str) -> Callable[[T], T]:
+    """Decorator: register a class under `(category, name)` in the global resolver.
+
+    Example:
+        @register("strategies", "my-loop")
+        class MyLoop(ReasoningStrategy):
+            ...
+    """
+
+    def decorator(cls: T) -> T:
+        Resolver.global_().register(category, name, cls)
+        return cls
+
+    return decorator
+
+
+def parse_model_string(model_str: str) -> tuple[str, str]:
+    """Parse `"<provider>:<model_id>"` into `(provider, model_id)`.
+
+    Raises:
+        ModuleError: if the string does not contain a `:`.
+    """
+    if ":" not in model_str:
+        raise ModuleError(
+            f"Invalid model string {model_str!r}: expected '<provider>:<model_id>' "
+            f"(for example, 'anthropic:claude-sonnet-4.7')."
+        )
+    provider, _, model_id = model_str.partition(":")
+    if not provider or not model_id:
+        raise ModuleError(
+            f"Invalid model string {model_str!r}: provider and model_id must both be non-empty."
+        )
+    return provider, model_id

--- a/packages/agentforge-core/src/agentforge_core/testing/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/__init__.py
@@ -1,0 +1,17 @@
+"""Testing utilities — conformance suites that every driver must pass.
+
+Per ADR-0007 and feat-016, every ABC in `agentforge-core` ships a
+shared conformance suite. External module packages (e.g.
+`agentforge-memory-postgres`) import these helpers to verify their
+drivers against the locked contract.
+
+The suites live in core (rather than the runtime package) so module
+authors only need `agentforge-core` to test conformance — they don't
+have to depend on the full runtime.
+"""
+
+from __future__ import annotations
+
+from agentforge_core.testing.conformance import run_memory_conformance
+
+__all__ = ["run_memory_conformance"]

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -1,0 +1,134 @@
+"""Conformance suites for `agentforge-core` ABCs.
+
+Every shipped or third-party driver must pass these suites. They are
+exposed as functions (not pytest collections) so they can be invoked
+from any test runner by passing in a ready-to-use store / client.
+
+Usage in a driver's tests:
+
+    import pytest
+    from agentforge_core.testing import run_memory_conformance
+    from my_pkg import MyMemoryStore
+
+    @pytest.mark.asyncio
+    async def test_my_driver_conforms() -> None:
+        async with MyMemoryStore.from_url("...") as store:
+            await run_memory_conformance(store)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.values.claim import Claim
+
+
+def _claim(
+    *,
+    project: str = "p1",
+    agent: str = "a1",
+    run_id: str = "run-x",
+    category: str = "finding",
+    payload: dict[str, object] | None = None,
+) -> Claim:
+    return Claim(
+        run_id=run_id,
+        project=project,
+        agent=agent,
+        category=category,
+        payload=payload if payload is not None else {"v": 1},
+    )
+
+
+async def _collect(it: AsyncIterator[Claim]) -> list[Claim]:
+    return [c async for c in it]
+
+
+async def run_memory_conformance(store: MemoryStore) -> None:
+    """Run the full MemoryStore conformance suite against `store`.
+
+    The store must be empty when this is called and is left empty when
+    the function returns (every claim written is also deleted, except
+    where the contract demands history retention via `supersede`).
+
+    Raises:
+        AssertionError: a contract was violated.
+    """
+    # 1. put + get roundtrip
+    c1 = _claim(category="finding")
+    cid = await store.put(c1)
+    assert cid == c1.id, "put() must return the claim's id"
+    fetched = await store.get(cid)
+    assert fetched is not None, "get() must return the persisted claim"
+    assert fetched.id == c1.id
+
+    # 2. get returns None for unknown id
+    missing = await store.get("01HX-NONEXISTENT")
+    assert missing is None, "get() of an unknown id must return None"
+
+    # 3. query with no filters returns at least the claim we put
+    all_results = await store.query()
+    assert any(
+        c.id == cid for c in all_results
+    ), "query() with no filters must include the put claim"
+
+    # 4. query filters by project
+    other_project = _claim(project="other-project")
+    await store.put(other_project)
+    only_p1 = await store.query(project="p1")
+    assert any(c.id == cid for c in only_p1)
+    assert all(
+        c.project == "p1" for c in only_p1
+    ), "query(project=...) must filter results to that project"
+
+    # 5. query filters by agent
+    other_agent = _claim(agent="other-agent")
+    await store.put(other_agent)
+    only_a1 = await store.query(agent="a1")
+    assert all(
+        c.agent == "a1" for c in only_a1
+    ), "query(agent=...) must filter results to that agent"
+
+    # 6. query filters by category
+    decision = _claim(category="decision")
+    await store.put(decision)
+    only_findings = await store.query(category="finding")
+    assert all(
+        c.category == "finding" for c in only_findings
+    ), "query(category=...) must filter results to that category"
+
+    # 7. query filters by run_id
+    other_run = _claim(run_id="run-y")
+    await store.put(other_run)
+    only_run_x = await store.query(run_id="run-x")
+    assert all(
+        c.run_id == "run-x" for c in only_run_x
+    ), "query(run_id=...) must filter results to that run_id"
+
+    # 8. query respects limit
+    limited = await store.query(limit=1)
+    assert len(limited) <= 1, "query(limit=N) must return at most N claims"
+
+    # 9. supersede chains old → new
+    new_claim = _claim(payload={"v": 2})
+    new_id = await store.supersede(cid, new_claim)
+    assert new_id == new_claim.id
+    refetched = await store.get(new_id)
+    assert refetched is not None
+    assert refetched.supersedes == cid, "supersede() must set supersedes link on the new claim"
+
+    # 10. stream yields claims
+    streamed = await _collect(store.stream(project="p1"))
+    assert len(streamed) >= 1, "stream() must yield matching claims"
+    assert all(c.project == "p1" for c in streamed)
+
+    # 11. capabilities() returns a set
+    caps = store.capabilities()
+    assert isinstance(caps, set)
+
+    # 12. supports() reflects capabilities()
+    if caps:
+        sample = next(iter(caps))
+        assert store.supports(sample) is True
+    assert store.supports("definitely-not-a-capability-2026") is False

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -69,42 +69,42 @@ async def run_memory_conformance(store: MemoryStore) -> None:
 
     # 3. query with no filters returns at least the claim we put
     all_results = await store.query()
-    assert any(
-        c.id == cid for c in all_results
-    ), "query() with no filters must include the put claim"
+    assert any(c.id == cid for c in all_results), (
+        "query() with no filters must include the put claim"
+    )
 
     # 4. query filters by project
     other_project = _claim(project="other-project")
     await store.put(other_project)
     only_p1 = await store.query(project="p1")
     assert any(c.id == cid for c in only_p1)
-    assert all(
-        c.project == "p1" for c in only_p1
-    ), "query(project=...) must filter results to that project"
+    assert all(c.project == "p1" for c in only_p1), (
+        "query(project=...) must filter results to that project"
+    )
 
     # 5. query filters by agent
     other_agent = _claim(agent="other-agent")
     await store.put(other_agent)
     only_a1 = await store.query(agent="a1")
-    assert all(
-        c.agent == "a1" for c in only_a1
-    ), "query(agent=...) must filter results to that agent"
+    assert all(c.agent == "a1" for c in only_a1), (
+        "query(agent=...) must filter results to that agent"
+    )
 
     # 6. query filters by category
     decision = _claim(category="decision")
     await store.put(decision)
     only_findings = await store.query(category="finding")
-    assert all(
-        c.category == "finding" for c in only_findings
-    ), "query(category=...) must filter results to that category"
+    assert all(c.category == "finding" for c in only_findings), (
+        "query(category=...) must filter results to that category"
+    )
 
     # 7. query filters by run_id
     other_run = _claim(run_id="run-y")
     await store.put(other_run)
     only_run_x = await store.query(run_id="run-x")
-    assert all(
-        c.run_id == "run-x" for c in only_run_x
-    ), "query(run_id=...) must filter results to that run_id"
+    assert all(c.run_id == "run-x" for c in only_run_x), (
+        "query(run_id=...) must filter results to that run_id"
+    )
 
     # 8. query respects limit
     limited = await store.query(limit=1)

--- a/packages/agentforge-core/src/agentforge_core/values/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/values/__init__.py
@@ -1,0 +1,42 @@
+"""Locked value types — Pydantic v2 models the framework's contracts use.
+
+Per ADR-0007, these shapes are part of the framework's stable surface;
+adding a field requires a minor bump, removing or renaming a field
+requires a major bump.
+"""
+
+from __future__ import annotations
+
+from agentforge_core.values.claim import Claim
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    MessageRole,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    ToolSpec,
+)
+from agentforge_core.values.state import (
+    AgentState,
+    FinishReason,
+    RunResult,
+    Step,
+    StepKind,
+)
+
+__all__ = [
+    "AgentState",
+    "Claim",
+    "FinishReason",
+    "LLMResponse",
+    "Message",
+    "MessageRole",
+    "RunResult",
+    "Step",
+    "StepKind",
+    "StopReason",
+    "TokenUsage",
+    "ToolCall",
+    "ToolSpec",
+]

--- a/packages/agentforge-core/src/agentforge_core/values/claim.py
+++ b/packages/agentforge-core/src/agentforge_core/values/claim.py
@@ -1,0 +1,30 @@
+"""`Claim` — a persisted unit of agent-produced knowledge.
+
+Written through `MemoryStore`. The `(project, agent)` pair namespaces
+claims; cross-agent and cross-project queries are explicit verbs (per
+feat-005 design). `id` is a ULID for sortable monotonic ordering.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from ulid import ULID
+
+
+class Claim(BaseModel):
+    """A persisted unit of agent-produced knowledge."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str = Field(default_factory=lambda: str(ULID()))
+    run_id: str
+    project: str
+    agent: str
+    category: str
+    payload: dict[str, Any]
+    supersedes: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/packages/agentforge-core/src/agentforge_core/values/messages.py
+++ b/packages/agentforge-core/src/agentforge_core/values/messages.py
@@ -1,0 +1,84 @@
+"""Provider-agnostic message and response shapes for the LLM contract.
+
+Every `LLMClient` (feat-003) returns `LLMResponse`; every reasoning
+strategy operates on `list[Message]` regardless of which provider
+backs the agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MessageRole = Literal["system", "user", "assistant", "tool"]
+"""Allowed message roles. Mirrors the Anthropic / OpenAI common set."""
+
+StopReason = Literal["end_turn", "tool_use", "max_tokens", "stop_sequence", "other"]
+"""Provider-normalised reason the LLM stopped emitting tokens."""
+
+
+class Message(BaseModel):
+    """One turn in the chat-completion exchange."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    role: MessageRole
+    content: str
+    name: str | None = None
+    tool_call_id: str | None = None
+
+
+class ToolCall(BaseModel):
+    """A tool invocation emitted by the LLM."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolSpec(BaseModel):
+    """Provider-agnostic tool description sent to the LLM.
+
+    `schema` is the JSON-schema dict (typically from a Pydantic model's
+    `model_json_schema()`). The `Tool` ABC's `to_spec()` produces this.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    name: str
+    description: str
+    schema_: dict[str, Any] = Field(alias="schema")
+
+
+class TokenUsage(BaseModel):
+    """Token accounting from a single LLM call."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    cache_read_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+    thinking_tokens: int = Field(default=0, ge=0)
+
+    @property
+    def total(self) -> int:
+        """Sum of input + output tokens (excludes cache and thinking metadata)."""
+        return self.input_tokens + self.output_tokens
+
+
+class LLMResponse(BaseModel):
+    """Provider-agnostic response from one LLM call."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    content: str
+    tool_calls: tuple[ToolCall, ...] = ()
+    stop_reason: StopReason
+    usage: TokenUsage
+    cost_usd: float = Field(ge=0.0)
+    model: str
+    provider: str

--- a/packages/agentforge-core/src/agentforge_core/values/state.py
+++ b/packages/agentforge-core/src/agentforge_core/values/state.py
@@ -1,0 +1,93 @@
+"""`AgentState`, `Step`, `RunResult` — the trace shape of an agent run.
+
+Per ADR-0008, `state.steps` is uniform across reasoning strategies so
+debugging skills transfer between agents that use different loop
+shapes (ReAct, Plan-Execute, ToT, Multi-Agent).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentforge_core.values.messages import ToolCall
+
+StepKind = Literal[
+    "think",
+    "act",
+    "observe",
+    "plan",
+    "synthesize",
+    "branch",
+    "delegate",
+    "system",
+]
+"""Closed enum of step kinds. Every reasoning strategy emits steps from
+this set; new kinds require a feature doc + minor version bump."""
+
+FinishReason = Literal[
+    "completed",
+    "iteration_cap",
+    "budget_exceeded",
+    "guardrail",
+    "error",
+    "cancelled",
+]
+"""How a run terminated. Mirrors the runtime's branching of
+`BudgetExceeded` / `GuardrailViolation` / clean completion."""
+
+
+class Step(BaseModel):
+    """One unit of progress in `AgentState.steps`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    iteration: int = Field(ge=0)
+    kind: StepKind
+    content: str | dict[str, Any]
+    tool_call: ToolCall | None = None
+    tokens_in: int = Field(default=0, ge=0)
+    tokens_out: int = Field(default=0, ge=0)
+    cost_usd: float = Field(default=0.0, ge=0.0)
+    duration_ms: int = Field(default=0, ge=0)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentState(BaseModel):
+    """Mutable per-run state passed through the reasoning loop.
+
+    Strategies append to `steps`; tools and pipeline tasks may append
+    to `findings`. The runtime owns the lifecycle.
+    """
+
+    model_config = ConfigDict(strict=True, validate_assignment=True)
+
+    run_id: str
+    task: str
+    steps: list[Step] = Field(default_factory=list)
+    findings: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunResult(BaseModel):
+    """Final, immutable output of `Agent.run()`.
+
+    Carries the agent's answer plus full trace, cost accounting, and the
+    run's `run_id` for cross-system correlation (ADR-0010).
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    output: str | dict[str, Any]
+    findings: tuple[Any, ...] = ()
+    steps: tuple[Step, ...] = ()
+    cost_usd: float = Field(ge=0.0)
+    tokens_in: int = Field(ge=0)
+    tokens_out: int = Field(ge=0)
+    run_id: str
+    duration_ms: int = Field(ge=0)
+    finish_reason: FinishReason = "completed"
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/packages/agentforge-core/tests/unit/test_budget.py
+++ b/packages/agentforge-core/tests/unit/test_budget.py
@@ -1,0 +1,186 @@
+"""Unit tests for `BudgetPolicy`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import (
+    BudgetExceeded,
+    GuardrailViolation,
+)
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+def test_default_construction() -> None:
+    b = BudgetPolicy()
+    assert b.usd == 1.0
+    assert b.max_tokens == 200_000
+    assert b.max_iterations == 25
+    assert b.error_streak_limit == 3
+    assert b.spent_usd == 0.0
+    assert b.reserved_usd == 0.0
+    assert b.consumed_tokens == 0
+    assert b.iteration == 0
+    assert b.error_streak == 0
+
+
+def test_check_passes_at_construction() -> None:
+    b = BudgetPolicy()
+    b.check()
+
+
+def test_remaining_usd_initial() -> None:
+    b = BudgetPolicy(usd=2.0)
+    assert b.remaining_usd() == pytest.approx(2.0)
+
+
+def test_remaining_usd_after_spend_and_reserve() -> None:
+    b = BudgetPolicy(usd=2.0)
+    b.commit(0.4)
+    b.reserve(0.6)
+    assert b.remaining_usd() == pytest.approx(1.0)
+
+
+def test_remaining_usd_clamps_to_zero() -> None:
+    b = BudgetPolicy(usd=1.0)
+    b.commit(1.5)
+    assert b.remaining_usd() == 0.0
+
+
+def test_check_raises_budget_exceeded_on_usd_exhaustion() -> None:
+    b = BudgetPolicy(usd=1.0)
+    b.commit(1.0)
+    with pytest.raises(BudgetExceeded, match="USD budget exhausted"):
+        b.check()
+
+
+def test_check_raises_budget_exceeded_on_token_exhaustion() -> None:
+    b = BudgetPolicy(usd=10.0, max_tokens=100)
+    b.commit(0.0, tokens=100)
+    with pytest.raises(BudgetExceeded, match="Token budget"):
+        b.check()
+
+
+def test_check_raises_guardrail_on_iteration_cap() -> None:
+    b = BudgetPolicy(usd=10.0, max_iterations=2)
+    b.increment_iteration()
+    b.increment_iteration()
+    with pytest.raises(GuardrailViolation, match="Iteration cap"):
+        b.check()
+
+
+def test_check_raises_guardrail_on_error_streak() -> None:
+    b = BudgetPolicy(usd=10.0, error_streak_limit=2)
+    b.record_error()
+    b.record_error()
+    with pytest.raises(GuardrailViolation, match="Error streak"):
+        b.check()
+
+
+def test_record_success_resets_error_streak() -> None:
+    b = BudgetPolicy(error_streak_limit=3)
+    b.record_error()
+    b.record_error()
+    b.record_success()
+    assert b.error_streak == 0
+
+
+def test_reserve_reduces_remaining() -> None:
+    b = BudgetPolicy(usd=2.0)
+    b.reserve(0.5)
+    assert b.reserved_usd == pytest.approx(0.5)
+    assert b.remaining_usd() == pytest.approx(1.5)
+
+
+def test_reserve_negative_raises_value_error() -> None:
+    b = BudgetPolicy()
+    with pytest.raises(ValueError, match="negative"):
+        b.reserve(-0.1)
+
+
+def test_reserve_exceeding_remaining_raises_budget_exceeded() -> None:
+    b = BudgetPolicy(usd=1.0)
+    b.reserve(0.6)
+    with pytest.raises(BudgetExceeded, match="Cannot reserve"):
+        b.reserve(0.5)
+
+
+def test_commit_records_spent_and_tokens() -> None:
+    b = BudgetPolicy()
+    b.commit(0.25, tokens=100)
+    assert b.spent_usd == pytest.approx(0.25)
+    assert b.consumed_tokens == 100
+
+
+def test_commit_negative_usd_raises() -> None:
+    b = BudgetPolicy()
+    with pytest.raises(ValueError, match="negative cost"):
+        b.commit(-0.1)
+
+
+def test_commit_negative_tokens_raises() -> None:
+    b = BudgetPolicy()
+    with pytest.raises(ValueError, match="negative tokens"):
+        b.commit(0.0, tokens=-1)
+
+
+def test_release_reservation_reduces_reserved() -> None:
+    b = BudgetPolicy(usd=2.0)
+    b.reserve(0.5)
+    b.release_reservation(0.3)
+    assert b.reserved_usd == pytest.approx(0.2)
+
+
+def test_release_reservation_clamps_to_zero() -> None:
+    b = BudgetPolicy(usd=2.0)
+    b.reserve(0.2)
+    b.release_reservation(0.5)
+    assert b.reserved_usd == 0.0
+
+
+def test_release_reservation_negative_raises() -> None:
+    b = BudgetPolicy()
+    with pytest.raises(ValueError, match="negative reservation"):
+        b.release_reservation(-0.1)
+
+
+def test_increment_iteration() -> None:
+    b = BudgetPolicy()
+    b.increment_iteration()
+    b.increment_iteration()
+    assert b.iteration == 2
+
+
+@given(
+    cap=st.floats(min_value=0.0, max_value=1000.0, allow_nan=False),
+    operations=st.lists(
+        st.tuples(
+            st.sampled_from(["reserve", "commit", "release"]),
+            st.floats(min_value=0.0, max_value=10.0, allow_nan=False),
+        ),
+        max_size=20,
+    ),
+)
+@settings(max_examples=50, deadline=None)
+def test_property_invariant_spent_plus_reserved_never_exceeds_cap(
+    cap: float, operations: list[tuple[str, float]]
+) -> None:
+    """For any sequence of (reserve, commit, release) operations, spent +
+    reserved stays within cap or raises BudgetExceeded."""
+    b = BudgetPolicy(usd=cap)
+    for op, amount in operations:
+        try:
+            if op == "reserve":
+                b.reserve(amount)
+            elif op == "commit":
+                b.commit(amount)
+            else:
+                b.release_reservation(amount)
+        except BudgetExceeded:
+            pass
+        # invariant: never exceed cap when budget is healthy
+        if b.spent_usd + b.reserved_usd > cap + 1e-9:
+            # commit can exceed (records actual past spend that overran);
+            # reservation cannot — that's the only case allowed to over-cap
+            assert b.spent_usd > cap or b.spent_usd + b.reserved_usd <= cap + 1e-9

--- a/packages/agentforge-core/tests/unit/test_budget.py
+++ b/packages/agentforge-core/tests/unit/test_budget.py
@@ -162,25 +162,32 @@ def test_increment_iteration() -> None:
         max_size=20,
     ),
 )
-@settings(max_examples=50, deadline=None)
-def test_property_invariant_spent_plus_reserved_never_exceeds_cap(
+@settings(max_examples=100, deadline=None)
+def test_property_reserve_never_admits_overrun(
     cap: float, operations: list[tuple[str, float]]
 ) -> None:
-    """For any sequence of (reserve, commit, release) operations, spent +
-    reserved stays within cap or raises BudgetExceeded."""
+    """Per BudgetPolicy.reserve's contract:
+
+      A successful `reserve(x)` (no BudgetExceeded raised) must leave
+      `spent_usd + reserved_usd <= cap`.
+
+    `commit()` records actual spend and CAN take spent_usd over cap
+    (real money was already spent, the framework just records it);
+    `release_reservation` is monotone-decreasing on reserved_usd.
+    Only `reserve` enforces the budget invariant.
+    """
     b = BudgetPolicy(usd=cap)
     for op, amount in operations:
-        try:
-            if op == "reserve":
+        if op == "reserve":
+            try:
                 b.reserve(amount)
-            elif op == "commit":
-                b.commit(amount)
-            else:
-                b.release_reservation(amount)
-        except BudgetExceeded:
-            pass
-        # invariant: never exceed cap when budget is healthy
-        if b.spent_usd + b.reserved_usd > cap + 1e-9:
-            # commit can exceed (records actual past spend that overran);
-            # reservation cannot — that's the only case allowed to over-cap
-            assert b.spent_usd > cap or b.spent_usd + b.reserved_usd <= cap + 1e-9
+            except BudgetExceeded:
+                continue
+            # post-reserve invariant
+            assert b.spent_usd + b.reserved_usd <= cap + 1e-9
+        elif op == "commit":
+            b.commit(amount)  # always succeeds
+        else:
+            b.release_reservation(amount)
+            # release never makes reserved_usd negative
+            assert b.reserved_usd >= 0.0

--- a/packages/agentforge-core/tests/unit/test_claim.py
+++ b/packages/agentforge-core/tests/unit/test_claim.py
@@ -1,0 +1,66 @@
+"""Unit tests for `Claim`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.values.claim import Claim
+from pydantic import ValidationError
+
+
+def _make(**overrides: object) -> Claim:
+    base: dict[str, object] = {
+        "run_id": "r1",
+        "project": "proj",
+        "agent": "ag",
+        "category": "finding",
+        "payload": {"x": 1},
+    }
+    base.update(overrides)
+    return Claim(**base)  # type: ignore[arg-type]
+
+
+def test_claim_basic() -> None:
+    c = _make()
+    assert c.run_id == "r1"
+    assert c.project == "proj"
+    assert c.agent == "ag"
+    assert c.category == "finding"
+    assert c.payload == {"x": 1}
+    assert c.supersedes is None
+
+
+def test_claim_id_default_is_ulid() -> None:
+    c = _make()
+    assert isinstance(c.id, str)
+    # ULID Crockford-Base32: 26 chars
+    assert len(c.id) == 26
+
+
+def test_claim_distinct_ids() -> None:
+    a = _make()
+    b = _make()
+    assert a.id != b.id
+
+
+def test_claim_is_frozen() -> None:
+    c = _make()
+    with pytest.raises(ValidationError):
+        c.payload = {"y": 2}  # type: ignore[misc]
+
+
+def test_claim_supersedes_link() -> None:
+    older = _make()
+    newer = _make(supersedes=older.id)
+    assert newer.supersedes == older.id
+
+
+def test_claim_explicit_id_preserved() -> None:
+    c = _make(id="01HX-MANUAL")
+    assert c.id == "01HX-MANUAL"
+
+
+def test_claim_round_trip_json() -> None:
+    c = _make()
+    payload = c.model_dump_json()
+    restored = Claim.model_validate_json(payload)
+    assert restored == c

--- a/packages/agentforge-core/tests/unit/test_contracts_evaluator.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_evaluator.py
@@ -1,0 +1,78 @@
+"""Unit tests for the `Evaluator` ABC and `EvalResult` value type."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+from agentforge_core.contracts.evaluator import EvalResult, Evaluator
+from pydantic import ValidationError
+
+# ---- EvalResult ----
+
+
+def test_eval_result_basic() -> None:
+    r = EvalResult(evaluator="faithfulness", score=0.91, label="pass")
+    assert r.evaluator == "faithfulness"
+    assert r.score == pytest.approx(0.91)
+    assert r.label == "pass"
+
+
+def test_eval_result_is_frozen() -> None:
+    r = EvalResult(evaluator="x", score=0.5)
+    with pytest.raises(ValidationError):
+        r.score = 0.6  # type: ignore[misc]
+
+
+def test_eval_result_allows_nan_score() -> None:
+    """Per feat-006, NaN score means 'not applicable'."""
+    r = EvalResult(evaluator="coverage", score=float("nan"))
+    assert math.isnan(r.score)
+
+
+def test_eval_result_optional_fields_default_none() -> None:
+    r = EvalResult(evaluator="x", score=0.0)
+    assert r.label is None
+    assert r.reasoning is None
+    assert r.raw == {}
+
+
+# ---- Evaluator ABC ----
+
+
+def test_evaluator_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        Evaluator()  # type: ignore[abstract]
+
+
+class FaithfulnessEvaluator(Evaluator):
+    name = "faithfulness"
+    cost_estimate_usd = 0.0
+
+    async def evaluate(self, finding: Any, context: dict[str, Any]) -> EvalResult:
+        return EvalResult(evaluator=self.name, score=0.91, label="pass")
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_works() -> None:
+    ev = FaithfulnessEvaluator()
+    result = await ev.evaluate("anything", {})
+    assert result.evaluator == "faithfulness"
+    assert result.label == "pass"
+
+
+def test_default_cost_estimate_zero() -> None:
+    assert FaithfulnessEvaluator.cost_estimate_usd == 0.0
+
+
+class _LLMJudge(Evaluator):
+    name = "llm-judge"
+    cost_estimate_usd = 0.05
+
+    async def evaluate(self, finding: Any, context: dict[str, Any]) -> EvalResult:
+        return EvalResult(evaluator=self.name, score=0.7)
+
+
+def test_subclass_can_declare_cost_estimate() -> None:
+    assert _LLMJudge.cost_estimate_usd == pytest.approx(0.05)

--- a/packages/agentforge-core/tests/unit/test_contracts_finding.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_finding.py
@@ -1,0 +1,63 @@
+"""Unit tests for the `Finding` Protocol."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from agentforge_core.contracts.finding import Finding
+
+
+@dataclass
+class _SimpleFinding:
+    severity: str
+    category: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def test_dataclass_with_required_attrs_satisfies_protocol() -> None:
+    finding = _SimpleFinding(severity="warning", category="style", message="x")
+    assert isinstance(finding, Finding)
+
+
+def test_object_missing_severity_does_not_satisfy_protocol() -> None:
+    class _Half:
+        category = "x"
+        message = "y"
+
+        def to_dict(self) -> dict[str, Any]:
+            return {}
+
+    assert not isinstance(_Half(), Finding)
+
+
+def test_object_missing_to_dict_does_not_satisfy_protocol() -> None:
+    @dataclass
+    class _NoDict:
+        severity: str
+        category: str
+        message: str
+
+    assert not isinstance(_NoDict("a", "b", "c"), Finding)
+
+
+def test_arbitrary_class_with_protocol_shape_qualifies() -> None:
+    """Domain-specific variants satisfy the Protocol structurally —
+    no inheritance required (per feat-008 / ADR-0012)."""
+
+    class _CoverageFinding:
+        severity: str = "info"
+        category: str = "coverage"
+        message: str = "Module foo has 80% coverage"
+
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "severity": self.severity,
+                "category": self.category,
+                "message": self.message,
+            }
+
+    assert isinstance(_CoverageFinding(), Finding)

--- a/packages/agentforge-core/tests/unit/test_contracts_llm.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_llm.py
@@ -1,0 +1,62 @@
+"""Unit tests for the `LLMClient` ABC."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.values.messages import LLMResponse, Message, TokenUsage, ToolSpec
+
+
+def test_llmclient_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        LLMClient()  # type: ignore[abstract]
+
+
+class _MinimalClient(LLMClient):
+    """Minimal subclass overriding every abstract method."""
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        return LLMResponse(
+            content="ok",
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+            cost_usd=0.0,
+            model="m",
+            provider="p",
+        )
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_works() -> None:
+    client = _MinimalClient()
+    response = await client.call("sys", [Message(role="user", content="hi")])
+    assert response.content == "ok"
+    await client.close()
+
+
+def test_default_capabilities_is_empty() -> None:
+    assert _MinimalClient().capabilities() == set()
+
+
+def test_supports_returns_false_for_unknown_capability() -> None:
+    assert _MinimalClient().supports("caching") is False
+
+
+class _CachingClient(_MinimalClient):
+    def capabilities(self) -> set[str]:
+        return {"caching", "streaming"}
+
+
+def test_supports_returns_true_for_declared_capability() -> None:
+    client = _CachingClient()
+    assert client.supports("caching") is True
+    assert client.supports("streaming") is True
+    assert client.supports("thinking") is False

--- a/packages/agentforge-core/tests/unit/test_contracts_memory.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_memory.py
@@ -1,0 +1,118 @@
+"""Unit tests for the `MemoryStore` ABC."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.values.claim import Claim
+
+
+def test_memorystore_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        MemoryStore()  # type: ignore[abstract]
+
+
+class _MinimalStore(MemoryStore):
+    """Minimal subclass overriding every abstract method."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, Claim] = {}
+
+    async def put(self, claim: Claim) -> str:
+        self._items[claim.id] = claim
+        return claim.id
+
+    async def get(self, claim_id: str) -> Claim | None:
+        return self._items.get(claim_id)
+
+    async def query(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+        limit: int = 100,
+    ) -> list[Claim]:
+        return list(self._items.values())[:limit]
+
+    async def supersede(self, old_id: str, new_claim: Claim) -> str:
+        return new_claim.id
+
+    def stream(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+    ) -> AsyncIterator[Claim]:
+        async def _agen() -> AsyncIterator[Claim]:
+            for c in self._items.values():
+                yield c
+
+        return _agen()
+
+    async def close(self) -> None:
+        self._items.clear()
+
+
+def _claim() -> Claim:
+    return Claim(
+        run_id="r1",
+        project="p",
+        agent="a",
+        category="finding",
+        payload={"x": 1},
+    )
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_put_and_get() -> None:
+    store = _MinimalStore()
+    c = _claim()
+    cid = await store.put(c)
+    assert cid == c.id
+    fetched = await store.get(cid)
+    assert fetched is c
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_query() -> None:
+    store = _MinimalStore()
+    await store.put(_claim())
+    await store.put(_claim())
+    results = await store.query()
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_stream() -> None:
+    store = _MinimalStore()
+    await store.put(_claim())
+    collected = [c async for c in store.stream()]
+    assert len(collected) == 1
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_close() -> None:
+    store = _MinimalStore()
+    await store.put(_claim())
+    await store.close()
+    assert await store.get("anything") is None
+
+
+def test_default_capabilities_is_empty() -> None:
+    assert _MinimalStore().capabilities() == set()
+
+
+def test_supports_uses_capabilities() -> None:
+    class _GraphStore(_MinimalStore):
+        def capabilities(self) -> set[str]:
+            return {"graph"}
+
+    g = _GraphStore()
+    assert g.supports("graph") is True
+    assert g.supports("vector") is False

--- a/packages/agentforge-core/tests/unit/test_contracts_strategy.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_strategy.py
@@ -1,0 +1,28 @@
+"""Unit tests for the `ReasoningStrategy` ABC."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.state import AgentState, Step
+
+
+def test_reasoning_strategy_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        ReasoningStrategy()  # type: ignore[abstract]
+
+
+class _NoOpStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        state.steps.append(Step(iteration=0, kind="system", content="no-op strategy ran"))
+        return state
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_works() -> None:
+    strategy = _NoOpStrategy()
+    state = AgentState(run_id="r1", task="t")
+    result = await strategy.run(state)
+    assert result is state
+    assert len(result.steps) == 1
+    assert result.steps[0].kind == "system"

--- a/packages/agentforge-core/tests/unit/test_contracts_tool.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_tool.py
@@ -1,0 +1,94 @@
+"""Unit tests for the `Tool` ABC."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+import pytest
+from agentforge_core.contracts.tool import Tool
+from pydantic import BaseModel
+
+
+class _PingInput(BaseModel):
+    target: str
+
+
+class PingTool(Tool):
+    name = "ping"
+    description = "Pings a target."
+    input_schema = _PingInput
+
+    async def run(self, target: str) -> dict[str, Any]:
+        return {"target": target, "ok": True}
+
+
+def test_tool_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        Tool()  # type: ignore[abstract]
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_works() -> None:
+    tool = PingTool()
+    result = await tool.run(target="example.com")
+    assert result == {"target": "example.com", "ok": True}
+
+
+def test_to_spec_returns_tool_spec_with_inferred_schema() -> None:
+    spec = PingTool().to_spec()
+    assert spec.name == "ping"
+    assert spec.description == "Pings a target."
+    assert spec.schema_["type"] == "object"
+    assert "target" in spec.schema_["properties"]
+
+
+def test_default_capabilities_is_frozen_empty_set() -> None:
+    assert PingTool.capabilities == frozenset()
+
+
+def test_subclass_must_declare_required_attrs() -> None:
+    with pytest.raises(TypeError, match="must declare class attribute"):
+
+        class _Incomplete(Tool):
+            async def run(self, **kwargs: Any) -> Any:
+                return None
+
+
+def test_intermediate_abstract_subclass_does_not_trigger_check() -> None:
+    """An intermediate abstract subclass (no `name`) is allowed; only
+    concrete subclasses must declare the attributes."""
+
+    class _AbstractMixin(Tool):
+        @abstractmethod
+        async def run(self, **kwargs: Any) -> Any: ...
+
+    # No error at class creation. Concrete child must still declare attrs.
+    class _Concrete(_AbstractMixin):
+        name = "x"
+        description = "y"
+        input_schema = _PingInput
+
+        async def run(self, **kwargs: Any) -> Any:
+            return None
+
+    _Concrete()
+
+
+def test_inherited_attributes_satisfy_the_check() -> None:
+    """If `name` etc. come from an intermediate concrete class, fine."""
+
+    class _Base(Tool):
+        name = "base"
+        description = "base desc"
+        input_schema = _PingInput
+
+        async def run(self, **kwargs: Any) -> Any:
+            return None
+
+    class _Child(_Base):
+        # inherits all three attributes
+        async def run(self, **kwargs: Any) -> Any:
+            return "child"
+
+    assert _Child.name == "base"

--- a/packages/agentforge-core/tests/unit/test_exceptions.py
+++ b/packages/agentforge-core/tests/unit/test_exceptions.py
@@ -1,0 +1,56 @@
+"""Unit tests for the AgentForge exception hierarchy."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.production.exceptions import (
+    AgentForgeError,
+    BudgetExceeded,
+    CapabilityNotSupported,
+    GuardrailViolation,
+    ModuleError,
+    ProviderError,
+)
+
+
+@pytest.mark.parametrize(
+    "subclass",
+    [
+        BudgetExceeded,
+        GuardrailViolation,
+        ModuleError,
+        ProviderError,
+        CapabilityNotSupported,
+    ],
+)
+def test_every_specific_error_subclasses_agentforge_error(
+    subclass: type[Exception],
+) -> None:
+    assert issubclass(subclass, AgentForgeError)
+
+
+def test_agentforge_error_subclasses_exception() -> None:
+    assert issubclass(AgentForgeError, Exception)
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [
+        AgentForgeError,
+        BudgetExceeded,
+        GuardrailViolation,
+        ModuleError,
+        ProviderError,
+        CapabilityNotSupported,
+    ],
+)
+def test_message_preserved_through_str(exc_cls: type[Exception]) -> None:
+    err = exc_cls("custom message")
+    assert str(err) == "custom message"
+
+
+def test_can_catch_any_specific_error_via_base() -> None:
+    with pytest.raises(AgentForgeError):
+        raise BudgetExceeded("test")
+    with pytest.raises(AgentForgeError):
+        raise GuardrailViolation("test")

--- a/packages/agentforge-core/tests/unit/test_log_filter.py
+++ b/packages/agentforge-core/tests/unit/test_log_filter.py
@@ -1,0 +1,101 @@
+"""Unit tests for `RunIdFilter` and the install/uninstall helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from agentforge_core.production.log_filter import (
+    RunIdFilter,
+    install_run_id_filter,
+    uninstall_run_id_filter,
+)
+from agentforge_core.production.run_context import bind_run, new_run, reset_run
+
+
+class _CaptureHandler(logging.Handler):
+    """Captures emitted records into a list for assertion."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def isolated_logger() -> tuple[logging.Logger, _CaptureHandler]:
+    """Per-test logger with a capture handler. No root propagation."""
+    logger = logging.getLogger(f"test.agentforge.log_filter.{id(object())}")
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    logger.filters.clear()
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+    handler = _CaptureHandler()
+    logger.addHandler(handler)
+    return logger, handler
+
+
+def test_filter_attaches_run_id_when_active(
+    isolated_logger: tuple[logging.Logger, _CaptureHandler],
+) -> None:
+    logger, handler = isolated_logger
+    install_run_id_filter(logger)
+    ctx = new_run()
+    token = bind_run(ctx)
+    try:
+        logger.info("hello")
+    finally:
+        reset_run(token)
+
+    record = next(r for r in handler.records if r.getMessage() == "hello")
+    assert getattr(record, "run_id", None) == ctx.run_id
+
+
+def test_filter_attaches_dash_when_no_run(
+    isolated_logger: tuple[logging.Logger, _CaptureHandler],
+) -> None:
+    logger, handler = isolated_logger
+    install_run_id_filter(logger)
+    logger.info("idle")
+    record = next(r for r in handler.records if r.getMessage() == "idle")
+    assert getattr(record, "run_id", None) == "-"
+
+
+def test_install_is_idempotent(
+    isolated_logger: tuple[logging.Logger, _CaptureHandler],
+) -> None:
+    logger, _ = isolated_logger
+    a = install_run_id_filter(logger)
+    b = install_run_id_filter(logger)
+    assert a is b
+    count = sum(1 for f in logger.filters if isinstance(f, RunIdFilter))
+    assert count == 1
+
+
+def test_uninstall_removes_filter(
+    isolated_logger: tuple[logging.Logger, _CaptureHandler],
+) -> None:
+    logger, _ = isolated_logger
+    install_run_id_filter(logger)
+    uninstall_run_id_filter(logger)
+    assert not any(isinstance(f, RunIdFilter) for f in logger.filters)
+
+
+def test_uninstall_when_not_installed_is_noop(
+    isolated_logger: tuple[logging.Logger, _CaptureHandler],
+) -> None:
+    logger, _ = isolated_logger
+    uninstall_run_id_filter(logger)
+    assert not any(isinstance(f, RunIdFilter) for f in logger.filters)
+
+
+def test_install_default_targets_root() -> None:
+    install_run_id_filter()
+    try:
+        root = logging.getLogger()
+        assert any(isinstance(f, RunIdFilter) for f in root.filters)
+    finally:
+        uninstall_run_id_filter()

--- a/packages/agentforge-core/tests/unit/test_messages.py
+++ b/packages/agentforge-core/tests/unit/test_messages.py
@@ -1,0 +1,164 @@
+"""Unit tests for the message / response value types."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolCall,
+    ToolSpec,
+)
+from pydantic import ValidationError
+
+# ---- Message ----
+
+
+def test_message_basic_construction() -> None:
+    m = Message(role="user", content="hi")
+    assert m.role == "user"
+    assert m.content == "hi"
+    assert m.name is None
+    assert m.tool_call_id is None
+
+
+def test_message_is_frozen() -> None:
+    m = Message(role="user", content="hi")
+    with pytest.raises(ValidationError):
+        m.role = "system"  # type: ignore[misc]
+
+
+def test_message_rejects_invalid_role() -> None:
+    with pytest.raises(ValidationError):
+        Message(role="captain", content="hi")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("role", ["system", "user", "assistant", "tool"])
+def test_message_accepts_each_valid_role(role: str) -> None:
+    Message(role=role, content="ok")  # type: ignore[arg-type]
+
+
+# ---- ToolCall ----
+
+
+def test_tool_call_basic() -> None:
+    tc = ToolCall(id="t-1", name="search", arguments={"q": "hi"})
+    assert tc.id == "t-1"
+    assert tc.arguments == {"q": "hi"}
+
+
+def test_tool_call_arguments_default_empty() -> None:
+    tc = ToolCall(id="t-1", name="ping")
+    assert tc.arguments == {}
+
+
+def test_tool_call_is_frozen() -> None:
+    tc = ToolCall(id="t-1", name="x", arguments={})
+    with pytest.raises(ValidationError):
+        tc.id = "t-2"  # type: ignore[misc]
+
+
+# ---- ToolSpec ----
+
+
+def test_tool_spec_basic() -> None:
+    spec = ToolSpec(
+        name="search",
+        description="Web search",
+        schema={"type": "object", "properties": {"q": {"type": "string"}}},
+    )
+    assert spec.name == "search"
+    assert spec.schema_["type"] == "object"
+
+
+def test_tool_spec_schema_alias_round_trip() -> None:
+    """The Python attribute is `schema_` but the JSON key is `schema`."""
+    spec = ToolSpec(name="x", description="y", schema={"type": "object"})
+    payload = spec.model_dump(by_alias=True)
+    assert "schema" in payload
+    assert "schema_" not in payload
+
+
+# ---- TokenUsage ----
+
+
+def test_token_usage_total() -> None:
+    u = TokenUsage(input_tokens=100, output_tokens=50)
+    assert u.total == 150
+
+
+def test_token_usage_total_excludes_cache_and_thinking() -> None:
+    u = TokenUsage(
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_tokens=100,
+        cache_write_tokens=20,
+        thinking_tokens=1000,
+    )
+    assert u.total == 15  # cache and thinking are accounting metadata
+
+
+def test_token_usage_negatives_rejected() -> None:
+    with pytest.raises(ValidationError):
+        TokenUsage(input_tokens=-1, output_tokens=0)
+
+
+# ---- LLMResponse ----
+
+
+def _usage(i: int = 1, o: int = 1) -> TokenUsage:
+    return TokenUsage(input_tokens=i, output_tokens=o)
+
+
+def test_llm_response_basic() -> None:
+    r = LLMResponse(
+        content="ok",
+        stop_reason="end_turn",
+        usage=_usage(),
+        cost_usd=0.001,
+        model="m",
+        provider="p",
+    )
+    assert r.tool_calls == ()
+    assert r.cost_usd == pytest.approx(0.001)
+
+
+def test_llm_response_is_frozen() -> None:
+    r = LLMResponse(
+        content="x",
+        stop_reason="end_turn",
+        usage=_usage(),
+        cost_usd=0.0,
+        model="m",
+        provider="p",
+    )
+    with pytest.raises(ValidationError):
+        r.content = "y"  # type: ignore[misc]
+
+
+def test_llm_response_rejects_negative_cost() -> None:
+    with pytest.raises(ValidationError):
+        LLMResponse(
+            content="x",
+            stop_reason="end_turn",
+            usage=_usage(),
+            cost_usd=-0.01,
+            model="m",
+            provider="p",
+        )
+
+
+@pytest.mark.parametrize(
+    "stop",
+    ["end_turn", "tool_use", "max_tokens", "stop_sequence", "other"],
+)
+def test_llm_response_accepts_every_stop_reason(stop: str) -> None:
+    LLMResponse(
+        content="x",
+        stop_reason=stop,  # type: ignore[arg-type]
+        usage=_usage(),
+        cost_usd=0.0,
+        model="m",
+        provider="p",
+    )

--- a/packages/agentforge-core/tests/unit/test_resolver.py
+++ b/packages/agentforge-core/tests/unit/test_resolver.py
@@ -1,0 +1,138 @@
+"""Unit tests for the in-process resolver and `parse_model_string`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.resolver import Resolver, parse_model_string, register
+
+
+@pytest.fixture
+def resolver() -> Resolver:
+    return Resolver()
+
+
+# ---- parse_model_string ----
+
+
+def test_parse_model_string_basic() -> None:
+    assert parse_model_string("anthropic:claude-sonnet-4.7") == (
+        "anthropic",
+        "claude-sonnet-4.7",
+    )
+
+
+def test_parse_model_string_keeps_subsequent_colons() -> None:
+    """Only the first ':' splits — provider IDs may contain colons."""
+    p, m = parse_model_string("bedrock:us-east-1:anthropic.claude-sonnet")
+    assert p == "bedrock"
+    assert m == "us-east-1:anthropic.claude-sonnet"
+
+
+def test_parse_model_string_no_colon_raises() -> None:
+    with pytest.raises(ModuleError, match="expected '<provider>:<model_id>'"):
+        parse_model_string("just-a-name")
+
+
+def test_parse_model_string_empty_provider_raises() -> None:
+    with pytest.raises(ModuleError, match="non-empty"):
+        parse_model_string(":model")
+
+
+def test_parse_model_string_empty_model_raises() -> None:
+    with pytest.raises(ModuleError, match="non-empty"):
+        parse_model_string("provider:")
+
+
+# ---- Resolver instance ----
+
+
+def test_register_and_resolve(resolver: Resolver) -> None:
+    class A:
+        pass
+
+    resolver.register("strategies", "a", A)
+    assert resolver.resolve("strategies", "a") is A
+
+
+def test_resolve_unknown_raises_with_helpful_message(
+    resolver: Resolver,
+) -> None:
+    with pytest.raises(ModuleError, match="No module registered"):
+        resolver.resolve("strategies", "nothing")
+
+
+def test_resolve_unknown_lists_available(resolver: Resolver) -> None:
+    class A:
+        pass
+
+    resolver.register("strategies", "alpha", A)
+    with pytest.raises(ModuleError, match=r"alpha"):
+        resolver.resolve("strategies", "beta")
+
+
+def test_register_same_class_twice_is_idempotent(resolver: Resolver) -> None:
+    class A:
+        pass
+
+    resolver.register("strategies", "a", A)
+    resolver.register("strategies", "a", A)
+    assert resolver.resolve("strategies", "a") is A
+
+
+def test_register_different_class_under_same_name_raises(
+    resolver: Resolver,
+) -> None:
+    class A:
+        pass
+
+    class B:
+        pass
+
+    resolver.register("strategies", "a", A)
+    with pytest.raises(ModuleError, match="already registered"):
+        resolver.register("strategies", "a", B)
+
+
+def test_list_filters_by_category(resolver: Resolver) -> None:
+    class A:
+        pass
+
+    class B:
+        pass
+
+    resolver.register("strategies", "a", A)
+    resolver.register("memory", "b", B)
+    assert {n for _, n, _ in resolver.list_("strategies")} == {"a"}
+    assert {n for _, n, _ in resolver.list_("memory")} == {"b"}
+    assert len(resolver.list_()) == 2
+
+
+def test_clear_empties_registry(resolver: Resolver) -> None:
+    class A:
+        pass
+
+    resolver.register("strategies", "a", A)
+    resolver.clear()
+    assert resolver.list_() == []
+
+
+# ---- Global resolver and decorator ----
+
+
+def test_global_resolver_is_singleton() -> None:
+    a = Resolver.global_()
+    b = Resolver.global_()
+    assert a is b
+
+
+def test_register_decorator_uses_global() -> None:
+    Resolver.global_().clear()
+
+    @register("strategies", "decorator-test")
+    class _MyStrategy:
+        pass
+
+    cls = Resolver.global_().resolve("strategies", "decorator-test")
+    assert cls is _MyStrategy
+    Resolver.global_().clear()

--- a/packages/agentforge-core/tests/unit/test_run_context.py
+++ b/packages/agentforge-core/tests/unit/test_run_context.py
@@ -1,0 +1,133 @@
+"""Unit tests for `RunContext`, `current_run`, and the ContextVar."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agentforge_core.production.run_context import (
+    RunContext,
+    bind_run,
+    current_run,
+    new_run,
+    reset_run,
+)
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError as _PydValidationError
+
+
+def test_new_run_assigns_ulid() -> None:
+    ctx = new_run()
+    # ULIDs are 26-char Base32 (Crockford).
+    assert isinstance(ctx.run_id, str)
+    assert len(ctx.run_id) == 26
+
+
+def test_new_run_seeds_idempotency() -> None:
+    ctx = new_run(task="hello")
+    assert isinstance(ctx.idempotency_seed, str)
+    assert len(ctx.idempotency_seed) == 32
+
+
+def test_new_run_distinct_ids() -> None:
+    a = new_run()
+    b = new_run()
+    assert a.run_id != b.run_id
+
+
+def test_idempotency_key_stable_for_same_parts() -> None:
+    ctx = new_run()
+    k1 = ctx.idempotency_key_for("charge", "customer-42")
+    k2 = ctx.idempotency_key_for("charge", "customer-42")
+    assert k1 == k2
+
+
+def test_idempotency_key_differs_for_different_parts() -> None:
+    ctx = new_run()
+    k1 = ctx.idempotency_key_for("charge", "customer-42")
+    k2 = ctx.idempotency_key_for("charge", "customer-99")
+    assert k1 != k2
+
+
+def test_idempotency_keys_differ_across_runs_for_same_parts() -> None:
+    a = new_run()
+    b = new_run()
+    assert a.idempotency_key_for("op", 1) != b.idempotency_key_for("op", 1)
+
+
+def test_idempotency_key_is_64_hex_chars() -> None:
+    ctx = new_run()
+    key = ctx.idempotency_key_for("anything")
+    assert len(key) == 64
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+def test_current_run_raises_when_no_run_active() -> None:
+    with pytest.raises(RuntimeError, match="No active RunContext"):
+        current_run()
+
+
+def test_bind_and_reset_run() -> None:
+    ctx = new_run()
+    token = bind_run(ctx)
+    try:
+        assert current_run() is ctx
+    finally:
+        reset_run(token)
+    with pytest.raises(RuntimeError):
+        current_run()
+
+
+@pytest.mark.asyncio
+async def test_run_id_propagates_across_nested_async_tasks() -> None:
+    """ContextVar must follow asyncio tasks (per Python docs)."""
+    ctx = new_run()
+    token = bind_run(ctx)
+    try:
+
+        async def nested() -> str:
+            return current_run().run_id
+
+        async with asyncio.TaskGroup() as tg:
+            t1 = tg.create_task(nested())
+            t2 = tg.create_task(nested())
+        assert t1.result() == ctx.run_id
+        assert t2.result() == ctx.run_id
+    finally:
+        reset_run(token)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_isolated() -> None:
+    """Two concurrent agent runs must see distinct contexts."""
+    ctx_a = new_run()
+    ctx_b = new_run()
+
+    async def run_with(ctx: RunContext) -> str:
+        token = bind_run(ctx)
+        try:
+            await asyncio.sleep(0)  # let scheduler interleave
+            return current_run().run_id
+        finally:
+            reset_run(token)
+
+    a, b = await asyncio.gather(run_with(ctx_a), run_with(ctx_b))
+    assert a == ctx_a.run_id
+    assert b == ctx_b.run_id
+
+
+def test_run_context_is_immutable_for_run_id() -> None:
+    """Strict mode rejects type errors; assignment validated."""
+    ctx = new_run()
+    with pytest.raises(_PydValidationError):
+        ctx.run_id = 12345  # type: ignore[assignment]
+
+
+@given(parts=st.lists(st.one_of(st.integers(), st.text(max_size=20)), max_size=5))
+def test_property_idempotency_keys_deterministic(parts: list[object]) -> None:
+    """For any parts, calling idempotency_key_for twice returns the same key."""
+    ctx = new_run()
+    a = ctx.idempotency_key_for(*parts)
+    b = ctx.idempotency_key_for(*parts)
+    assert a == b

--- a/packages/agentforge-core/tests/unit/test_state.py
+++ b/packages/agentforge-core/tests/unit/test_state.py
@@ -1,0 +1,123 @@
+"""Unit tests for `Step`, `AgentState`, `RunResult`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.values.messages import ToolCall
+from agentforge_core.values.state import AgentState, RunResult, Step
+from pydantic import ValidationError
+
+# ---- Step ----
+
+
+def test_step_basic() -> None:
+    s = Step(iteration=0, kind="think", content="planning")
+    assert s.iteration == 0
+    assert s.kind == "think"
+    assert s.content == "planning"
+    assert s.tool_call is None
+    assert s.tokens_in == 0
+
+
+def test_step_with_tool_call() -> None:
+    tc = ToolCall(id="t-1", name="ping", arguments={})
+    s = Step(iteration=1, kind="act", content={"x": 1}, tool_call=tc)
+    assert s.tool_call is tc
+
+
+def test_step_is_frozen() -> None:
+    s = Step(iteration=0, kind="think", content="x")
+    with pytest.raises(ValidationError):
+        s.iteration = 5  # type: ignore[misc]
+
+
+def test_step_rejects_invalid_kind() -> None:
+    with pytest.raises(ValidationError):
+        Step(iteration=0, kind="bogus", content="x")  # type: ignore[arg-type]
+
+
+def test_step_rejects_negative_iteration() -> None:
+    with pytest.raises(ValidationError):
+        Step(iteration=-1, kind="think", content="x")
+
+
+# ---- AgentState ----
+
+
+def test_agent_state_basic() -> None:
+    state = AgentState(run_id="r1", task="hello")
+    assert state.run_id == "r1"
+    assert state.task == "hello"
+    assert state.steps == []
+    assert state.findings == []
+
+
+def test_agent_state_appends_steps() -> None:
+    state = AgentState(run_id="r1", task="t")
+    s = Step(iteration=0, kind="think", content="planning")
+    state.steps.append(s)
+    assert len(state.steps) == 1
+
+
+def test_agent_state_validate_assignment() -> None:
+    """Strict mode + validate_assignment rejects bad replacements."""
+    state = AgentState(run_id="r1", task="t")
+    with pytest.raises(ValidationError):
+        state.run_id = 42  # type: ignore[assignment]
+
+
+# ---- RunResult ----
+
+
+def test_run_result_basic() -> None:
+    r = RunResult(
+        output="hello",
+        cost_usd=0.001,
+        tokens_in=10,
+        tokens_out=5,
+        run_id="r1",
+        duration_ms=120,
+    )
+    assert r.output == "hello"
+    assert r.finish_reason == "completed"
+
+
+def test_run_result_is_frozen() -> None:
+    r = RunResult(
+        output="x",
+        cost_usd=0.0,
+        tokens_in=0,
+        tokens_out=0,
+        run_id="r1",
+        duration_ms=0,
+    )
+    with pytest.raises(ValidationError):
+        r.output = "y"  # type: ignore[misc]
+
+
+def test_run_result_rejects_negative_duration() -> None:
+    with pytest.raises(ValidationError):
+        RunResult(
+            output="x",
+            cost_usd=0.0,
+            tokens_in=0,
+            tokens_out=0,
+            run_id="r1",
+            duration_ms=-1,
+        )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["completed", "iteration_cap", "budget_exceeded", "guardrail", "error", "cancelled"],
+)
+def test_run_result_accepts_every_finish_reason(reason: str) -> None:
+    RunResult(
+        output="x",
+        cost_usd=0.0,
+        tokens_in=0,
+        tokens_out=0,
+        run_id="r1",
+        duration_ms=0,
+        finish_reason=reason,  # type: ignore[arg-type]
+    )

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -54,10 +54,11 @@ dependencies = [
 # agentforge = "agentforge.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/"
-Repository = "https://github.com/"
-Documentation = "https://github.com/"
-Changelog = "https://github.com/"
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Documentation = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Scaffoldic/agentforge-py/issues"
 
 [tool.uv.sources]
 agentforge-core = { workspace = true }

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -2,9 +2,10 @@
 
 This package is the default runtime. It ships:
 
-  - The `Agent` orchestrator (lands later in feat-001).
+  - The `Agent` orchestrator (locked constructor surface per feat-001).
   - `InMemoryStore` — process-local default `MemoryStore` so a fresh
     agent has persistence wired without external infra.
+  - The configuration loader (`load_config`).
 
 For provider clients, persistence drivers, MCP, observability backends,
 and safety modules, install the corresponding `agentforge-<X>` packages
@@ -16,11 +17,16 @@ the per-feature specs under `docs/features/`.
 
 from __future__ import annotations
 
+from agentforge.agent import Agent
+from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
 
 __version__ = "0.0.0"
 
 __all__ = [
+    "Agent",
+    "AgentForgeConfig",
     "InMemoryStore",
     "__version__",
+    "load_config",
 ]

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -1,11 +1,26 @@
 """AgentForge — open-source plug-and-play framework for production AI agents.
 
-This package is the default runtime: `Agent`, `ReActLoop`, default
-tools, simple findings, in-memory store, basic safety, `BudgetPolicy`.
+This package is the default runtime. It ships:
+
+  - The `Agent` orchestrator (lands later in feat-001).
+  - `InMemoryStore` — process-local default `MemoryStore` so a fresh
+    agent has persistence wired without external infra.
+
+For provider clients, persistence drivers, MCP, observability backends,
+and safety modules, install the corresponding `agentforge-<X>` packages
+or use the `agentforge[<extra>]` install (per ADR-0003).
 
 See the project docs at `docs/README.md` (in the design workspace) and
 the per-feature specs under `docs/features/`.
 """
 
+from __future__ import annotations
+
+from agentforge.memory import InMemoryStore
+
 __version__ = "0.0.0"
-__all__: list[str] = []
+
+__all__ = [
+    "InMemoryStore",
+    "__version__",
+]

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -1,0 +1,263 @@
+"""`Agent` — the framework's top-level orchestrator.
+
+Per feat-001 §4.2 and ADR-0007, the constructor surface is locked.
+Adding a kwarg with a safe default is a minor bump; removing or
+renaming requires a major bump.
+
+Lifecycle (per ADR-0010):
+
+    Agent.__init__: load config → resolve modules → wire defaults →
+                    install RunIdFilter (if configured)
+    Agent.run(task): bind RunContext → call strategy.run(state) →
+                     run evaluators → fire on_finish → return RunResult
+    Agent.close(): release LLM client / memory / hooks (async ctx mgr OK)
+
+feat-001 ships the lifecycle + locked surface; feat-002 adds the
+default `ReActLoop`, feat-003 the provider surface, feat-007 the full
+fallback chain. The `Agent` constructor stays unchanged across those
+features.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import TracebackType
+
+from agentforge_core.contracts.evaluator import Evaluator
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import (
+    AgentForgeError,
+    BudgetExceeded,
+    GuardrailViolation,
+    ModuleError,
+)
+from agentforge_core.production.log_filter import (
+    install_run_id_filter,
+    uninstall_run_id_filter,
+)
+from agentforge_core.production.run_context import (
+    RunContext,
+    bind_run,
+    new_run,
+    reset_run,
+)
+from agentforge_core.resolver import Resolver, parse_model_string
+from agentforge_core.values.state import AgentState, FinishReason, RunResult
+
+from agentforge.config import AgentForgeConfig, load_config
+from agentforge.memory import InMemoryStore
+
+StepHook = Callable[..., Awaitable[None] | None]
+"""Hook signature: takes a Step, returns awaitable-or-None."""
+
+FinishHook = Callable[..., Awaitable[None] | None]
+"""Hook signature: takes a RunResult, returns awaitable-or-None."""
+
+
+class Agent:
+    """Framework-level agent orchestrator.
+
+    The constructor signature is the locked public API; see
+    `docs/features/feat-001-core-contracts-and-agent.md` §4.2.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | LLMClient | None = None,
+        tools: list[Tool] | None = None,
+        strategy: str | ReasoningStrategy | None = None,
+        memory: MemoryStore | None = None,
+        evaluators: list[Evaluator] | None = None,
+        system_prompt: str | None = None,
+        budget_usd: float | None = None,
+        max_iterations: int | None = None,
+        on_step: StepHook | None = None,
+        on_finish: FinishHook | None = None,
+        config_path: str | Path | None = None,
+        install_log_filter: bool = True,
+    ) -> None:
+        self._config: AgentForgeConfig = load_config(config_path)
+
+        # Resolve model.
+        self._llm: LLMClient | None
+        resolved_model = model if model is not None else self._config.agent.model
+        self._llm = self._resolve_model(resolved_model)
+
+        # Resolve strategy.
+        resolved_strategy = strategy if strategy is not None else self._config.agent.strategy
+        self._strategy: ReasoningStrategy = self._resolve_strategy(resolved_strategy)
+
+        # Defaults: in-memory store, no evaluators, no tools.
+        self._memory: MemoryStore = memory if memory is not None else InMemoryStore()
+        self._tools: list[Tool] = list(tools) if tools is not None else []
+        self._evaluators: list[Evaluator] = list(evaluators) if evaluators is not None else []
+        self._system_prompt: str | None = (
+            system_prompt if system_prompt is not None else self._config.agent.system_prompt
+        )
+
+        # Budget — kwargs override config; config overrides Pydantic default.
+        cap_usd = budget_usd if budget_usd is not None else self._config.agent.budget_usd
+        max_iter = (
+            max_iterations if max_iterations is not None else self._config.agent.max_iterations
+        )
+        self._budget = BudgetPolicy(usd=cap_usd, max_iterations=max_iter)
+
+        self._on_step = on_step
+        self._on_finish = on_finish
+        self._closed = False
+
+        if install_log_filter and self._config.logging.run_id_filter:
+            install_run_id_filter()
+
+    # ------------------------------------------------------------------
+    # Resolution helpers (used at construction; raise at startup, P11).
+    # ------------------------------------------------------------------
+
+    def _resolve_model(self, model: str | LLMClient | None) -> LLMClient | None:
+        if model is None:
+            return None
+        if isinstance(model, LLMClient):
+            return model
+        # String — parse "<provider>:<model_id>". Provider lookup is
+        # deferred to feat-003; for now we surface a clear error so the
+        # developer knows what's missing.
+        provider, _ = parse_model_string(model)
+        raise ModuleError(
+            f"No LLM provider registered for {provider!r}. "
+            f"feat-001 ships only the abstraction; install agentforge-{provider} "
+            f"(when feat-003 ships) or pass a typed LLMClient instance directly."
+        )
+
+    def _resolve_strategy(self, strategy: str | ReasoningStrategy | None) -> ReasoningStrategy:
+        if isinstance(strategy, ReasoningStrategy):
+            return strategy
+        if strategy is None:
+            raise ModuleError(
+                "No reasoning strategy provided. feat-001 ships only the "
+                "ReasoningStrategy ABC; install agentforge[react] (when feat-002 "
+                "ships) or pass a custom ReasoningStrategy instance via "
+                "Agent(strategy=...)."
+            )
+        # String name — look up in the resolver (feat-002 will register
+        # ReActLoop here when it ships).
+        cls = Resolver.global_().resolve("strategies", strategy)
+        if not callable(cls):
+            raise ModuleError(f"Resolved strategy {strategy!r} is not constructible: {cls!r}.")
+        instance = cls()
+        if not isinstance(instance, ReasoningStrategy):
+            raise ModuleError(
+                f"Resolved strategy {strategy!r} ({cls.__name__}) does not "
+                f"implement ReasoningStrategy."
+            )
+        return instance
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def memory(self) -> MemoryStore:
+        return self._memory
+
+    @property
+    def tools(self) -> list[Tool]:
+        return list(self._tools)
+
+    @property
+    def budget(self) -> BudgetPolicy:
+        return self._budget
+
+    async def run(self, task: str) -> RunResult:
+        """Execute the agent's reasoning loop on `task`.
+
+        Returns:
+            A `RunResult` with the agent's output, full trace, and cost.
+        """
+        if self._closed:
+            raise ModuleError("Agent has been closed; create a new instance.")
+        ctx: RunContext = new_run(task=task)
+        token = bind_run(ctx)
+        started_ms = time.monotonic()
+        finish_reason: FinishReason = "completed"
+        try:
+            state = AgentState(run_id=ctx.run_id, task=task)
+            try:
+                await self._strategy.run(state)
+            except BudgetExceeded:
+                finish_reason = "budget_exceeded"
+                raise
+            except GuardrailViolation:
+                finish_reason = "guardrail"
+                raise
+            except AgentForgeError:
+                finish_reason = "error"
+                raise
+            duration_ms = int((time.monotonic() - started_ms) * 1000)
+            output = self._extract_output(state)
+            tokens_in = sum(s.tokens_in for s in state.steps)
+            tokens_out = sum(s.tokens_out for s in state.steps)
+            result = RunResult(
+                output=output,
+                steps=tuple(state.steps),
+                cost_usd=self._budget.spent_usd,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                run_id=ctx.run_id,
+                duration_ms=duration_ms,
+                finish_reason=finish_reason,
+            )
+            await self._fire_finish(result)
+            return result
+        finally:
+            reset_run(token)
+
+    async def close(self) -> None:
+        """Release resources held by the agent (LLM, memory, log filter)."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._llm is not None:
+            await self._llm.close()
+        await self._memory.close()
+        uninstall_run_id_filter()
+
+    async def __aenter__(self) -> Agent:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_output(state: AgentState) -> str:
+        """Pick the agent's final output from `state.steps`.
+
+        feat-001 uses the simplest rule: the content of the last
+        non-system step, stringified. feat-002 strategies will set
+        a richer convention.
+        """
+        for step in reversed(state.steps):
+            if step.kind != "system":
+                content = step.content
+                return content if isinstance(content, str) else str(content)
+        return ""
+
+    async def _fire_finish(self, result: RunResult) -> None:
+        if self._on_finish is None:
+            return
+        outcome = self._on_finish(result)
+        if outcome is not None and hasattr(outcome, "__await__"):
+            await outcome

--- a/packages/agentforge/src/agentforge/config/__init__.py
+++ b/packages/agentforge/src/agentforge/config/__init__.py
@@ -1,0 +1,18 @@
+"""Configuration loader for `agentforge.yaml`.
+
+feat-001 ships only the partial schema that feat-001's surface needs.
+feat-012 ships the full schema with module / observability / providers
+sections. Both phases use the same loader; the schema grows additively.
+"""
+
+from __future__ import annotations
+
+from agentforge.config.loader import load_config
+from agentforge.config.schema import AgentConfig, AgentForgeConfig, LoggingConfig
+
+__all__ = [
+    "AgentConfig",
+    "AgentForgeConfig",
+    "LoggingConfig",
+    "load_config",
+]

--- a/packages/agentforge/src/agentforge/config/loader.py
+++ b/packages/agentforge/src/agentforge/config/loader.py
@@ -1,0 +1,105 @@
+"""YAML loader with env-var interpolation for `agentforge.yaml`.
+
+Per ADR-0013, configuration is *data*: the loader supports env-var
+interpolation (`${VAR}`, `${VAR:default}`, `${VAR:?error}`, `$$` →
+`$`) and Pydantic validation, but no Jinja, no dynamic imports, no
+arbitrary template logic.
+
+Resolution order (last wins):
+    1. Defaults from each Pydantic model.
+    2. agentforge.yaml on disk (if present).
+    3. Constructor kwargs to Agent (handled in `agentforge.agent`).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from agentforge_core.production.exceptions import ModuleError
+
+from agentforge.config.schema import AgentForgeConfig
+
+_INTERP_RE = re.compile(
+    r"""
+    \$\$                     # $$ -> literal $
+    | \$\{                   # ${
+        (?P<name>[A-Z_][A-Z0-9_]*)
+        (?:
+            :
+            (?:
+                \?(?P<error>[^}]*)
+                | (?P<default>[^}]*)
+            )
+        )?
+      \}
+    """,
+    re.VERBOSE,
+)
+
+
+def _interp(value: str) -> str:
+    """Interpolate env-var references inside a string."""
+
+    def repl(match: re.Match[str]) -> str:
+        if match.group(0) == "$$":
+            return "$"
+        name = match.group("name")
+        error = match.group("error")
+        default = match.group("default")
+        env_value = os.environ.get(name)
+        if env_value is not None:
+            return env_value
+        if error is not None:
+            raise ModuleError(f"Required env var {name} not set: {error}")
+        if default is not None:
+            return default
+        raise ModuleError(f"Required env var {name} not set (no default provided).")
+
+    return _INTERP_RE.sub(repl, value)
+
+
+def _walk(value: Any) -> Any:
+    """Recursively interpolate strings inside a config tree."""
+    if isinstance(value, str):
+        return _interp(value)
+    if isinstance(value, dict):
+        return {k: _walk(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_walk(v) for v in value]
+    return value
+
+
+def load_config(path: Path | str | None = None) -> AgentForgeConfig:
+    """Load and validate `agentforge.yaml`.
+
+    Args:
+        path: Path to the YAML file. If None, looks for
+            `./agentforge.yaml` in the current working directory; if
+            absent, returns the default config.
+
+    Returns:
+        Validated `AgentForgeConfig`.
+
+    Raises:
+        ModuleError: env-var interpolation or YAML parse error.
+        ValidationError: schema validation failed.
+    """
+    if path is None:
+        candidate = Path.cwd() / "agentforge.yaml"
+        if not candidate.exists():
+            return AgentForgeConfig()
+        path = candidate
+    path = Path(path)
+    with path.open() as f:
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise ModuleError(
+            f"agentforge.yaml at {path} must be a mapping at the top level; "
+            f"got {type(raw).__name__}."
+        )
+    interpolated = _walk(raw)
+    return AgentForgeConfig.model_validate(interpolated)

--- a/packages/agentforge/src/agentforge/config/schema.py
+++ b/packages/agentforge/src/agentforge/config/schema.py
@@ -1,0 +1,41 @@
+"""Pydantic root models for `agentforge.yaml` (feat-001 partial schema)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LoggingConfig(BaseModel):
+    """`logging:` section of agentforge.yaml."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    level: str = "INFO"
+    run_id_filter: bool = True
+    format: str = "text"  # "text" | "json"
+
+
+class AgentConfig(BaseModel):
+    """`agent:` section of agentforge.yaml — feat-001 surface only."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str | None = None
+    model: str | None = None
+    strategy: str | None = None
+    system_prompt: str | None = None
+    budget_usd: float = Field(default=1.0, ge=0.0)
+    max_iterations: int = Field(default=25, ge=1)
+
+
+class AgentForgeConfig(BaseModel):
+    """Root model — feat-001 surface only.
+
+    feat-012 will widen this with `modules`, `providers`, `output`, etc.
+    Subsequent features add sections additively (semver-minor bumps).
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    agent: AgentConfig = Field(default_factory=AgentConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)

--- a/packages/agentforge/src/agentforge/memory/__init__.py
+++ b/packages/agentforge/src/agentforge/memory/__init__.py
@@ -1,0 +1,14 @@
+"""Default in-process memory implementations.
+
+`InMemoryStore` ships with `agentforge` so a fresh `Agent(...)` has
+durable-shaped state out of the box without external infra. It is
+the safe default; production deployments swap to a real driver
+(`agentforge-memory-sqlite`, `-postgres`, etc.) via `agentforge.yaml`
+once feat-005 lands.
+"""
+
+from __future__ import annotations
+
+from agentforge.memory.in_memory import InMemoryStore
+
+__all__ = ["InMemoryStore"]

--- a/packages/agentforge/src/agentforge/memory/in_memory.py
+++ b/packages/agentforge/src/agentforge/memory/in_memory.py
@@ -1,0 +1,102 @@
+"""`InMemoryStore` — process-local `MemoryStore` implementation.
+
+Used as the default when no persistence module is configured. Loses
+data on process exit (by design — for tests, demos, ephemeral runs).
+For durable storage swap to a feat-005 driver via `agentforge.yaml`.
+
+Implementation notes:
+
+  - Storage is an `OrderedDict[str, Claim]` keyed by claim id, so
+    insertion order is preserved (sortable ULID ids already provide
+    monotonic ordering, but the dict guarantees it after deletes /
+    supersedes).
+  - All operations are ``async def`` to match the `MemoryStore`
+    contract; they don't actually do I/O so they complete on the
+    current event-loop tick.
+  - Thread safety is NOT a goal — this is for in-process single-loop
+    use. Multi-process / multi-worker deployments use feat-005 drivers.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import AsyncIterator
+
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.values.claim import Claim
+
+
+class InMemoryStore(MemoryStore):
+    """Process-local `MemoryStore` backed by an in-memory ``OrderedDict``."""
+
+    def __init__(self) -> None:
+        self._items: OrderedDict[str, Claim] = OrderedDict()
+
+    async def put(self, claim: Claim) -> str:
+        self._items[claim.id] = claim
+        return claim.id
+
+    async def get(self, claim_id: str) -> Claim | None:
+        return self._items.get(claim_id)
+
+    async def query(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+        limit: int = 100,
+    ) -> list[Claim]:
+        results: list[Claim] = []
+        for claim in self._items.values():
+            if project is not None and claim.project != project:
+                continue
+            if agent is not None and claim.agent != agent:
+                continue
+            if category is not None and claim.category != category:
+                continue
+            if run_id is not None and claim.run_id != run_id:
+                continue
+            results.append(claim)
+            if len(results) >= limit:
+                break
+        return results
+
+    async def supersede(self, old_id: str, new_claim: Claim) -> str:
+        if old_id not in self._items:
+            raise ModuleError(f"Cannot supersede unknown claim id: {old_id!r}")
+        if new_claim.supersedes is None:
+            new_claim = new_claim.model_copy(update={"supersedes": old_id})
+        elif new_claim.supersedes != old_id:
+            raise ModuleError(
+                f"new_claim.supersedes={new_claim.supersedes!r} does not match old_id={old_id!r}"
+            )
+        self._items[new_claim.id] = new_claim
+        return new_claim.id
+
+    def stream(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+    ) -> AsyncIterator[Claim]:
+        async def _agen() -> AsyncIterator[Claim]:
+            for claim in list(self._items.values()):
+                if project is not None and claim.project != project:
+                    continue
+                if agent is not None and claim.agent != agent:
+                    continue
+                if category is not None and claim.category != category:
+                    continue
+                if run_id is not None and claim.run_id != run_id:
+                    continue
+                yield claim
+
+        return _agen()
+
+    async def close(self) -> None:
+        self._items.clear()

--- a/packages/agentforge/tests/unit/test_agent.py
+++ b/packages/agentforge/tests/unit/test_agent.py
@@ -1,0 +1,146 @@
+"""Unit tests for the `Agent` orchestrator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentforge import Agent, InMemoryStore
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.values.state import AgentState, RunResult, Step
+
+
+class _NoOpStrategy(ReasoningStrategy):
+    """Test-only strategy: emits one 'observe' step and returns."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        state.steps.append(Step(iteration=0, kind="observe", content="hello world"))
+        return state
+
+
+# ---- Construction ----
+
+
+def test_agent_without_strategy_raises_at_construction() -> None:
+    with pytest.raises(ModuleError, match="No reasoning strategy"):
+        Agent()
+
+
+def test_agent_accepts_strategy_instance() -> None:
+    agent = Agent(strategy=_NoOpStrategy())
+    assert isinstance(agent.memory, InMemoryStore)
+
+
+def test_agent_uses_provided_memory() -> None:
+    custom = InMemoryStore()
+    agent = Agent(strategy=_NoOpStrategy(), memory=custom)
+    assert agent.memory is custom
+
+
+def test_agent_default_budget_is_one_dollar() -> None:
+    agent = Agent(strategy=_NoOpStrategy())
+    assert agent.budget.usd == pytest.approx(1.0)
+
+
+def test_agent_kwarg_budget_overrides_default() -> None:
+    agent = Agent(strategy=_NoOpStrategy(), budget_usd=5.0)
+    assert agent.budget.usd == pytest.approx(5.0)
+
+
+def test_agent_kwarg_max_iterations_overrides_default() -> None:
+    agent = Agent(strategy=_NoOpStrategy(), max_iterations=50)
+    assert agent.budget.max_iterations == 50
+
+
+def test_agent_string_model_without_provider_registered_raises() -> None:
+    with pytest.raises(ModuleError, match="No LLM provider registered"):
+        Agent(model="anthropic:claude-sonnet-4.7", strategy=_NoOpStrategy())
+
+
+def test_agent_invalid_model_string_raises() -> None:
+    with pytest.raises(ModuleError, match="Invalid model string"):
+        Agent(model="just-a-name", strategy=_NoOpStrategy())
+
+
+def test_agent_loads_config_from_explicit_path(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  budget_usd: 7.5\n")
+    agent = Agent(strategy=_NoOpStrategy(), config_path=yaml_path)
+    assert agent.budget.usd == pytest.approx(7.5)
+
+
+def test_kwarg_overrides_config_file(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  budget_usd: 7.5\n")
+    agent = Agent(strategy=_NoOpStrategy(), config_path=yaml_path, budget_usd=10.0)
+    assert agent.budget.usd == pytest.approx(10.0)
+
+
+# ---- Lifecycle ----
+
+
+@pytest.mark.asyncio
+async def test_run_produces_run_result_with_run_id() -> None:
+    agent = Agent(strategy=_NoOpStrategy(), install_log_filter=False)
+    result = await agent.run("hi")
+    assert isinstance(result, RunResult)
+    # ULID = 26 chars
+    assert len(result.run_id) == 26
+    assert len(result.steps) == 1
+    assert result.steps[0].kind == "observe"
+
+
+@pytest.mark.asyncio
+async def test_run_extracts_output_from_last_step() -> None:
+    agent = Agent(strategy=_NoOpStrategy(), install_log_filter=False)
+    result = await agent.run("hi")
+    assert result.output == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes() -> None:
+    async with Agent(strategy=_NoOpStrategy(), install_log_filter=False) as agent:
+        await agent.run("hi")
+    # After exit, agent is closed.
+    with pytest.raises(ModuleError, match="closed"):
+        await agent.run("again")
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    agent = Agent(strategy=_NoOpStrategy(), install_log_filter=False)
+    await agent.close()
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_on_finish_hook_fires() -> None:
+    seen: list[RunResult] = []
+
+    def hook(result: RunResult) -> None:
+        seen.append(result)
+
+    agent = Agent(
+        strategy=_NoOpStrategy(),
+        on_finish=hook,
+        install_log_filter=False,
+    )
+    result = await agent.run("hi")
+    assert seen == [result]
+
+
+@pytest.mark.asyncio
+async def test_on_finish_async_hook_awaited() -> None:
+    seen: list[RunResult] = []
+
+    async def hook(result: RunResult) -> None:
+        seen.append(result)
+
+    agent = Agent(
+        strategy=_NoOpStrategy(),
+        on_finish=hook,
+        install_log_filter=False,
+    )
+    result = await agent.run("hi")
+    assert seen == [result]

--- a/packages/agentforge/tests/unit/test_config.py
+++ b/packages/agentforge/tests/unit/test_config.py
@@ -1,0 +1,95 @@
+"""Unit tests for the YAML loader + env-var interpolation + schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentforge.config import AgentForgeConfig, load_config
+from agentforge_core.production.exceptions import ModuleError
+from pydantic import ValidationError
+
+
+def test_default_config_when_no_file_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config()
+    assert isinstance(cfg, AgentForgeConfig)
+    assert cfg.agent.budget_usd == 1.0
+    assert cfg.agent.max_iterations == 25
+    assert cfg.logging.run_id_filter is True
+
+
+def test_loads_explicit_path(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text(
+        "agent:\n  model: anthropic:claude-sonnet-4.7\n  budget_usd: 5.0\n  max_iterations: 50\n"
+    )
+    cfg = load_config(yaml_path)
+    assert cfg.agent.model == "anthropic:claude-sonnet-4.7"
+    assert cfg.agent.budget_usd == pytest.approx(5.0)
+    assert cfg.agent.max_iterations == 50
+
+
+def test_env_var_interpolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_MODEL", "anthropic:claude-haiku-4-5")
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  model: ${MY_MODEL}\n")
+    cfg = load_config(yaml_path)
+    assert cfg.agent.model == "anthropic:claude-haiku-4-5"
+
+
+def test_env_var_default_used_when_unset(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  model: ${UNSET_VAR:fallback}\n")
+    cfg = load_config(yaml_path)
+    assert cfg.agent.model == "fallback"
+
+
+def test_env_var_required_with_error_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("REQUIRED_KEY", raising=False)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  model: ${REQUIRED_KEY:?Set REQUIRED_KEY}\n")
+    with pytest.raises(ModuleError, match="Required env var REQUIRED_KEY"):
+        load_config(yaml_path)
+
+
+def test_env_var_required_no_default_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("UNSET_REQUIRED", raising=False)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  model: ${UNSET_REQUIRED}\n")
+    with pytest.raises(ModuleError, match="not set"):
+        load_config(yaml_path)
+
+
+def test_double_dollar_escape(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  system_prompt: 'Cost is $$5'\n")
+    cfg = load_config(yaml_path)
+    assert cfg.agent.system_prompt == "Cost is $5"
+
+
+def test_unknown_top_level_key_rejected(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("unknown_section:\n  foo: bar\n")
+    with pytest.raises(ValidationError):
+        load_config(yaml_path)
+
+
+def test_invalid_yaml_top_level_raises(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("- just a list\n- not a mapping\n")
+    with pytest.raises(ModuleError, match="must be a mapping"):
+        load_config(yaml_path)
+
+
+def test_negative_budget_rejected(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("agent:\n  budget_usd: -1.0\n")
+    with pytest.raises(ValidationError):
+        load_config(yaml_path)

--- a/packages/agentforge/tests/unit/test_in_memory_store.py
+++ b/packages/agentforge/tests/unit/test_in_memory_store.py
@@ -1,0 +1,162 @@
+"""Unit tests for `InMemoryStore` — `MemoryStore` reference implementation."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge.memory import InMemoryStore
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.values.claim import Claim
+
+
+def _claim(
+    *,
+    project: str = "p",
+    agent: str = "a",
+    run_id: str = "r",
+    category: str = "finding",
+    payload: dict[str, object] | None = None,
+) -> Claim:
+    return Claim(
+        run_id=run_id,
+        project=project,
+        agent=agent,
+        category=category,
+        payload=payload if payload is not None else {"v": 1},
+    )
+
+
+@pytest.fixture
+async def store() -> InMemoryStore:
+    return InMemoryStore()
+
+
+@pytest.mark.asyncio
+async def test_put_returns_id(store: InMemoryStore) -> None:
+    c = _claim()
+    cid = await store.put(c)
+    assert cid == c.id
+
+
+@pytest.mark.asyncio
+async def test_get_returns_claim(store: InMemoryStore) -> None:
+    c = _claim()
+    await store.put(c)
+    fetched = await store.get(c.id)
+    assert fetched is c
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_for_unknown_id(store: InMemoryStore) -> None:
+    assert await store.get("01HX-NONEXISTENT") is None
+
+
+@pytest.mark.asyncio
+async def test_query_no_filters_returns_all(store: InMemoryStore) -> None:
+    a = _claim()
+    b = _claim()
+    await store.put(a)
+    await store.put(b)
+    results = await store.query()
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_project(store: InMemoryStore) -> None:
+    await store.put(_claim(project="p1"))
+    await store.put(_claim(project="p2"))
+    results = await store.query(project="p1")
+    assert len(results) == 1
+    assert results[0].project == "p1"
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_agent(store: InMemoryStore) -> None:
+    await store.put(_claim(agent="a1"))
+    await store.put(_claim(agent="a2"))
+    assert all(c.agent == "a1" for c in await store.query(agent="a1"))
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_category(store: InMemoryStore) -> None:
+    await store.put(_claim(category="finding"))
+    await store.put(_claim(category="decision"))
+    assert all(c.category == "finding" for c in await store.query(category="finding"))
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_run_id(store: InMemoryStore) -> None:
+    await store.put(_claim(run_id="r1"))
+    await store.put(_claim(run_id="r2"))
+    assert all(c.run_id == "r1" for c in await store.query(run_id="r1"))
+
+
+@pytest.mark.asyncio
+async def test_query_combines_filters(store: InMemoryStore) -> None:
+    await store.put(_claim(project="p", agent="a"))
+    await store.put(_claim(project="p", agent="other"))
+    await store.put(_claim(project="other", agent="a"))
+    results = await store.query(project="p", agent="a")
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_respects_limit(store: InMemoryStore) -> None:
+    for _ in range(5):
+        await store.put(_claim())
+    assert len(await store.query(limit=3)) == 3
+
+
+@pytest.mark.asyncio
+async def test_supersede_links_old_to_new(store: InMemoryStore) -> None:
+    old = _claim()
+    await store.put(old)
+    new = _claim(payload={"v": 2})
+    await store.supersede(old.id, new)
+    refetched = await store.get(new.id)
+    assert refetched is not None
+    assert refetched.supersedes == old.id
+
+
+@pytest.mark.asyncio
+async def test_supersede_unknown_id_raises(store: InMemoryStore) -> None:
+    new = _claim()
+    with pytest.raises(ModuleError, match="Cannot supersede unknown"):
+        await store.supersede("01HX-MISSING", new)
+
+
+@pytest.mark.asyncio
+async def test_supersede_with_mismatched_supersedes_raises(
+    store: InMemoryStore,
+) -> None:
+    old = _claim()
+    await store.put(old)
+    new = Claim(
+        run_id="r",
+        project="p",
+        agent="a",
+        category="finding",
+        payload={"v": 2},
+        supersedes="01HX-OTHER",
+    )
+    with pytest.raises(ModuleError, match="does not match"):
+        await store.supersede(old.id, new)
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_filtered_claims(store: InMemoryStore) -> None:
+    await store.put(_claim(project="p1"))
+    await store.put(_claim(project="p2"))
+    collected = [c async for c in store.stream(project="p1")]
+    assert len(collected) == 1
+    assert collected[0].project == "p1"
+
+
+@pytest.mark.asyncio
+async def test_close_clears_state(store: InMemoryStore) -> None:
+    await store.put(_claim())
+    await store.close()
+    assert await store.query() == []
+
+
+def test_default_capabilities_empty() -> None:
+    assert InMemoryStore().capabilities() == set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,25 @@ requires-python = ">=3.13"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 
-# The workspace root itself is not installed; the [project] block exists
-# only to satisfy uv. Member packages are the installable units.
+# The workspace root depends on its members so `uv sync` at the root
+# installs every member (and their dependencies) into the shared venv.
+dependencies = [
+    "agentforge-core",
+    "agentforge",
+]
 
 [tool.uv.workspace]
 members = ["packages/*"]
 
+[tool.uv.sources]
+agentforge-core = { workspace = true }
+agentforge = { workspace = true }
+
 [tool.uv]
-dev-dependencies = [
+package = false   # the root is a virtual workspace; not itself published
+
+[dependency-groups]
+dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ package = false   # the root is a virtual workspace; not itself published
 
 [dependency-groups]
 dev = [
+    "types-PyYAML>=6.0",
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",

--- a/tests/conformance/test_memory_in_memory.py
+++ b/tests/conformance/test_memory_in_memory.py
@@ -1,0 +1,21 @@
+"""InMemoryStore conformance — runs the shared `MemoryStore` suite.
+
+The same suite is run by every memory driver that ships in feat-005
+(`agentforge-memory-sqlite`, `-postgres`, `-surrealdb`, `-neo4j`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge.memory import InMemoryStore
+from agentforge_core.testing import run_memory_conformance
+
+
+@pytest.mark.conformance
+@pytest.mark.asyncio
+async def test_in_memory_store_passes_conformance() -> None:
+    store = InMemoryStore()
+    try:
+        await run_memory_conformance(store)
+    finally:
+        await store.close()

--- a/tests/integration/test_agent_full_lifecycle.py
+++ b/tests/integration/test_agent_full_lifecycle.py
@@ -1,0 +1,179 @@
+"""Integration test — full Agent lifecycle with a fake LLM + tool + memory.
+
+Exercises the per-feature §4.1 user-facing surface in feat-001 against
+real wiring: a `ReasoningStrategy` that calls a fake `LLMClient`, runs
+a fake `Tool`, persists a `Claim` through `InMemoryStore`, and returns
+a `RunResult`. Validates run_id propagation end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge import Agent, InMemoryStore
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.production.run_context import current_run
+from agentforge_core.values.claim import Claim
+from agentforge_core.values.messages import LLMResponse, Message, TokenUsage, ToolSpec
+from agentforge_core.values.state import AgentState, Step
+from pydantic import BaseModel
+
+# ---- Fakes ----
+
+
+class _FakeLLM(LLMClient):
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        self.calls += 1
+        return LLMResponse(
+            content=f"answer for: {messages[-1].content}",
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+            cost_usd=0.001,
+            model="fake",
+            provider="fake",
+        )
+
+    async def close(self) -> None:
+        pass
+
+
+class _PingInput(BaseModel):
+    target: str
+
+
+class _PingTool(Tool):
+    name = "ping"
+    description = "Pings a target."
+    input_schema = _PingInput
+
+    async def run(self, target: str) -> dict[str, Any]:
+        return {"target": target, "ok": True}
+
+
+class _SimpleStrategy(ReasoningStrategy):
+    """One LLM call + one tool call + one memory write per run."""
+
+    def __init__(self, llm: LLMClient, tool: Tool, memory: InMemoryStore) -> None:
+        self._llm = llm
+        self._tool = tool
+        self._memory = memory
+
+    async def run(self, state: AgentState) -> AgentState:
+        # Verify run_id is bound and matches state
+        run_ctx = current_run()
+        assert run_ctx.run_id == state.run_id
+
+        # 1. Think
+        response = await self._llm.call(
+            "You are a careful assistant.",
+            [Message(role="user", content=state.task)],
+        )
+        state.steps.append(
+            Step(
+                iteration=0,
+                kind="think",
+                content=response.content,
+                tokens_in=response.usage.input_tokens,
+                tokens_out=response.usage.output_tokens,
+                cost_usd=response.cost_usd,
+            )
+        )
+
+        # 2. Act (tool call)
+        tool_result = await self._tool.run(target="example.com")
+        state.steps.append(Step(iteration=1, kind="act", content=tool_result))
+
+        # 3. Persist a claim
+        claim = Claim(
+            run_id=state.run_id,
+            project="integration-test",
+            agent="full-lifecycle",
+            category="finding",
+            payload={"answer": response.content, "tool_result": tool_result},
+        )
+        await self._memory.put(claim)
+
+        # 4. Final observe
+        state.steps.append(Step(iteration=2, kind="observe", content=response.content))
+        return state
+
+
+# ---- Test ----
+
+
+@pytest.mark.asyncio
+async def test_agent_full_lifecycle_with_fake_llm_tool_memory() -> None:
+    llm = _FakeLLM()
+    tool = _PingTool()
+    memory = InMemoryStore()
+    strategy = _SimpleStrategy(llm=llm, tool=tool, memory=memory)
+
+    async with Agent(
+        strategy=strategy,
+        memory=memory,
+        tools=[tool],
+        budget_usd=2.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("Ping example.com")
+
+        # 1. RunResult shape
+        assert result.output.startswith("answer for: Ping example.com")
+        assert len(result.run_id) == 26
+        assert result.duration_ms >= 0
+        assert result.tokens_in == 10
+        assert result.tokens_out == 5
+        assert result.finish_reason == "completed"
+        assert len(result.steps) == 3
+
+        # 2. Strategy actually ran
+        assert llm.calls == 1
+
+        # 3. Claim persisted with the same run_id (queried before close)
+        claims = await memory.query(run_id=result.run_id)
+        assert len(claims) == 1
+        assert claims[0].run_id == result.run_id
+        assert claims[0].project == "integration-test"
+
+
+@pytest.mark.asyncio
+async def test_run_id_propagates_to_tool_via_current_run() -> None:
+    """Tools must see the same run_id via current_run() that ends up on
+    RunResult."""
+    seen_ids: list[str] = []
+
+    class _RunIdCapturingTool(Tool):
+        name = "capture"
+        description = "Captures the current run id."
+        input_schema = _PingInput
+
+        async def run(self, target: str) -> dict[str, Any]:
+            seen_ids.append(current_run().run_id)
+            return {"ok": True}
+
+    class _SingleToolStrategy(ReasoningStrategy):
+        def __init__(self, tool: Tool) -> None:
+            self._tool = tool
+
+        async def run(self, state: AgentState) -> AgentState:
+            await self._tool.run(target="x")
+            state.steps.append(Step(iteration=0, kind="observe", content="done"))
+            return state
+
+    tool = _RunIdCapturingTool()
+    strategy = _SingleToolStrategy(tool=tool)
+    async with Agent(strategy=strategy, install_log_filter=False) as agent:
+        result = await agent.run("test")
+
+    assert seen_ids == [result.run_id]

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -86,6 +87,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.8.4" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -761,6 +763,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/6b/f9d82598121b2f0532238381aec27734c24a0ff548ac352b358c2857a176/types_pyyaml-6.0.12.20260508.tar.gz", hash = "sha256:5ae42149c3ebf7aaaf6c65ee49af590c80f0ba52e9e3f75a75c5564b33556fa6", size = 17776, upload-time = "2026-05-08T04:48:28.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/80/96690460fe7f4e4b4ab0ecd79a8609aec2ae63927ad97625f3c747ca6a1d/types_pyyaml-6.0.12.20260508-py3-none-any.whl", hash = "sha256:edc094ed3a918b0c6232f71a5b67fdf38e76e17517b7d87bfbb9fc27d442fb51", size = 20309, upload-time = "2026-05-08T04:48:27.822Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,800 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[manifest]
+members = [
+    "agentforge",
+    "agentforge-core",
+    "agentforge-workspace",
+]
+
+[[package]]
+name = "agentforge"
+version = "0.0.0"
+source = { editable = "packages/agentforge" }
+dependencies = [
+    { name = "agentforge-core" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "pydantic", specifier = ">=2.10" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "typer", specifier = ">=0.15" },
+]
+
+[[package]]
+name = "agentforge-core"
+version = "0.0.0"
+source = { editable = "packages/agentforge-core" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-ulid" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.10" },
+    { name = "python-ulid", specifier = ">=3.0" },
+]
+
+[[package]]
+name = "agentforge-workspace"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "agentforge" },
+    { name = "agentforge-core" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "hypothesis" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge", editable = "packages/agentforge" },
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.8" },
+    { name = "hypothesis", specifier = ">=6.115" },
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pre-commit", specifier = ">=4.0" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
+    { name = "ruff", specifier = ">=0.8.4" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/9d/912fefab0e30aee6a3af8a62bbea4a81b29afa4ba2c973d31170620a26de/ast_serialize-0.3.0.tar.gz", hash = "sha256:1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b", size = 60689, upload-time = "2026-04-30T23:24:48.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/57/a54d4de491d6cdd7a4e4b0952cc3ca9f60dcefa7b5fb48d6d492debe1649/ast_serialize-0.3.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3a867927df59f76a18dc1d874a0b2c079b42c58972dca637905576deb0912e14", size = 1182966, upload-time = "2026-04-30T23:23:57.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/a5db014bb0f91b209236b57c429389e31290c0093532b8436d577699b2fa/ast_serialize-0.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a6fb063bf040abf8321e7b8113a0554eda445ffc508aa51287f8808886a5ae22", size = 1171316, upload-time = "2026-04-30T23:23:59.63Z" },
+    { url = "https://files.pythonhosted.org/packages/15/59/fd55133e478c4326f60a11df02573bf7ccb2ac685810b50f1803d0f68053/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5075cd8482573d743586779e5f9b652a015e37d4e95132d7e5a9bc5c8f483d8f", size = 1232234, upload-time = "2026-04-30T23:24:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/79/0ca1d26357ecb4a697d74d00b73ef3137f24c140424125393a0de820eb09/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:41560b27794f4553b0f77811e9fb325b77db4a2b39018d437e09932275306e66", size = 1233437, upload-time = "2026-04-30T23:24:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/7078ec94dd6e124b8e028ac77016a4f13c83fa1c145790f2e68f3816998b/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b967c01ca74909c5d90e0fe4393401e2cc5da5ebd9a6262a19e45ffd3757dec8", size = 1440188, upload-time = "2026-04-30T23:24:04.717Z" },
+    { url = "https://files.pythonhosted.org/packages/21/16/cca7195ef55a012f8013c3442afa91d287a0a36dcf88b480b262475135b3/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:424ebb8f46cd993f7cec4009d119312d8433dd90e6b0df0499cd2c91bdcc5af9", size = 1254211, upload-time = "2026-04-30T23:24:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/f3d4dfae67dee6580534361a6343367d34217e7d25cff858bd1d8f03b8ed/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d14b1d566b56e2ee70b11fec1de7e0b94ec7cd83717ec7d189967841a361190e", size = 1255973, upload-time = "2026-04-30T23:24:07.772Z" },
+    { url = "https://files.pythonhosted.org/packages/14/41/55fbfe02c42f40fbe3e74eda167d977d555ff720ce1abfa08515236efd88/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7ba30b18735f047ec11103d1ab92f4789cf1fea1e0dc89b04a2f5a0632fd79de", size = 1298629, upload-time = "2026-04-30T23:24:09.4Z" },
+    { url = "https://files.pythonhosted.org/packages/28/36/7d2501cacc7989fb8504aa9da2a2022a174200a59d4e6639de4367a57fdd/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ea0754cb7b0f682ebb005ffb0d18f8d17993490d9c289863cd69cacc4ab8df", size = 1408435, upload-time = "2026-04-30T23:24:11.013Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/54e3b469c3fa0bf9cd532fa643d1d33b73303f8d70beac3e366b68dd64b7/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a0c5aa1073a5ba7b2abaa4b54abe8b8d75c4d1e2d54a2ff70b0ca6222fea5728", size = 1508174, upload-time = "2026-04-30T23:24:12.635Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/9b9621865b02c60539e26d9b114a312b4fa46aa703e33e79317174bfea21/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4e52650d834c1ea7791969a361de2c54c13b2fb4c519ec79445fa8b9021a147d", size = 1502354, upload-time = "2026-04-30T23:24:14.186Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/f138bc5c43b0c414fdd12eefe15677839323078b6e75301ad7f96cd26d45/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15bd6af3f136c61dae27805eb6b8f3269e85a545c4c27ffe9e530ead78d2b36d", size = 1450504, upload-time = "2026-04-30T23:24:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/97ef9e1c315601db74365955c8edd3292e3055500d6317602815dbdf08ae/ast_serialize-0.3.0-cp314-cp314t-win32.whl", hash = "sha256:d188bfe37b674b49708497683051d4b571366a668799c9b8e8a94513694969d9", size = 1058662, upload-time = "2026-04-30T23:24:17.535Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d6/e2c3483c31580fdb623f92ad38d2f856cde4b9205a3e6bd84760f3de7d82/ast_serialize-0.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5832c2fdf8f8a6cf682b4cfcf677f5eaf39b4ddbc490f5480cfccdd1e7ce8fa1", size = 1100349, upload-time = "2026-04-30T23:24:18.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/89/29abcb1fe18a429cda60c6e0bbd1d6e90499339842a2f548d7567542357e/ast_serialize-0.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:670f177188d128fb7f9f15b5ad0e1b553d22c34e3f584dcb83eb8077600437f0", size = 1072895, upload-time = "2026-04-30T23:24:20.706Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9", size = 1190024, upload-time = "2026-04-30T23:24:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/eb88584b2f0234e581762011208ca203252bf6c98e59b4769daa571f3576/ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc", size = 1178633, upload-time = "2026-04-30T23:24:24.35Z" },
+    { url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4", size = 1241351, upload-time = "2026-04-30T23:24:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/44/68fcf50478cf1093f2d423f034ae06453122c8b415d8e21a44668eca485d/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d21453734ad39367ede5d37efe4f59f830ce1c09f432fc72a90e368f77a4a3e7", size = 1239582, upload-time = "2026-04-30T23:24:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c1/a6c9fa284eceb5fc6f21347e968445a051d7ca2c4d34e6a04314646dbcee/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94", size = 1448853, upload-time = "2026-04-30T23:24:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5f/8ad3829a09e4e8c5328a53ce7d4711d660944e3e164c5f6abcc2c8f27167/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b6e23a98e57560a055f5c4b68700a0fd5ce483d2814c23140b3638c7f5d1e61", size = 1262204, upload-time = "2026-04-30T23:24:31.482Z" },
+    { url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0", size = 1266458, upload-time = "2026-04-30T23:24:33.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/58/b3a8be3777cd3744324fd5cec0d80d37cd96fc7cbb0fb010e03dff1e870f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4388a1796c228f1ce5c391426f7d21a0003ad3b47f677dbeded9bd1a85c7209f", size = 1308700, upload-time = "2026-04-30T23:24:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/13/03/f8312d6b57f5471a9dc7946f22b8798a1fc296d38c25766223aacadec42c/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a", size = 1416724, upload-time = "2026-04-30T23:24:36.562Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5d/13fc3789a7abac00559da2e2e9f386db4612aa1f84fc53d09bf714c37545/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b", size = 1515441, upload-time = "2026-04-30T23:24:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/7ab43fc7a23b1f970281093228f5f79bed6edeed7a3e672bde6d7a832a58/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cc14bf402bdc0978594ecce783793de2c7470cd4f5cd7eb286ca97ed8ff7cba9", size = 1510522, upload-time = "2026-04-30T23:24:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ec/d75fc2b788d319f1fad77c14156896f31afdfc68af85b505e5bdebcb9592/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57", size = 1460917, upload-time = "2026-04-30T23:24:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/95/74/f99c81193a2725911e1911ae567ed27c2f2419332c7f3537366f9d238cac/ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2", size = 1067804, upload-time = "2026-04-30T23:24:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/76af00c47daa151e89f98ae21fbbcb2840aaa9f5766579c4da76a3c57188/ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549", size = 1105561, upload-time = "2026-04-30T23:24:44.578Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/46/d3ec57ad500f598d1554bd14ce4df615960549ab2844961bc4e1f5fbd174/ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a", size = 1077165, upload-time = "2026-04-30T23:24:46.377Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz", hash = "sha256:31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4", size = 466444, upload-time = "2026-04-27T20:18:37.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl", hash = "sha256:e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8", size = 532145, upload-time = "2026-04-27T20:18:35.043Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/cb/c1945e506893b5b8577fb45a60c80e3ffe4a82092a04a6f29b0b951d9a24/librt-0.10.0.tar.gz", hash = "sha256:1aba1e8aa4e3307a7be68a74149545fde7451964dc0235a8bec5704a17bdda42", size = 191799, upload-time = "2026-05-05T16:31:23.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/29/681a75c82f4cc90d29e4b257a3299b79fe13fe927a04c57b8109d70b6957/librt-0.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f0ede79d682e73f91c1b599a76d78b7464b9b5d213754cedb13372d9df36e596", size = 77299, upload-time = "2026-05-05T16:30:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/62/24/0c7ca445a55d04be79cac19819437fd094782347fa116f6681844fa6143e/librt-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0ba0b131fdb336c8b9c948e397f4a7e649d0f783b529f07b647bf4961df392e", size = 79930, upload-time = "2026-05-05T16:30:01.555Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1f/1e2b8f6443ef9e9a81e89486ca70e22f3684f93db003ce6eaefc3d0839b9/librt-0.10.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2728117da2afb96fb957768725ee43dc9a2d73b031e02da424b818a3cdd3a275", size = 246195, upload-time = "2026-05-05T16:30:03.261Z" },
+    { url = "https://files.pythonhosted.org/packages/74/61/9dc9e03de0439ad84c1c240aac8b747f12c90cb797ea6042f7bdb8d3410f/librt-0.10.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:723ba80594c49cdf0584196fc430752262605dc9449902fc9bd3d9b79976cb77", size = 234951, upload-time = "2026-05-05T16:30:04.881Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f4/635223117d7590875bca441275065a3bf491203ad4208bd1cc3ffd90c5a1/librt-0.10.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7292edaaca294a61a978c53a3c7d6130d099b0dfbc8f0a65916cdc6b891b9852", size = 262768, upload-time = "2026-05-05T16:30:06.638Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/66/b04152d0cd8b6ca2b428a8bd3230343230c35ed304a932f35b5375f2f828/librt-0.10.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89fe9d539f2c10a1666633eeeac507ce95dd06d9ecc58de3c6390dba156a3d3a", size = 255075, upload-time = "2026-05-05T16:30:08.216Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1e/25bac4c7f2ca36f0e612cade186970683cf79153d96beccc3a11a9e19b97/librt-0.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4efa7b9587503fa5b67f40593302b9c8836d211d222ff9f7cafe67be5f8f0b10", size = 268559, upload-time = "2026-05-05T16:30:10.1Z" },
+    { url = "https://files.pythonhosted.org/packages/18/54/4601faab35b6632a13200faa146ca62bfd111ffbe2568be430d65c89493a/librt-0.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:22dc982ef59df0136df36092ccbdbb570ced8aafb33e49585739b2f1de1c13b6", size = 261753, upload-time = "2026-05-05T16:30:11.912Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cf/39f4023509e94fade8b074666fa3292db9cb6b34ea5dcbe7af53df9fca1d/librt-0.10.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6f2e5f3606253a84cea719c94a3bb1c54487b5d617d0254d46e0920d8a06be3f", size = 264055, upload-time = "2026-05-05T16:30:13.465Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/00/40247209fc46a8e308a91412d5206aedf8efb667ee89eb625820106a5c2f/librt-0.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:40884bfaa1e29f6b6a9be255007d8f359bfc9e61d68bdef8ed3158bfcbc95df9", size = 286190, upload-time = "2026-05-05T16:30:15.073Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/6e/5566beb94431a985abe1787af5ef86e087750172ff9d0bbf20f93e88132d/librt-0.10.0-cp313-cp313-win32.whl", hash = "sha256:3cd34cd8254eba756660bff6c2da91278248184301054fe3e4feb073bdd49b14", size = 62949, upload-time = "2026-05-05T16:30:16.503Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c2/3ea3301d6c8dff51d39dbe8ed75db3dc92896947d4afb5eeadf821c1e67f/librt-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:7baac5313e2d8dce1386f97777a8d03ab28f5fe1e780b3b9ac2ee7544551fedc", size = 71152, upload-time = "2026-05-05T16:30:17.766Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/de/5d49cb92cadcbc77d3abc27b93fd6030ed8437487dde2eae38cab5e6704d/librt-0.10.0-cp313-cp313-win_arm64.whl", hash = "sha256:afc5b4406c8e2515698d922a5c7823a009312835ea58196671fff40e35cb8166", size = 61336, upload-time = "2026-05-05T16:30:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/64/7165e08108cc185a13a9c069f0685e6ef92e70e07fddf7edf5e7348c6316/librt-0.10.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f09588a30e6a22ec624090d72a3ab1a6d4d5485c3ed739603e76aa3c16efa688", size = 76794, upload-time = "2026-05-05T16:30:20.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ef/bf8613febf651b90c5222ee79dea5ae58d4cc2b544df69d3033424448934/librt-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:131ade118d12bd7a0adc4e655474a553f1b76cf78385868885944d21d51e45e0", size = 79662, upload-time = "2026-05-05T16:30:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/67/9eddd165c1d8397bdf99b38bf12b5a55b3def5035b49eedb49f2775d1430/librt-0.10.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8b9ab28e40d011c373a189eae900c916e66d6fbecf7983e9e4883089ee085ef", size = 242390, upload-time = "2026-05-05T16:30:23.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d1/d95da80334501866cd37004ab5d7483220d05862fab4b5405394f0264f0d/librt-0.10.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:67c39bb30da73bae1f293d1ed8bc2f8f6642649dd0928d3600aeff3041ac23d6", size = 232603, upload-time = "2026-05-05T16:30:25.198Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fa/e6d64d28718bc1be4e1736fcb037ca1c4dfca927e7167df75a7d5215665e/librt-0.10.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c3273c6b774614f093c8927c2bf1b077d0fefde988fe98f46a333734e5597ab", size = 259187, upload-time = "2026-05-05T16:30:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3f/3fdb77e7f937dad59cfd76b720be7e7643400ec76b2da35befab8d66ba30/librt-0.10.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9dd7c1b86a4baa583ab5db977484b93a2c474e69e96ef3e9538387ea54229cb9", size = 251846, upload-time = "2026-05-05T16:30:28.56Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ca/f4d49133dd86a6f55d79eca30bf412fa722f511a9abe67f62f57aa64e66a/librt-0.10.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a77385c5a202e831149f7ad03be9e67cf80e957e52c614e83dcb822c95222eb8", size = 264936, upload-time = "2026-05-05T16:30:30.491Z" },
+    { url = "https://files.pythonhosted.org/packages/de/66/a8df2fbadc1f6c1827a096d11c40175bd526133480bd3bc88ec64a03d257/librt-0.10.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c6a5eafa74b5655bad59886138ed68426f098a6beb8cb95a71f2cc3cd8bb33fe", size = 258699, upload-time = "2026-05-05T16:30:32.002Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/1e3c83613fe05451bb969e27b68a573d177f08d5f63533cc29fec0989658/librt-0.10.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:1fc93d0439204c50ab4d1512611ce2c206f1b369b419f69c7c27c761561e3291", size = 259825, upload-time = "2026-05-05T16:30:35.077Z" },
+    { url = "https://files.pythonhosted.org/packages/09/24/5e2f926ee9d3ef348d9339526d7062abb5c44d8419e3179528c01d78c102/librt-0.10.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:79e713c178bc7a744adfbee6b4619a288eecc0c914da2a9313a20255abe2f0cf", size = 282548, upload-time = "2026-05-05T16:30:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7d/3e89ed6ad0162561fa8bef9df3195e24263104c955713cd0237d3711fad2/librt-0.10.0-cp314-cp314-win32.whl", hash = "sha256:2eba9d955a68c41d9f326be3da42f163ec3518b7ab20f1c826224e7bed71e0bf", size = 58970, upload-time = "2026-05-05T16:30:38.183Z" },
+    { url = "https://files.pythonhosted.org/packages/76/25/579e731c94a7086a268bfa3e7a4945cd47836bebd3cbf3faeafd2e7eaef9/librt-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbfaf7f5145e9917f5d18bffa298eff6a19d74e7b8b11dabdca95785befe8dbf", size = 67260, upload-time = "2026-05-05T16:30:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f8/235822b7ae0b2334f12ee18bcf2476d07924077a5efeea57dbe927704be2/librt-0.10.0-cp314-cp314-win_arm64.whl", hash = "sha256:8d6d385d1969849a6b1397114df22714b6ded917bada98668e3e974dc663477e", size = 57156, upload-time = "2026-05-05T16:30:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e3/9b919cbf1e8eb770bf91bb7df28125e0f1daf4587169afefd95402636e9a/librt-0.10.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:6c3a82d3bd32631ef5c79922dfc028520c9ad840255979ab4d908271818039ee", size = 79150, upload-time = "2026-05-05T16:30:42.761Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/72a944aa3bc3498169a168087eff58ca48b58bf1b704e59d091fd30739f3/librt-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d64cc66005dc324c9bb1fa3fc2841f529002f6eb15966d55e46d430f56955a6a", size = 82304, upload-time = "2026-05-05T16:30:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e3/fcc290a33e295019759472dfa794d204e43504b276ac65eab7fd9da20ea3/librt-0.10.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bb562cd28c88cd2c6a9a6c78f99dc39348d6b16c94adc25de0e574acf1176e9", size = 272556, upload-time = "2026-05-05T16:30:45.497Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/54/546975e4c997573885e7f040a05012f8838e06fb12b0c3c1fbb76254e9d7/librt-0.10.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:b809aa2854d019c28773b03605df22adc675ee4f3f4402d673581313e8906119", size = 256941, upload-time = "2026-05-05T16:30:47.059Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/f1d03401571b331653acddbd4e8cd955c06d945241dd08b25192fac0d04b/librt-0.10.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc15acabdd519bd4176fdadc2119e5e3093485d86f89138daf47e5b4cedb983a", size = 285855, upload-time = "2026-05-05T16:30:48.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/62cf80ff046c339faf56718b3a940244d4beb70f1c6407289b5830ec11e9/librt-0.10.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b1b2d835307d08ddadd94568e2369648ec9173bd3eea6d7f52a1abe717c81f98", size = 275321, upload-time = "2026-05-05T16:30:50.63Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ea/da5918d4070362e9a4d2ee9cd34f9dc84902daad8fd4275f8504a727ff4e/librt-0.10.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d261c6a2f93335a5167887fb0223e8b98ffce20ee3fde242e8e58a37ece6d0e5", size = 293993, upload-time = "2026-05-05T16:30:52.577Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8d/68b6086bed1fcdc314c640ea04e31e52d18052e08059fa595409d66a51a9/librt-0.10.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e2ffd44963f8e7f68995504d90f9881d64e94dc1d8e310039b9526108fc0c0f7", size = 284254, upload-time = "2026-05-05T16:30:55.086Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c8/b810f1d84ec34a5a7ed93d7b510ab04164d75fbdf23088d5c3fbe6b08357/librt-0.10.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f285f6455ed495791c4d8630e5af732960adea93cac4c893d15619f2eae53e8", size = 284925, upload-time = "2026-05-05T16:30:56.728Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/3c82d4158c5a2c62528b8fccce65a8c9ad700e480e86f9389387435089a5/librt-0.10.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6034ff52e663d34c7b82ef2aa2f94ad7c1d939e2368e63b06844bc4d127d2e1", size = 307830, upload-time = "2026-05-05T16:30:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3a/9c635ac3e8a00383ff689161d3eac8a30b3b2ddc711b40471e6b8983ea29/librt-0.10.0-cp314-cp314t-win32.whl", hash = "sha256:657860fd877fba6a241ea088ef99f63ca819945d3c715265da670bad56c37ebe", size = 60147, upload-time = "2026-05-05T16:31:00.293Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e8/6f65f3e565d4ac212cddddd552eacc8035ffdf941ca0ad6fe945a211d41f/librt-0.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:56ded2d66010203a0cb5af063b609e3f079531a0e5e576d618dece859fd2e1af", size = 68649, upload-time = "2026-05-05T16:31:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/51/78/a0705a67cacd81e5fa01a5035b3adbdfbb43a7b8d4bd27e2b282ae61baf2/librt-0.10.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1ee63f30abf18ed4830fdbaf87b2b6f4bba1e198d46085c314edde4045e56715", size = 58247, upload-time = "2026-05-05T16:31:03.191Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/dc/7e6d49f04fca40b9dd5c752a51a432ffe67fb45200702bc9eee0cb4bbb26/mypy-2.0.0.tar.gz", hash = "sha256:1a9e3900ac5c40f1fe813506c7739da6e6f0eab2729067ebd94bfb0bbba53532", size = 3869036, upload-time = "2026-05-06T19:26:43.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/c6/996a1e535e5d0d597c3b1460fc962733091f885f312e749350eb2ac10965/mypy-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9ef5f581b61240d1cc629b12f8df6565ed6ffac0d82ed745eef7833222ab50b9", size = 14737259, upload-time = "2026-05-06T19:20:23.081Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c5/0f9460e26b77f434bd53f47d1ce32a3cd4580c92a5331fa5dfc059f9421a/mypy-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:20e3470a165dbc249bdfbe8d1c5172727ef22688cffc279f8c3aa264ab9d4d9a", size = 13538377, upload-time = "2026-05-06T19:21:08.804Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/3e/8ea2f8dd1e5c9c279fb3c28193bdb850adf4d3d8172880abad829eced609/mypy-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:224ba142eee8b4d65d4db657cb1fc22abec30b135ded6ab297302ba1f62e505d", size = 13914264, upload-time = "2026-05-06T19:24:12.875Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/78bd3b8520f676acee9dab48ea71473e68f6d5cf14b59fbd800bea50a92b/mypy-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e879ad8a03908ff74d15e8a9b42bf049918e6798d52c011011f1873d0b5877e", size = 14926761, upload-time = "2026-05-06T19:20:12.846Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ef/b52fa340522da3d22e669117c3b83155c2660f7cdc035856958fbfffb224/mypy-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:65c5c15bcbd18d6fe927cc55c459597a3517d69cc3123f067be3b020010e115e", size = 15157014, upload-time = "2026-05-06T19:25:49.78Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/dde7614250c6d017936c7aa3bb63b9b52c7cfd298d3f1be9be45f307870b/mypy-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:d1a068acd7c9fb77e9f8923f1556f2f49d6d7895821121b8d97fa5642b9c52f5", size = 11067049, upload-time = "2026-05-06T19:21:16.116Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ec/1d6af4830a94a285442db19caa02f160cc1a255e4f324eec5458e6c2bafb/mypy-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:ef9d96da1ddffbc21f27d3939319b6846d12393baa17c4d2f3e81e040e73ce2c", size = 9967903, upload-time = "2026-05-06T19:22:15.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2c/6fefe954207860aed6eeb91776795e64a257d3ce0360862288984ce121f5/mypy-2.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c918c64e8ce36557851b0347f84eb12f1965d3a06813c36df253eb0c0afd1d82", size = 14729633, upload-time = "2026-05-06T19:24:53.383Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/d336f5b820af189eb0390cce21de62d264c0a4e64713dfbe81bfc4fc7739/mypy-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:301f1a8ccc7d79b542ee218b28bb49443a83e194eb3d10da63ff1649e5aa5d34", size = 13559524, upload-time = "2026-05-06T19:22:24.906Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/d7bb54fde1770f0484e5fbdbdce37a41e95ed0a1cd493ec60ead111e356c/mypy-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdf4ef489d44ce350bac3fd699907834e551d4c934e9cc862ef201215ab1558d", size = 13936018, upload-time = "2026-05-06T19:25:02.992Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ba/5be51316b91e6a6bf6e3a8adb3de500e7e1fb5bf9491743b8cbc81a34a2c/mypy-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cde2d0989f912fc850890f727d0d76495e7a6c5bdd9912a1efdb64952b4398d", size = 14910712, upload-time = "2026-05-06T19:25:21.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/e2c8c3b373e20ebfb66e6c83a99027fd67df4ec43b08879f74e822d2dc4c/mypy-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdf05693c231a14fe37dbfce192a3a1372c26a833af4a80f550547742952e719", size = 15141499, upload-time = "2026-05-06T19:20:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/12/36/07756f933e00416d912e35878cfcf89a593a3350a885691c0bb85ae0226a/mypy-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:73aee2da33a2237e66cbe84a94780e53599847e86bb3aa7b93e405e8cd9905f2", size = 11240511, upload-time = "2026-05-06T19:21:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/70/05/79ac1f20f2397353f3845f7b8bb5d8006cda7c8ef9092f04f9de3c6135f2/mypy-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:1f6dcd8f39971f41edab2728c877c4ac8b50ad3c387ff2770423b79a05d23910", size = 10149336, upload-time = "2026-05-06T19:22:08.383Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e0/0db84e0ebbad6e99e566c68e4b465784f2a2294f7719e8db9d509ef23087/mypy-2.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a04e980b9275c76159da66c6e1723c7798306f9802b31bdaf9358d0c84030ce8", size = 15797362, upload-time = "2026-05-06T19:22:00.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a4/14cc0768164dd53bec48aa41a20270b18df9bf72aa5054278bf133608315/mypy-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:33f9cf4825469b2bc73c53ba55f6d9a9b4cdb60f9e6e228745581520f29b8771", size = 14635914, upload-time = "2026-05-06T19:23:43.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/48/d866a3e23b4dc5974c77d9cf65a435bf22de01a84dd4620917950e233960/mypy-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191675c3c7dc2a5c7722a035a6909c277f14046c5e4e02aa5fbf65f8524f08ad", size = 15270866, upload-time = "2026-05-06T19:22:34.756Z" },
+    { url = "https://files.pythonhosted.org/packages/71/eb/de9ef94958eb2078a6b908ceb247757dc384d3a238d3bd6ed7d81de5eaf8/mypy-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3d26c4321a3b06fc9f04c741e0733af693f82d823f8e64e47b2e63b7f19fa84", size = 16093131, upload-time = "2026-05-06T19:23:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/07/0ab2c1a9d26e90942612724cbd5788f16b7810c5dd39bfcf79286c6c4524/mypy-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bbcbc4d5917ca6ce12de70e051de7f533e3bf92d548b41a38a2232a6fe356525", size = 16330685, upload-time = "2026-05-06T19:21:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/46f85d1371a5be642dad263828118ae1efd536d91d8bd2000c68acff3920/mypy-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:dbc6ba6d40572ae49268531565793a8f07eac7fc65ad76d482c9b4c8765b6043", size = 12752017, upload-time = "2026-05-06T19:22:44.002Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/94ca48800cac19eb28a58188a768aaec0d16cac0f373915f073058ab0855/mypy-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:77926029dfcb7e1a3ecb0acb2ddbb24ca36be03f7d623e1759ad5376be8f6c01", size = 10527097, upload-time = "2026-05-06T19:20:58.973Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/14/fd0694aa594d6e9f9fd16ce821be2eff295197a273262ef56ddcc1388d68/mypy-2.0.0-py3-none-any.whl", hash = "sha256:8a92b2be3146b4fa1f062af7eb05574cbf3e6eb8e1f14704af1075423144e4e5", size = 2673434, upload-time = "2026-05-06T19:26:32.856Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+]


### PR DESCRIPTION
## Summary

Lands feat-001 — the foundational layer of AgentForge. Every other feature plugs into the contracts, value types, production rails, resolver, configuration loader, `InMemoryStore`, and `Agent` orchestrator delivered here.

5 commits on this branch (squash-merge to main per `.claude/standards/git.md`):

1. `da9bc60` — production rails + value types (BudgetPolicy, RunContext, RunIdFilter, exception hierarchy, all frozen Pydantic v2 value types)
2. `f630c69` — core contracts (LLMClient / Tool / ReasoningStrategy / MemoryStore / Evaluator ABCs + Finding Protocol)
3. `2d04ecb` — `InMemoryStore` + shared `run_memory_conformance` suite
4. `09af2b5` — `Agent` orchestrator + resolver + YAML config loader + integration tests
5. `b5bd8e1` — CHANGELOG finalisation

## Feature

Closes feat-001. See [`docs/features/feat-001-core-contracts-and-agent.md`](https://github.com/Scaffoldic/agentforge-py) (in the design workspace).

## Design principles cited

- **P1** — Contracts stable; implementations interchangeable. Every ABC in `agentforge-core` is locked at the public-API layer.
- **P3** — One LLM call costs USD; the framework knows it. `BudgetPolicy.check` exists; reasoning strategies (feat-002) call it before every LLM call.
- **P4** — Every run has `run_id`; every log line carries it. `RunContext` + `current_run()` ContextVar + `RunIdFilter` deliver this.
- **P5** — Configuration is data; behaviour is code. YAML schema with `extra="forbid"` and env-var interpolation only — no Jinja, no dynamic imports.
- **P6** — Defaults are loud; opt-ins are quiet. `BudgetPolicy(usd=1.0)` is on by default; `RunIdFilter` auto-installs.
- **P7** — Type-safe at the seam. `mypy --strict` clean across all 28 source files; Pydantic v2 strict-mode validation everywhere.
- **P11** — Fail at startup, not at runtime. Bad model strings, missing strategies, invalid configs all raise at `Agent(...)`, never inside `run()`.
- **P12** — A primitive belongs in core only when two real consumers need it.
- **ADR-0007** — ABC + Protocol contracts as the framework's stable surface.
- **ADR-0010** — Production rails owned by framework.
- **ADR-0013** — Configuration is declarative data.
- **ADR-0014** — Async-first core.

## Tests added

- **Unit:** 174 (production rails / value types / contracts / resolver / config / Agent / InMemoryStore)
- **Integration:** 2 (full Agent lifecycle with fake LLM + tool + InMemoryStore; run_id propagation through tools)
- **Conformance:** 1 (InMemoryStore against `run_memory_conformance`)
- **Property (Hypothesis):** 2 (idempotency-key determinism; BudgetPolicy reserve invariant)
- **Total: 192 tests, 0.45s**

**Coverage on diff:** 94.28% (gate is 90%)

## Bugs carried (per `.claude/development-pipeline.md` §5)

- `[BUG-CARRIED]` bootstrap: placeholder URLs (`https://github.com/`) in README/NOTICE/CHANGELOG/pyproject.toml replaced with the actual remote — fixed in `da9bc60`.
- `[BUG-CARRIED]` bootstrap: workspace `pyproject.toml` had deprecated `[tool.uv] dev-dependencies` and didn't list members as deps — migrated to `[dependency-groups] dev` + `[tool.uv.sources]` workspace=true in `da9bc60`.
- `[BUG-CARRIED]` bootstrap: `tests/__init__.py` files caused a pytest conftest path collision across packages — removed in `da9bc60` (pytest convention).
- `[BUG-CARRIED]` pre-commit: pytest hooks tolerate exit 5 (no tests collected) for empty integration dirs during the build phase — `da9bc60`.
- `[BUG-CARRIED]` pre-commit: bandit hook now passes `-c pyproject.toml` so `[tool.bandit] skips=["B101"]` applies to the conformance suite's asserts — `2d04ecb`.
- `[BUG-CARRIED]` Hypothesis property test for `BudgetPolicy` had an incorrect invariant (asserted `spent + reserved <= cap` unconditionally; `commit()` legitimately admits overrun on actual past spend) — reformulated to test the correct contract: a successful `reserve()` must leave `spent + reserved <= cap` — `f630c69`.

## Pre-commit hook output

```
✅ ruff format
✅ ruff check
✅ mypy --strict (28 source files, 0 issues)
✅ bandit -c pyproject.toml
✅ pytest unit
✅ pytest integration (excludes live)
✅ coverage >= 90% (actual: 94.28%)
✅ Conventional Commits format on every commit
```

## What's NOT in this PR (deferred to subsequent features)

- `ReActLoop` and the experimental strategies → feat-002
- Provider clients (`agentforge-anthropic`, etc.) → feat-003
- `@tool` decorator and built-in tool catalogue → feat-004
- Persistence drivers (sqlite/postgres/surrealdb/neo4j) → feat-005
- Evaluator implementations → feat-006
- Fallback chain + idempotency-key tool integration → feat-007
- `Finding` variants and renderer registry → feat-008
- OTel observability → feat-009
- Module discovery via entry points → feat-010
- Scaffolding CLI → feat-011

The contracts and lifecycle in this PR are designed so all of those land additively without changing the `Agent` constructor signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)