### PR TITLE
chore: decouple agentforge-py from private design workspace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,27 +2,12 @@
 
 <one-paragraph description of what this PR does and why>
 
-## Feature
-
-Closes feat-NNN. See `docs/features/feat-NNN-*.md` (in the design workspace).
-
-## Design principles cited
-
-- P<N>: <one-line how this PR honours it>
-- ADR-<NNNN>: <one-line how>
-
 ## Tests added
 
 - Unit: <count>
 - Integration: <count>
 - Conformance: <count>
-- Coverage on diff: <pct>%
-
-## Bugs carried (per `.claude/development-pipeline.md` §5)
-
-- [BUG-CARRIED] feat-PRIOR: <description> — fixed in <commit-sha>
-
-(or "None")
+- Coverage on diff: <pct>% (gate is 90%)
 
 ## Pre-commit hook output
 
@@ -30,7 +15,7 @@ Closes feat-NNN. See `docs/features/feat-NNN-*.md` (in the design workspace).
 ✅ ruff format
 ✅ ruff check
 ✅ mypy --strict
-✅ bandit
+✅ bandit -c pyproject.toml
 ✅ pytest unit
 ✅ pytest integration
 ✅ coverage >= 90%
@@ -38,11 +23,12 @@ Closes feat-NNN. See `docs/features/feat-NNN-*.md` (in the design workspace).
 
 ## Checklist
 
-- [ ] Branch is `feat/NNN-slug` (one feature, one PR)
+- [ ] Branch follows convention: `feat/<NNN>-<slug>`, `fix/<slug>`,
+      `docs/<slug>`, or `chore/<slug>`
+- [ ] One feature / fix / chore — not mixed
 - [ ] Conventional Commits format on every commit
-- [ ] Feature doc Status updated
-- [ ] AGENTS.md updated if conventions changed
-- [ ] ADR written if a load-bearing decision was made
-- [ ] `.claude/state/current.md` reflects current state
-- [ ] `.claude/state/log.md` has milestone entries for this branch
-- [ ] No `--no-verify` used (or explicit user approval logged)
+      (`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `chore:` /
+      `perf:` / `revert:`)
+- [ ] `AGENTS.md` updated if conventions changed
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`
+- [ ] No `--no-verify` used (or explicit reason in commit message)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # Pre-commit hook configuration for agentforge-py.
 #
-# Reference: .claude/checklists/pre-commit.md (in the parent design workspace)
-# This config is the agentforge-py-scoped subset of the project-wide hook
-# at ../../.pre-commit-config.yaml.
+# Install once after cloning the repo: `uv run pre-commit install`.
+# Run all hooks manually against every file: `uv run pre-commit run --all-files`.
+# CI runs the same checks; see .github/workflows/ci.yml.
 
 minimum_pre_commit_version: "3.5.0"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,85 +1,107 @@
 # AGENTS.md — agentforge-py
 
-> Scoped AI rules for the **`agentforge-py`** repository specifically.
-> The project-wide canonical rules live at
-> [`../../AGENTS.md`](../../AGENTS.md). Read both.
+> Repository conventions for any AI assistant editing this repo.
+> Tool-agnostic — `CLAUDE.md` and any future tool-specific rules files
+> defer to this one.
 
-## Read first
+## What this repo is
 
-1. [`../../AGENTS.md`](../../AGENTS.md) — project-wide rules and the
-   12 hard rules (every change must honour at least one design
-   principle, locked contracts, configuration-driven, etc.)
-2. [`../../.claude/state/current.md`](../../.claude/state/current.md)
-   — what feature is in progress, on which branch
-3. [`../../.claude/development-pipeline.md`](../../.claude/development-pipeline.md)
-   — per-feature workflow
+`agentforge-py` is the Python implementation of [AgentForge](https://github.com/Scaffoldic/agentforge-py),
+an open-source plug-and-play framework for building production AI
+agents. The repo is a **uv workspace** with two member packages today:
 
-## Repo-specific shape
-
-This is a **uv workspace** with two member packages today:
-
-- `packages/agentforge-core/` — locked ABCs and value types. No I/O,
-  no third-party SDKs except Pydantic.
-- `packages/agentforge/` — the default runtime. Imports from
+- `packages/agentforge-core/` — locked contracts (ABCs, value types,
+  production-rails primitives, resolver, testing utilities). No I/O,
+  no third-party SDKs except Pydantic + python-ulid.
+- `packages/agentforge/` — default runtime (`Agent` orchestrator,
+  `InMemoryStore`, configuration loader). Imports from
   `agentforge-core`; never the reverse.
 
-When a feature adds a new module (e.g. `agentforge-anthropic`,
-`agentforge-memory-postgres`), it lands as a new directory under
-`packages/`. The new member is added to the `[tool.uv.workspace] members`
-glob in the root `pyproject.toml` (already a wildcard, no edit needed).
+When new modules ship (provider clients, persistence drivers, MCP,
+observability, safety, etc. — see `CHANGELOG.md`), each lands as a
+new directory under `packages/`. The workspace glob in the root
+`pyproject.toml` already covers them.
 
-## Hard rules specific to this repo
+## Hard rules
 
-- **`agentforge-core` imports nothing from `agentforge` or any other
-  module.** It's the leaf of the dependency graph.
-- **No magic numbers** — every threshold/timeout/limit comes from a
-  Pydantic config model with a documented default. See
-  [`../../.claude/standards/configuration.md`](../../.claude/standards/configuration.md).
-- **Type hints everywhere** — `mypy --strict` is the gate.
-  `Any` only at genuine boundaries (raw provider responses).
-- **Async by default** — public methods on contracts are `async def`.
-  Sync wrappers only as explicit `*_sync` shims.
-- **No print statements** — use `logging.getLogger(__name__)`.
-- **No `from langchain... import`** anywhere. Wrong framework.
-- **Tests use fixtures from YAML** under `tests/fixtures/`. Never
-  inline test data.
+| # | Rule | Reference |
+|---|---|---|
+| 1 | `agentforge-core` imports nothing from `agentforge` or any other module package. It is the leaf of the dependency graph. | dependency policy |
+| 2 | Contracts in `agentforge-core` (every ABC + the `Finding` Protocol + the locked value types) are **stable surface**. Adding a method to an ABC is a major version bump; adding a field with a safe default is a minor bump. | locked contract layer |
+| 3 | Configuration is data, not code. No dynamic imports from YAML; no Jinja inside config. Env-var interpolation only (`${VAR}`, `${VAR:default}`, `${VAR:?error}`, `$$` → `$`). | `agentforge.config` |
+| 4 | No magic numbers in production code. Every threshold / timeout / limit comes from a Pydantic config model with a documented default. | configuration policy |
+| 5 | Test coverage must be ≥ 90% on every commit. Pre-commit blocks below; CI ratchet rejects regressions on `main`. | `.pre-commit-config.yaml` + `.github/workflows/ci.yml` |
+| 6 | One feature = one branch = one PR. Conventional Commits format (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `perf:`, `revert:`). | PR template |
+| 7 | Never bypass pre-commit with `--no-verify` unless the user explicitly authorises it for a specific commit (and the bypass is documented in the commit message). | pre-commit policy |
+| 8 | Type hints everywhere. `mypy --strict` is the gate. `Any` only at genuine boundaries (raw provider responses); never to paper over untyped internals. | `pyproject.toml > [tool.mypy]` |
+| 9 | Async-first. Public methods on locked contracts are `async def`. Sync callers use the `*_sync` shims (where exposed) or `asyncio.run()`. | locked contract layer |
 
-## Pre-commit
+## Anti-patterns reviewers will reject
 
-Install with `pre-commit install`. The hook config at
-[`.pre-commit-config.yaml`](./.pre-commit-config.yaml) enforces:
+- **`from langchain... import`** anywhere. Wrong framework.
+- **Hand-written JSON schemas** for tools — use Pydantic models on the
+  `Tool` ABC's `input_schema` class attribute (or the `@tool`
+  decorator once feat-004 ships).
+- **API keys as YAML literals** — use `${ENV_VAR}`.
+- **Catching exceptions to "make robust"** — let them surface; the
+  framework records them as observations and the LLM recovers.
+- **Wrappers around `Agent.run()` to add cross-cutting features** —
+  use the hook system (`on_step` / `on_finish`) once feat-009 ships
+  observability backends.
+- **Module-level singleton config** (`dspy.configure(...)` style) —
+  use dependency injection.
+- **Threading for I/O** — use `asyncio`.
 
-- `ruff format` + `ruff check --fix`
-- `mypy --strict`
-- `bandit -q -r packages/*/src/`
-- `pytest tests/unit -q -x` (and per-package unit tests)
-- `pytest tests/integration -q -x -m "not live"`
-- `pytest --cov --cov-fail-under=90`
+## Workflow
 
-Failure blocks the commit. Never bypass with `--no-verify` unless the
-user explicitly authorises.
-
-## Anti-patterns to avoid (will be flagged by reviewers and AI)
-
-- LangChain idioms (`Runnable`, `LCEL`, `RunnablePassthrough`)
-- Hand-written JSON schemas — use Pydantic and the `@tool` decorator
-- API keys as YAML literals — use `${ENV_VAR}`
-- Catching exceptions to "make robust" — let them surface
-- Wrappers around `Agent.run()` to add cross-cutting features — use hooks
-- Module-level singleton config (`dspy.configure(...)` style) — use DI
-- Threading for I/O — use `asyncio`
+- Branch from `main`. Conventional branch names: `feat/<NNN>-<slug>`,
+  `fix/<slug>`, `docs/<slug>`, `chore/<slug>`.
+- Every commit goes through pre-commit (`pre-commit install` after a
+  fresh clone). The hook runs ruff / mypy / bandit / pytest /
+  coverage. Failures block.
+- One feature = one PR. Squash-merge to `main`.
+- CI runs the same checks plus a multi-OS test matrix (Linux, macOS,
+  Windows) on Python 3.13.
 
 ## How to add a new module package
 
-1. Create `packages/agentforge-<X>/` with the same structure as
-   existing members (`pyproject.toml`, `src/agentforge_<x>/`, `tests/`).
+1. Create `packages/agentforge-<X>/` with the structure used by
+   existing members (`pyproject.toml`, `src/agentforge_<x>/`,
+   `tests/unit/`).
 2. Declare entry points in the new `pyproject.toml` under
    `[project.entry-points."agentforge.<category>"]`.
 3. Pin against `agentforge-core ~= <current major>`.
-4. Add at least one test in the new `tests/` directory.
-5. Update the workspace's `agentforge` aggregate optional-dependencies
-   in `packages/agentforge/pyproject.toml` if the new module belongs to
-   a curated extra (`[anthropic]`, `[full]`, etc.).
+4. Add at least one test.
+5. If the module belongs to a curated extra (`[anthropic]`, `[full]`,
+   etc.), update `packages/agentforge/pyproject.toml`'s
+   `[project.optional-dependencies]`.
+
+## Pre-commit (local)
+
+```bash
+uv sync --group dev
+uv run pre-commit install
+```
+
+The hook runs:
+
+- `ruff format` (pinned to `v0.15.12` — matches the venv and CI)
+- `ruff check --fix`
+- `mypy --strict` on `packages/*/src/`
+- `bandit -c pyproject.toml -r packages/*/src/`
+- `pytest -q -x -m "not live"` (per-package + workspace tests)
+- `pytest --cov --cov-fail-under=90`
+
+## Reading order on a fresh clone
+
+1. This file.
+2. `README.md` — quickstart, repo layout, install + dev commands.
+3. `CHANGELOG.md` — what's shipped and what's coming.
+4. `packages/agentforge-core/src/agentforge_core/` — the locked
+   contract layer. Start with `contracts/` then `values/` then
+   `production/`.
+5. `packages/agentforge/src/agentforge/agent.py` — the orchestrator
+   that ties everything together.
 
 <!-- agentforge:custom -->
 <!-- Project-specific instructions go below this line. Survives upgrades. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+### Changed
+
+- Documentation made self-contained for the public OSS repo: removed
+  `../../` references to a private design workspace from `AGENTS.md`,
+  `README.md`, the PR template, and the pre-commit config. Repo
+  conventions, install instructions, and the contributor workflow now
+  live entirely inside `agentforge-py`.
+
 ### Added
 
 - Repository bootstrap: uv workspace, ruff/mypy/pytest/coverage tooling,

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # agentforge-py
 
-Python implementation of [AgentForge](https://github.com/Scaffoldic/agentforge-py) — an open-source,
-plug-and-play framework for building production AI agents.
+Python implementation of [AgentForge](https://github.com/Scaffoldic/agentforge-py)
+— an open-source, plug-and-play framework for building production AI agents.
 
-> **Status:** v0.0 — pre-alpha. The repo is bootstrapped; no features
-> shipped yet. The full design lives in the design workspace at
-> [`../docs/`](../docs/) (relative to the parent `ai-agents/` workspace).
+> **Status:** v0.0 — pre-alpha. feat-001 (core contracts & `Agent`
+> orchestrator) is shipped; the rest of the v0.1 milestone is in
+> progress. See `CHANGELOG.md` for what's landed.
 
 ## What is AgentForge
 
-AgentForge is a framework for building AI agents in three lines plus one
-`pip install`. The opinionated parts — cost guardrails, run-id propagation,
-distributed tracing, fallback chains, durable claim records, evaluator
-suites, prompt-injection and PII defenses by default — are wired before
-you write a line of code. The interesting parts — your tools, your
-prompts, your reasoning shape — are where you spend your time.
+AgentForge is a framework for building AI agents in three lines plus
+one `pip install`. The opinionated parts — cost guardrails, run-id
+propagation, distributed tracing, fallback chains, durable claim
+records, evaluator suites, prompt-injection and PII defenses by
+default — are wired before you write a line of code. The interesting
+parts — your tools, your prompts, your reasoning shape — are where you
+spend your time.
 
-The full pitch and architecture are in the design workspace docs:
+```python
+# When the v0.1 milestone is complete:
+from agentforge import Agent
 
-- [`../../docs/README.md`](../../docs/README.md) — entry point
-- [`../../docs/design/architecture.md`](../../docs/design/architecture.md) — system view
-- [`../../docs/features/README.md`](../../docs/features/README.md) — feature catalogue
-- [`../../docs/adr/README.md`](../../docs/adr/README.md) — decision records
+agent = Agent(model="anthropic:claude-sonnet-4.7")
+result = await agent.run("Summarise this PR")
+print(result.output)
+```
 
 ## Repository structure
 
-This is a **uv workspace** — one git repo, multiple installable packages
-managed in lock-step (per ADR-0003 + ADR-0015).
+This is a **uv workspace** — one git repo, multiple installable
+packages managed in lock-step.
 
 ```
 agentforge-py/
@@ -34,35 +37,56 @@ agentforge-py/
 ├── uv.lock                         shared lock file
 ├── packages/
 │   ├── agentforge-core/            stable contracts (ABCs, value types)
-│   └── agentforge/                 default runtime (Agent, ReAct, defaults)
+│   └── agentforge/                 default runtime (Agent, defaults)
 ├── tests/                          cross-package integration / conformance
 └── .github/workflows/              CI
 ```
 
-Packages publish to PyPI as separate distributions; users `pip install
-agentforge` (or `agentforge[anthropic]`) and the right pieces land.
+Packages publish to PyPI as separate distributions; users
+`pip install agentforge` (or `agentforge[anthropic]` etc. as
+provider modules ship) and the right pieces land in the venv.
+
+## Install (end users)
+
+```bash
+pip install agentforge
+```
+
+Note: provider modules (`agentforge-anthropic`, `agentforge-bedrock`,
+`agentforge-openai`, …) and persistence modules
+(`agentforge-memory-sqlite`, `-postgres`, …) ship as separate packages
+in the v0.1 milestone. Install only what you need.
 
 ## Development
 
 Prerequisites: Python 3.13, [uv](https://docs.astral.sh/uv/).
 
 ```bash
-uv sync                              # create venv, install all members + dev deps
-uv run pytest                        # run all tests
+git clone git@github.com:Scaffoldic/agentforge-py.git
+cd agentforge-py
+uv sync --group dev                  # venv + members + dev deps
+uv run pytest                        # all tests (unit + integration + conformance)
 uv run ruff check                    # lint
-uv run mypy --strict packages/       # type-check
-pre-commit install                   # install git hooks
+uv run ruff format                   # auto-format
+uv run mypy --strict packages/agentforge-core/src packages/agentforge/src
+uv run pre-commit install            # git hooks
 ```
 
 ## Contributing
 
-This repo follows the AgentForge framework's strict development pipeline.
-Before you start, read:
+Before you start: read [`AGENTS.md`](./AGENTS.md) for the repo
+conventions (uv workspace layout, locked contract layer, anti-patterns
+reviewers will reject, the pre-commit gate, how to add a new module
+package).
 
-1. [`AGENTS.md`](./AGENTS.md) — repo-scoped AI assistant rules
-2. [`../../AGENTS.md`](../../AGENTS.md) — project-wide rules
-3. [`../../.claude/development-pipeline.md`](../../.claude/development-pipeline.md) — per-feature workflow
-4. [`../../.claude/standards/`](../../.claude/standards/) — coding, testing, docs, git, configuration
+Branch and PR conventions:
+
+- Branch from `main`. Names: `feat/<NNN>-<slug>`, `fix/<slug>`,
+  `docs/<slug>`, `chore/<slug>`.
+- Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`,
+  `refactor:`, `chore:`, `perf:`, `revert:`.
+- One feature = one PR. Squash-merge to `main`.
+- 90% coverage gate; pre-commit + CI block below.
 
 ## License
 


### PR DESCRIPTION
## Summary

`agentforge-py` is the public OSS repo for the AgentForge framework's Python implementation. The previous `AGENTS.md`, `README`, PR template, and pre-commit comments referenced a private design workspace at `../../` (where the maintainer's design docs and local dev pipeline live). Those references are removed so the repo is fully self-contained for outside contributors.

## What changed

- **`AGENTS.md`** — rewritten as a standalone repo-conventions document. Hard rules, anti-patterns, workflow, "how to add a new module package", and pre-commit description all inline. Zero parent links.
- **`README.md`** — focused on what end users and contributors of `agentforge-py` need: install, repo structure, dev quickstart, branch / PR conventions, license.
- **`.github/pull_request_template.md`** — trimmed to public-friendly content (summary, tests, pre-commit gate, checklist). Removed references to feat-NNN design docs and `.claude/state/` files that live outside this repo.
- **`.pre-commit-config.yaml`** — header rewritten with standalone install / run / CI-parity notes. Removed the parent-config pointer.
- **`CHANGELOG.md`** — `[Unreleased]` `Changed` entry records the decoupling.

## Tests added

- Unit: 0
- Integration: 0
- Conformance: 0
- Coverage on diff: n/a (docs/config only — no Python changes)

192 existing tests still pass.

## Pre-commit hook output

```
✅ ruff format (no Python changed)
✅ ruff check
✅ mypy --strict (no Python changed)
✅ bandit -c pyproject.toml
✅ pytest unit
✅ pytest integration
✅ coverage >= 90%
```

## Checklist

- [x] Branch `chore/decouple-from-parent-workspace`
- [x] One coherent chore — no mixed concerns
- [x] Conventional Commits format
- [x] `AGENTS.md` updated
- [x] `CHANGELOG.md` entry added
- [x] No `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)