### PR TITLE
feat(strategies): ship all four reasoning strategies stable (feat-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,88 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-002 — Reasoning strategies (all four stable).** All four
+  reasoning loops ship as production-stable in `agentforge.strategies`
+  (no experimental package per ADR-0008).
+
+  *Shared infrastructure (chunk 1):*
+  - **`RuntimeContext`** — frozen per-run execution context (LLM,
+    tools, memory, budget, system prompt) bound to
+    `state.metadata[RUNTIME_KEY]` by `Agent.run()`. Lives in
+    `agentforge` (not `agentforge-core`) to avoid the circular import
+    between contracts and runtime concerns.
+  - **`StrategyBase`** — abstract base every shipped strategy
+    inherits, providing `_check_guardrails`, `_record_step`, and
+    `_call_llm` (guardrail-check → LLM call → cost commit → step
+    record). The conformance suite verifies via AST inspection that
+    every concrete strategy class invokes `_check_guardrails` (or
+    `_call_llm`) inside its main loop.
+  - **`get_runtime(state)`** helper with clear errors when a strategy
+    is invoked outside `Agent.run()`.
+  - **`FakeLLMClient`** in `agentforge._testing` — scripted-response
+    LLM client driving every feat-002 unit & integration test.
+  - **`run_strategy_conformance`** in `agentforge_core.testing` — the
+    suite every shipped (and third-party) strategy must pass.
+
+  *`ReActLoop` (chunk 2):* modern reasoning + acting loop with
+  structured tool calls. Terminates on `stop_reason="end_turn"` (no
+  tool_calls in the response — the modern signal-based approach;
+  feature-flagged `Final Answer:` parsing is reserved for
+  experimental-only opt-in). Constructor surface locked at v0.1:
+  `ReActLoop(*, max_iterations=None)`. Registered as
+  `strategies/react`.
+
+  *`PlanExecuteLoop` (chunk 3):* typed plan + parallel execution.
+  Phases: PLAN (structured `Plan`/`PlanStep` Pydantic schema, cycles
+  & dangling deps caught at parse time) → EXECUTE (topological
+  batches, `asyncio.Semaphore`-capped concurrency) → SYNTHESIZE.
+  Re-plans on parse / execution failure up to `max_replans`.
+  Constructor: `PlanExecuteLoop(*, max_parallel_steps=4,
+  replan_on_failure=True, max_replans=1)`. Registered as
+  `strategies/plan-execute`.
+
+  *`TreeOfThoughts` (chunk 4):* beam-search reasoning with scored
+  branches. Phases: GENERATE (`branch_factor` candidates) → SCORE
+  (Pydantic `_BranchScoreList`, 0..1) → PRUNE (`score_threshold` +
+  optional top-K via `beam_width`) → EXPAND (recurse to `depth`) →
+  SYNTHESIZE (best path → final answer). Budget-aware graceful
+  degradation: estimates next-level cost from running average and
+  synthesises early instead of crashing if it would exceed the
+  remaining budget. `scorer="judge"` falls back to `"self"` for v0.1
+  (cheap-judge model lands in feat-006). Constructor:
+  `TreeOfThoughts(*, branch_factor=3, depth=2, score_threshold=0.5,
+  scorer="self", beam_width=None)`. Registered as `strategies/tot`.
+
+  *`MultiAgentSupervisor` (chunk 5):* supervisor delegates subtasks
+  to a configurable set of worker strategies. Phases: DELEGATE
+  (Pydantic `_DelegationPlan`, unknown workers dropped with logged
+  warning) → EXECUTE WORKERS (parallel under
+  `asyncio.Semaphore(max_parallel_workers)`; each worker gets a
+  fresh `AgentState`, a *proportional* `BudgetPolicy` cut from the
+  parent's remaining USD, and the shared parent `MemoryStore`;
+  per-worker spend reconciled into the parent budget on success
+  *and* failure; worker exceptions caught and recorded as a
+  `delegate` step with `error`) → AGGREGATE (synthesise outputs).
+  Workers can be any `ReasoningStrategy`, including another
+  `MultiAgentSupervisor` (recursive composition). Constructor:
+  `MultiAgentSupervisor(*, workers, max_parallel_workers=4,
+  max_rounds=1, worker_descriptions=None)`. Registered as
+  `strategies/multi-agent`.
+
+  *Cross-strategy guarantees (chunk 6):* Hypothesis property tests
+  prove the budget invariant holds across all four shipped
+  strategies: every run either terminates cleanly with
+  `spent_usd <= cap + max_call_cost` or raises `BudgetExceeded` /
+  `GuardrailViolation` (one in-flight call may push spend over the
+  cap; subsequent calls are blocked). Strategies are exercised over
+  randomized cap × per-call-cost matrices.
+
+  *Tests:* 300+ unit + integration + property tests covering
+  constructor validation, happy paths, parse-error fallback,
+  code-fence stripping, parallel-execution semantics, budget
+  graceful degradation, and recursive composition. ~96% line +
+  branch coverage on the diff.
+
 - Repository bootstrap: uv workspace, ruff/mypy/pytest/coverage tooling,
   GitHub Actions CI, pre-commit hook, Apache 2.0 license, AGENTS.md,
   README, member package skeletons (`agentforge-core`, `agentforge`).

--- a/packages/agentforge-core/src/agentforge_core/testing/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/__init__.py
@@ -12,6 +12,9 @@ have to depend on the full runtime.
 
 from __future__ import annotations
 
-from agentforge_core.testing.conformance import run_memory_conformance
+from agentforge_core.testing.conformance import (
+    run_memory_conformance,
+    run_strategy_conformance,
+)
 
-__all__ = ["run_memory_conformance"]
+__all__ = ["run_memory_conformance", "run_strategy_conformance"]

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -18,10 +18,16 @@ Usage in a driver's tests:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import typing
+from collections.abc import AsyncIterator, Awaitable, Callable
 
 from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.values.claim import Claim
+from agentforge_core.values.state import AgentState, StepKind
+
+_VALID_STEP_KINDS: frozenset[str] = frozenset(typing.get_args(StepKind))
+"""Closed enum mirror of `StepKind`. Used by `run_strategy_conformance`."""
 
 
 def _claim(
@@ -132,3 +138,83 @@ async def run_memory_conformance(store: MemoryStore) -> None:
         sample = next(iter(caps))
         assert store.supports(sample) is True
     assert store.supports("definitely-not-a-capability-2026") is False
+
+
+# ----------------------------------------------------------------------
+# Strategy conformance — feat-002.
+# ----------------------------------------------------------------------
+
+
+async def run_strategy_conformance(
+    strategy: ReasoningStrategy,
+    *,
+    state_factory: Callable[[], AgentState],
+    pre_run: Callable[[AgentState], None | Awaitable[None]] | None = None,
+) -> None:
+    """Run the shared `ReasoningStrategy` conformance suite.
+
+    Args:
+        strategy: A constructed strategy instance.
+        state_factory: Builds a fresh `AgentState` for each scenario
+            (with `RuntimeContext` bound on `state.metadata` if the
+            strategy needs one — the framework runtime does this; tests
+            must do it explicitly).
+        pre_run: Optional async-or-sync callable invoked on the freshly
+            built `AgentState` before `strategy.run()` (e.g. to seed
+            findings or steps). May be omitted.
+
+    Verifies the locked invariants of `ReasoningStrategy.run`:
+
+      1. Returns the same `AgentState` instance it was given.
+      2. Populates `state.steps` with at least one step.
+      3. Every emitted step's `kind` is a valid `StepKind` value.
+      4. `step.iteration` is monotonically non-decreasing across the run.
+      5. Every emitted step has non-negative `tokens_in`, `tokens_out`,
+         `cost_usd`, `duration_ms` (Pydantic enforces; the assertion
+         here is defence-in-depth).
+
+    Raises:
+        AssertionError: a contract was violated.
+    """
+    state = state_factory()
+    if pre_run is not None:
+        outcome = pre_run(state)
+        if outcome is not None and hasattr(outcome, "__await__"):
+            await outcome
+
+    result = await strategy.run(state)
+
+    # 1. Returns the same instance
+    assert result is state, (
+        "ReasoningStrategy.run must return the same AgentState instance "
+        "it received (state mutation, not replacement)."
+    )
+
+    # 2. Populates state.steps
+    assert len(state.steps) >= 1, (
+        "ReasoningStrategy.run must append at least one Step to state.steps before returning."
+    )
+
+    # 3. Every step.kind is valid
+    for step in state.steps:
+        assert step.kind in _VALID_STEP_KINDS, (
+            f"step.kind={step.kind!r} is not a valid StepKind. "
+            f"Valid kinds: {sorted(_VALID_STEP_KINDS)}"
+        )
+
+    # 4. step.iteration monotonic non-decreasing
+    last_iter = -1
+    for step in state.steps:
+        assert step.iteration >= last_iter, (
+            f"step.iteration must be monotonically non-decreasing; "
+            f"saw {step.iteration} after {last_iter}."
+        )
+        last_iter = step.iteration
+
+    # 5. Non-negative cost / token / duration fields (Pydantic
+    #    already enforces ge=0; this is defence-in-depth)
+    for step in state.steps:
+        assert step.tokens_in >= 0, "step.tokens_in must be non-negative"
+        assert step.tokens_out >= 0, "step.tokens_out must be non-negative"
+        assert step.cost_usd >= 0.0, "step.cost_usd must be non-negative"
+        assert step.duration_ms >= 0, "step.duration_ms must be non-negative"

--- a/packages/agentforge-core/src/agentforge_core/values/state.py
+++ b/packages/agentforge-core/src/agentforge_core/values/state.py
@@ -61,6 +61,14 @@ class AgentState(BaseModel):
 
     Strategies append to `steps`; tools and pipeline tasks may append
     to `findings`. The runtime owns the lifecycle.
+
+    The per-run execution context (`RuntimeContext` — LLM client,
+    tools, memory, budget, system prompt) is stored on
+    `state.metadata` under the key `"__agentforge_runtime__"`,
+    populated by `Agent.run()` before calling the strategy.
+    Strategies access it via the `get_runtime(state)` helper in
+    `agentforge.strategies._base`. Storing it on metadata keeps
+    `agentforge-core` free of dependencies on runtime modules.
     """
 
     model_config = ConfigDict(strict=True, validate_assignment=True)

--- a/packages/agentforge-core/tests/unit/test_resolver.py
+++ b/packages/agentforge-core/tests/unit/test_resolver.py
@@ -127,12 +127,21 @@ def test_global_resolver_is_singleton() -> None:
 
 
 def test_register_decorator_uses_global() -> None:
-    Resolver.global_().clear()
+    """The @register decorator targets the global resolver. Use a
+    unique name and avoid clearing the global — clearing would nuke
+    other modules' registrations (e.g. ReActLoop registers itself at
+    import time)."""
+    unique_name = f"decorator-test-{id(object())}"
 
-    @register("strategies", "decorator-test")
+    @register("strategies", unique_name)
     class _MyStrategy:
         pass
 
-    cls = Resolver.global_().resolve("strategies", "decorator-test")
-    assert cls is _MyStrategy
-    Resolver.global_().clear()
+    try:
+        cls = Resolver.global_().resolve("strategies", unique_name)
+        assert cls is _MyStrategy
+    finally:
+        # Tidy up: remove only our own entry, never clear the global.
+        # The Resolver doesn't expose a public "unregister", so we
+        # poke the internal map. Tests-only access pattern.
+        Resolver.global_()._registry.pop(("strategies", unique_name), None)

--- a/packages/agentforge-core/tests/unit/test_strategy_conformance.py
+++ b/packages/agentforge-core/tests/unit/test_strategy_conformance.py
@@ -1,0 +1,92 @@
+"""Unit tests for `run_strategy_conformance`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.testing import run_strategy_conformance
+from agentforge_core.values.state import AgentState, Step
+
+
+class _GoodStrategy(ReasoningStrategy):
+    """Conformant: returns same state, appends a valid step."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        state.steps.append(Step(iteration=0, kind="observe", content="ok"))
+        return state
+
+
+class _ReturnsDifferentState(ReasoningStrategy):
+    """Non-conformant: returns a fresh AgentState instead of mutating."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        return AgentState(
+            run_id=state.run_id,
+            task=state.task,
+            steps=[Step(iteration=0, kind="observe", content="ok")],
+        )
+
+
+class _NoSteps(ReasoningStrategy):
+    """Non-conformant: never appends a step."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        return state
+
+
+class _NonMonotonicIteration(ReasoningStrategy):
+    """Non-conformant: step.iteration goes backwards."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        state.steps.append(Step(iteration=5, kind="think", content="a"))
+        state.steps.append(Step(iteration=2, kind="observe", content="b"))
+        return state
+
+
+def _state_factory() -> AgentState:
+    return AgentState(run_id="r", task="t")
+
+
+@pytest.mark.asyncio
+async def test_good_strategy_passes() -> None:
+    await run_strategy_conformance(_GoodStrategy(), state_factory=_state_factory)
+
+
+@pytest.mark.asyncio
+async def test_strategy_returning_different_instance_fails() -> None:
+    with pytest.raises(AssertionError, match="same AgentState instance"):
+        await run_strategy_conformance(_ReturnsDifferentState(), state_factory=_state_factory)
+
+
+@pytest.mark.asyncio
+async def test_strategy_emitting_no_steps_fails() -> None:
+    with pytest.raises(AssertionError, match="at least one Step"):
+        await run_strategy_conformance(_NoSteps(), state_factory=_state_factory)
+
+
+@pytest.mark.asyncio
+async def test_non_monotonic_iteration_fails() -> None:
+    with pytest.raises(AssertionError, match="monotonically non-decreasing"):
+        await run_strategy_conformance(_NonMonotonicIteration(), state_factory=_state_factory)
+
+
+@pytest.mark.asyncio
+async def test_pre_run_hook_invoked() -> None:
+    seen: list[str] = []
+
+    def hook(state: AgentState) -> None:
+        seen.append(state.run_id)
+
+    await run_strategy_conformance(_GoodStrategy(), state_factory=_state_factory, pre_run=hook)
+    assert seen == ["r"]
+
+
+@pytest.mark.asyncio
+async def test_pre_run_async_hook_awaited() -> None:
+    seen: list[str] = []
+
+    async def hook(state: AgentState) -> None:
+        seen.append(state.run_id)
+
+    await run_strategy_conformance(_GoodStrategy(), state_factory=_state_factory, pre_run=hook)
+    assert seen == ["r"]

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -6,6 +6,8 @@ This package is the default runtime. It ships:
   - `InMemoryStore` — process-local default `MemoryStore` so a fresh
     agent has persistence wired without external infra.
   - The configuration loader (`load_config`).
+  - The reasoning-strategy infrastructure: `RuntimeContext`,
+    `StrategyBase`, `get_runtime`, `ReActLoop` (feat-002).
 
 For provider clients, persistence drivers, MCP, observability backends,
 and safety modules, install the corresponding `agentforge-<X>` packages
@@ -20,13 +22,20 @@ from __future__ import annotations
 from agentforge.agent import Agent
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import ReActLoop, StrategyBase, get_runtime
 
 __version__ = "0.0.0"
 
 __all__ = [
+    "RUNTIME_KEY",
     "Agent",
     "AgentForgeConfig",
     "InMemoryStore",
+    "ReActLoop",
+    "RuntimeContext",
+    "StrategyBase",
     "__version__",
+    "get_runtime",
     "load_config",
 ]

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -24,6 +24,7 @@ from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
 from agentforge.strategies import (
+    MultiAgentSupervisor,
     Plan,
     PlanExecuteLoop,
     PlanStep,
@@ -40,6 +41,7 @@ __all__ = [
     "Agent",
     "AgentForgeConfig",
     "InMemoryStore",
+    "MultiAgentSupervisor",
     "Plan",
     "PlanExecuteLoop",
     "PlanStep",

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -23,7 +23,14 @@ from agentforge.agent import Agent
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
-from agentforge.strategies import ReActLoop, StrategyBase, get_runtime
+from agentforge.strategies import (
+    Plan,
+    PlanExecuteLoop,
+    PlanStep,
+    ReActLoop,
+    StrategyBase,
+    get_runtime,
+)
 
 __version__ = "0.0.0"
 
@@ -32,6 +39,9 @@ __all__ = [
     "Agent",
     "AgentForgeConfig",
     "InMemoryStore",
+    "Plan",
+    "PlanExecuteLoop",
+    "PlanStep",
     "ReActLoop",
     "RuntimeContext",
     "StrategyBase",

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -29,6 +29,7 @@ from agentforge.strategies import (
     PlanStep,
     ReActLoop,
     StrategyBase,
+    TreeOfThoughts,
     get_runtime,
 )
 
@@ -45,6 +46,7 @@ __all__ = [
     "ReActLoop",
     "RuntimeContext",
     "StrategyBase",
+    "TreeOfThoughts",
     "__version__",
     "get_runtime",
     "load_config",

--- a/packages/agentforge/src/agentforge/_testing/__init__.py
+++ b/packages/agentforge/src/agentforge/_testing/__init__.py
@@ -1,0 +1,18 @@
+"""Local test helpers.
+
+Private package (underscore prefix) — these helpers exist only to
+support feat-002's tests (and other early features) until feat-016
+ships the full public testing API at `agentforge.testing`.
+
+Helpers here:
+
+- `FakeLLMClient` — minimal scripted-response `LLMClient`. Replaced
+  by feat-016's `MockLLMClient` (richer: recording / replay /
+  capability simulation).
+"""
+
+from __future__ import annotations
+
+from agentforge._testing.fake_llm import FakeLLMClient, echo_response
+
+__all__ = ["FakeLLMClient", "echo_response"]

--- a/packages/agentforge/src/agentforge/_testing/fake_llm.py
+++ b/packages/agentforge/src/agentforge/_testing/fake_llm.py
@@ -1,0 +1,126 @@
+"""`FakeLLMClient` — minimal scripted-response `LLMClient` for unit tests.
+
+Used by feat-002's strategy tests. Replaced by feat-016's full
+`MockLLMClient` (which supports recording / replay / capability
+simulation) when that lands; until then, this class is enough to
+drive the four reasoning strategies through their unit and
+integration tests.
+
+Usage:
+
+    fake = FakeLLMClient(
+        responses=[
+            LLMResponse(content="thought 1", stop_reason="tool_use",
+                        tool_calls=(ToolCall(id="t1", name="search",
+                                             arguments={"q": "x"}),),
+                        usage=TokenUsage(input_tokens=10, output_tokens=5),
+                        cost_usd=0.001, model="m", provider="p"),
+            LLMResponse(content="final answer", stop_reason="end_turn",
+                        usage=TokenUsage(input_tokens=12, output_tokens=8),
+                        cost_usd=0.002, model="m", provider="p"),
+        ],
+    )
+    # When the strategy under test calls fake.call(...) twice,
+    # it gets the two scripted responses in order.
+
+Responses can also be callables (called with the call's args) for
+dynamic scripting:
+
+    FakeLLMClient(responses=[lambda system, messages, tools=None: ...])
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.values.messages import LLMResponse, Message, TokenUsage, ToolSpec
+
+ResponseSpec = LLMResponse | Callable[..., LLMResponse]
+
+
+class FakeLLMClient(LLMClient):
+    """Scripted-response `LLMClient` for tests.
+
+    Constructor takes a list of `LLMResponse` instances OR callables
+    that build a response from the call args. Each `.call()` returns
+    the next item in the list; raises if the list is exhausted.
+    """
+
+    def __init__(
+        self,
+        responses: list[ResponseSpec] | None = None,
+        *,
+        capabilities: set[str] | None = None,
+    ) -> None:
+        self._responses: list[ResponseSpec] = list(responses or [])
+        self._call_count: int = 0
+        self._captured: list[tuple[str, list[Message], list[ToolSpec] | None]] = []
+        self._capabilities: set[str] = set(capabilities or ())
+        self._closed: bool = False
+
+    @property
+    def call_count(self) -> int:
+        """Number of `.call()` invocations so far."""
+        return self._call_count
+
+    @property
+    def captured(
+        self,
+    ) -> list[tuple[str, list[Message], list[ToolSpec] | None]]:
+        """Every `(system, messages, tools)` triple seen by `.call()`,
+        in order. Useful for asserting the strategy sent the expected
+        messages."""
+        return list(self._captured)
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        if self._closed:
+            raise RuntimeError("FakeLLMClient.close() was already called")
+        if self._call_count >= len(self._responses):
+            raise RuntimeError(
+                f"FakeLLMClient exhausted after {self._call_count} calls; "
+                f"add more scripted responses or check the strategy's loop."
+            )
+        spec = self._responses[self._call_count]
+        self._captured.append((system, list(messages), tools))
+        self._call_count += 1
+        if callable(spec):
+            return spec(system=system, messages=messages, tools=tools)
+        return spec
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def capabilities(self) -> set[str]:
+        return set(self._capabilities)
+
+
+def echo_response(
+    *,
+    content: str = "ok",
+    stop_reason: str = "end_turn",
+    cost_usd: float = 0.0,
+    input_tokens: int = 1,
+    output_tokens: int = 1,
+    **_: Any,
+) -> LLMResponse:
+    """Convenience builder for an `LLMResponse` with sensible defaults.
+
+    Used by tests that only care about a single LLM call's output
+    shape and don't want to hand-write the full `LLMResponse`
+    construction every time.
+    """
+    return LLMResponse(
+        content=content,
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+        cost_usd=cost_usd,
+        model="fake",
+        provider="fake",
+    )

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -52,6 +52,7 @@ from agentforge_core.values.state import AgentState, FinishReason, RunResult
 
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
 
 StepHook = Callable[..., Awaitable[None] | None]
 """Hook signature: takes a Step, returns awaitable-or-None."""
@@ -187,7 +188,20 @@ class Agent:
         started_ms = time.monotonic()
         finish_reason: FinishReason = "completed"
         try:
-            state = AgentState(run_id=ctx.run_id, task=task)
+            metadata: dict[str, object] = {}
+            if self._llm is not None:
+                metadata[RUNTIME_KEY] = RuntimeContext(
+                    llm=self._llm,
+                    tools=tuple(self._tools),
+                    memory=self._memory,
+                    budget=self._budget,
+                    system_prompt=self._system_prompt,
+                )
+            state = AgentState(
+                run_id=ctx.run_id,
+                task=task,
+                metadata=metadata,
+            )
             try:
                 await self._strategy.run(state)
             except BudgetExceeded:

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -188,13 +188,22 @@ class Agent:
         started_ms = time.monotonic()
         finish_reason: FinishReason = "completed"
         try:
+            # Construct a fresh BudgetPolicy per run so per-run mutable
+            # state (spent_usd, iteration, error_streak) doesn't leak
+            # across runs of the same Agent instance.
+            run_budget = BudgetPolicy(
+                usd=self._budget.usd,
+                max_tokens=self._budget.max_tokens,
+                max_iterations=self._budget.max_iterations,
+                error_streak_limit=self._budget.error_streak_limit,
+            )
             metadata: dict[str, object] = {}
             if self._llm is not None:
                 metadata[RUNTIME_KEY] = RuntimeContext(
                     llm=self._llm,
                     tools=tuple(self._tools),
                     memory=self._memory,
-                    budget=self._budget,
+                    budget=run_budget,
                     system_prompt=self._system_prompt,
                 )
             state = AgentState(
@@ -220,7 +229,7 @@ class Agent:
             result = RunResult(
                 output=output,
                 steps=tuple(state.steps),
-                cost_usd=self._budget.spent_usd,
+                cost_usd=run_budget.spent_usd,
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
                 run_id=ctx.run_id,

--- a/packages/agentforge/src/agentforge/resolver_register.py
+++ b/packages/agentforge/src/agentforge/resolver_register.py
@@ -1,0 +1,23 @@
+"""Registration helpers for shipped strategies / providers / etc.
+
+Thin wrappers over `agentforge_core.resolver.register` that the
+runtime package uses to register its built-in implementations
+under canonical names. Strategy authors writing custom loops
+should use `agentforge_core.resolver.register` directly; these
+helpers exist so the runtime's registrations sit alongside their
+class definitions for readability.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from agentforge_core.resolver import register
+
+T = TypeVar("T", bound=type)
+
+
+def register_strategy(name: str) -> Callable[[T], T]:
+    """Register a class under `(strategies, name)` in the global resolver."""
+    return register("strategies", name)

--- a/packages/agentforge/src/agentforge/runtime.py
+++ b/packages/agentforge/src/agentforge/runtime.py
@@ -1,0 +1,46 @@
+"""`RuntimeContext` — per-run execution context shared with strategies.
+
+Lives in `agentforge` (not `agentforge-core`) because it references
+the framework's runtime concerns — `BudgetPolicy`, the active
+`LLMClient`, the agent's tool catalogue, the active `MemoryStore`.
+`agentforge-core` defines those contracts; `agentforge` consumes
+them.
+
+`Agent.run()` constructs a `RuntimeContext` per run and stores it
+on `state.metadata` under `RUNTIME_KEY`. Strategies access it via
+`agentforge.strategies._base.get_runtime(state)`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.production.budget import BudgetPolicy
+
+RUNTIME_KEY = "__agentforge_runtime__"
+"""Documented key under `AgentState.metadata` where the runtime is bound."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContext:
+    """Per-run execution context.
+
+    Constructed by `Agent.run()` once per run and bound to
+    `state.metadata[RUNTIME_KEY]`. Strategies read via
+    `get_runtime(state)`.
+
+    Frozen — once bound, the context does not change for the
+    duration of the run. `BudgetPolicy` is itself mutable (the
+    strategy calls `.check()`, `.reserve()`, `.commit()`); the
+    immutability here is on the *binding*, not on the budget's
+    internal counters.
+    """
+
+    llm: LLMClient
+    tools: tuple[Tool, ...]
+    memory: MemoryStore
+    budget: BudgetPolicy
+    system_prompt: str | None = None

--- a/packages/agentforge/src/agentforge/strategies/__init__.py
+++ b/packages/agentforge/src/agentforge/strategies/__init__.py
@@ -1,17 +1,6 @@
 """Reasoning strategies — ReAct, Plan-Execute, Tree-of-Thoughts, Multi-Agent.
 
 All four shipped stable from v0.1 per feat-002 / ADR-0008.
-
-Concrete implementations land in subsequent feat-002 chunks:
-
-- `ReActLoop` — chunk 2
-- `PlanExecuteLoop` — chunk 3
-- `TreeOfThoughts` — chunk 4
-- `MultiAgentSupervisor` — chunk 5
-
-Chunk 1 (this commit) ships only `_StrategyBase` and the
-`get_runtime` helper that strategies use to access the per-run
-execution context.
 """
 
 from __future__ import annotations
@@ -21,11 +10,13 @@ from agentforge.strategies._base import (
     get_runtime,
 )
 from agentforge.strategies._plan import Plan, PlanStep
+from agentforge.strategies.multi_agent import MultiAgentSupervisor
 from agentforge.strategies.plan_execute import PlanExecuteLoop
 from agentforge.strategies.react import ReActLoop
 from agentforge.strategies.tot import TreeOfThoughts
 
 __all__ = [
+    "MultiAgentSupervisor",
     "Plan",
     "PlanExecuteLoop",
     "PlanStep",

--- a/packages/agentforge/src/agentforge/strategies/__init__.py
+++ b/packages/agentforge/src/agentforge/strategies/__init__.py
@@ -20,9 +20,14 @@ from agentforge.strategies._base import (
     StrategyBase,
     get_runtime,
 )
+from agentforge.strategies._plan import Plan, PlanStep
+from agentforge.strategies.plan_execute import PlanExecuteLoop
 from agentforge.strategies.react import ReActLoop
 
 __all__ = [
+    "Plan",
+    "PlanExecuteLoop",
+    "PlanStep",
     "ReActLoop",
     "StrategyBase",
     "get_runtime",

--- a/packages/agentforge/src/agentforge/strategies/__init__.py
+++ b/packages/agentforge/src/agentforge/strategies/__init__.py
@@ -1,0 +1,27 @@
+"""Reasoning strategies — ReAct, Plan-Execute, Tree-of-Thoughts, Multi-Agent.
+
+All four shipped stable from v0.1 per feat-002 / ADR-0008.
+
+Concrete implementations land in subsequent feat-002 chunks:
+
+- `ReActLoop` — chunk 2
+- `PlanExecuteLoop` — chunk 3
+- `TreeOfThoughts` — chunk 4
+- `MultiAgentSupervisor` — chunk 5
+
+Chunk 1 (this commit) ships only `_StrategyBase` and the
+`get_runtime` helper that strategies use to access the per-run
+execution context.
+"""
+
+from __future__ import annotations
+
+from agentforge.strategies._base import (
+    StrategyBase,
+    get_runtime,
+)
+
+__all__ = [
+    "StrategyBase",
+    "get_runtime",
+]

--- a/packages/agentforge/src/agentforge/strategies/__init__.py
+++ b/packages/agentforge/src/agentforge/strategies/__init__.py
@@ -20,8 +20,10 @@ from agentforge.strategies._base import (
     StrategyBase,
     get_runtime,
 )
+from agentforge.strategies.react import ReActLoop
 
 __all__ = [
+    "ReActLoop",
     "StrategyBase",
     "get_runtime",
 ]

--- a/packages/agentforge/src/agentforge/strategies/__init__.py
+++ b/packages/agentforge/src/agentforge/strategies/__init__.py
@@ -23,6 +23,7 @@ from agentforge.strategies._base import (
 from agentforge.strategies._plan import Plan, PlanStep
 from agentforge.strategies.plan_execute import PlanExecuteLoop
 from agentforge.strategies.react import ReActLoop
+from agentforge.strategies.tot import TreeOfThoughts
 
 __all__ = [
     "Plan",
@@ -30,5 +31,6 @@ __all__ = [
     "PlanStep",
     "ReActLoop",
     "StrategyBase",
+    "TreeOfThoughts",
     "get_runtime",
 ]

--- a/packages/agentforge/src/agentforge/strategies/_base.py
+++ b/packages/agentforge/src/agentforge/strategies/_base.py
@@ -149,10 +149,14 @@ class StrategyBase(ReasoningStrategy):
         runtime.budget.commit(response.cost_usd, response.usage.total)
         runtime.budget.increment_iteration()
 
-        # Record success unless the response contained a tool error
-        # (tool dispatch happens elsewhere; LLM calls themselves don't
-        # increment the error streak).
-        runtime.budget.record_success()
+        # Deliberately do NOT call record_success() here — the
+        # error_streak tracks tool-execution failures across
+        # iterations, not LLM-call success. Resetting on every LLM
+        # call would make the streak counter useless: every iteration
+        # would start with a streak reset, so a broken tool that
+        # always errors would never accumulate enough errors to trip
+        # the cap. Strategies call record_success() / record_error()
+        # around tool dispatches themselves.
 
         # Append the LLM-call step to the trace.
         self._record_step(

--- a/packages/agentforge/src/agentforge/strategies/_base.py
+++ b/packages/agentforge/src/agentforge/strategies/_base.py
@@ -1,0 +1,169 @@
+"""`StrategyBase` — shared helpers every shipped strategy inherits from.
+
+Concrete strategies (ReAct, Plan-Execute, Tree-of-Thoughts,
+Multi-Agent) inherit `StrategyBase` and implement `run(state)`.
+The base class provides the three operations every strategy
+performs at LLM-call boundaries:
+
+  - `_check_guardrails(state)` — `BudgetPolicy.check()` plus
+    iteration accounting. Required before every LLM call by the
+    `ReasoningStrategy` invariant; the conformance suite verifies
+    via AST inspection that every shipped strategy calls this
+    inside its main loop.
+  - `_record_step(state, kind, content, **kwargs)` — append a
+    `Step` to `state.steps` with consistent shape.
+  - `_call_llm(state, system, messages, tools=None)` —
+    guardrail-check → LLM call → record cost on the budget →
+    record `think` step → return `LLMResponse`.
+
+The class is named `StrategyBase` (no underscore) because it is
+part of the framework's *internal* public surface — strategy
+authors who write custom loops are encouraged to inherit from it
+to get conformance for free. (External-to-framework name without
+the underscore makes it discoverable; the class is exported from
+`agentforge.strategies`.)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import abstractmethod
+
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import LLMResponse, Message, ToolSpec
+from agentforge_core.values.state import AgentState, Step, StepKind
+
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+
+log = logging.getLogger(__name__)
+
+
+def get_runtime(state: AgentState) -> RuntimeContext:
+    """Return the `RuntimeContext` bound on `state.metadata`.
+
+    `Agent.run()` populates this before calling `strategy.run(state)`.
+    Strategies that bypass `Agent.run()` (e.g. unit tests) must bind
+    a context manually via `state.metadata[RUNTIME_KEY] = ...`.
+
+    Raises:
+        RuntimeError: no runtime context is bound (the strategy was
+            invoked outside of `Agent.run()` and no test fixture set
+            one up).
+    """
+    rt = state.metadata.get(RUNTIME_KEY)
+    if rt is None:
+        raise RuntimeError(
+            "AgentState has no RuntimeContext bound. Strategies should "
+            "be invoked via Agent.run(); tests that drive strategy.run() "
+            "directly must set state.metadata[RUNTIME_KEY] = "
+            "RuntimeContext(...) first."
+        )
+    if not isinstance(rt, RuntimeContext):
+        raise TypeError(
+            f"state.metadata[{RUNTIME_KEY}!r] is not a RuntimeContext: got {type(rt).__name__}"
+        )
+    return rt
+
+
+class StrategyBase(ReasoningStrategy):
+    """Abstract base for shipped reasoning strategies.
+
+    Provides the budget-aware LLM-call helper, step recording, and
+    guardrail-check primitive used by every strategy. Subclasses
+    implement `run(state)`.
+    """
+
+    @abstractmethod
+    async def run(self, state: AgentState) -> AgentState: ...
+
+    # ----------------------------------------------------------------
+    # Helpers — every concrete strategy uses these.
+    # ----------------------------------------------------------------
+
+    def _check_guardrails(self, state: AgentState) -> None:
+        """Run all per-iteration guardrail checks.
+
+        Called before every LLM call. Raises `BudgetExceeded` /
+        `GuardrailViolation` if a cap is breached. The conformance
+        suite verifies via AST inspection that every concrete
+        strategy class invokes this method inside its main loop.
+        """
+        runtime = get_runtime(state)
+        runtime.budget.check()
+
+    def _record_step(
+        self,
+        state: AgentState,
+        *,
+        iteration: int,
+        kind: StepKind,
+        content: str | dict[str, object],
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        cost_usd: float = 0.0,
+        duration_ms: int = 0,
+        tool_call: object | None = None,
+    ) -> Step:
+        """Append a `Step` to `state.steps` with consistent shape."""
+        step = Step(
+            iteration=iteration,
+            kind=kind,
+            content=content,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+            duration_ms=duration_ms,
+            tool_call=tool_call,  # type: ignore[arg-type]
+        )
+        state.steps.append(step)
+        return step
+
+    async def _call_llm(
+        self,
+        state: AgentState,
+        *,
+        iteration: int,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+        kind: StepKind = "think",
+    ) -> LLMResponse:
+        """Guardrail-check → LLM call → record cost → record step.
+
+        Centralises the four operations every shipped strategy
+        performs at LLM-call boundaries. The conformance suite
+        treats a class that uses this helper as having satisfied
+        the guardrail-call invariant.
+        """
+        self._check_guardrails(state)
+        runtime = get_runtime(state)
+        llm: LLMClient = runtime.llm
+
+        started_ms = time.monotonic()
+        response = await llm.call(system=system, messages=messages, tools=tools)
+        duration_ms = int((time.monotonic() - started_ms) * 1000)
+
+        # Record cost on the shared BudgetPolicy.
+        runtime.budget.commit(response.cost_usd, response.usage.total)
+        runtime.budget.increment_iteration()
+
+        # Record success unless the response contained a tool error
+        # (tool dispatch happens elsewhere; LLM calls themselves don't
+        # increment the error streak).
+        runtime.budget.record_success()
+
+        # Append the LLM-call step to the trace.
+        self._record_step(
+            state,
+            iteration=iteration,
+            kind=kind,
+            content=response.content,
+            tokens_in=response.usage.input_tokens,
+            tokens_out=response.usage.output_tokens,
+            cost_usd=response.cost_usd,
+            duration_ms=duration_ms,
+        )
+
+        return response

--- a/packages/agentforge/src/agentforge/strategies/_plan.py
+++ b/packages/agentforge/src/agentforge/strategies/_plan.py
@@ -1,0 +1,93 @@
+"""`Plan` + `PlanStep` value types and topological-sort helper.
+
+Used by `PlanExecuteLoop` (feat-002 chunk 3). The plan is a typed
+Pydantic model so the LLM's JSON output is validated at parse time;
+cycle and dangling-dependency detection are enforced by a
+`model_validator` and `_topological_batches`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class PlanStep(BaseModel):
+    """One step in a `Plan`.
+
+    Attributes:
+        id: Stable identifier; `depends_on` references this.
+        description: Natural-language description of what the step does.
+        tool: Name of a registered tool to invoke. `None` means a
+            "think" step — an LLM call reasoning about `description`
+            in the context of prior step outputs.
+        arguments: Keyword arguments passed to the tool's `run()`. Only
+            used when `tool` is not `None`.
+        depends_on: List of `PlanStep.id`s that must complete before
+            this step executes. Empty list = step is independent.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str = Field(min_length=1)
+    description: str
+    tool: str | None = None
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    depends_on: list[str] = Field(default_factory=list)
+
+
+class Plan(BaseModel):
+    """A topologically valid execution plan."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    steps: list[PlanStep] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate(self) -> Plan:
+        ids = [step.id for step in self.steps]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Plan step ids must be unique")
+        id_set = set(ids)
+        for step in self.steps:
+            for dep in step.depends_on:
+                if dep not in id_set:
+                    raise ValueError(
+                        f"step {step.id!r} depends_on={dep!r} which is not a plan step id"
+                    )
+            if step.id in step.depends_on:
+                raise ValueError(f"step {step.id!r} depends on itself")
+        # Cycle detection — _topological_batches raises if a cycle exists.
+        _topological_batches(self.steps)
+        return self
+
+
+def _topological_batches(steps: list[PlanStep]) -> list[list[PlanStep]]:
+    """Group `steps` into a list of batches.
+
+    Each batch contains steps whose `depends_on` set is fully covered
+    by completed (earlier-batch) steps. Steps within a batch have no
+    dependencies on each other and may run concurrently.
+
+    Raises:
+        ValueError: a cycle exists in the dependency graph.
+    """
+    by_id = {step.id: step for step in steps}
+    remaining: dict[str, set[str]] = {s.id: set(s.depends_on) for s in steps}
+    completed: set[str] = set()
+    batches: list[list[PlanStep]] = []
+
+    while remaining:
+        ready_ids = [sid for sid, deps in remaining.items() if deps.issubset(completed)]
+        if not ready_ids:
+            unsorted = sorted(remaining.keys())
+            raise ValueError(
+                f"Cycle in plan dependencies; cannot order remaining steps: {unsorted}"
+            )
+        batches.append([by_id[sid] for sid in ready_ids])
+        completed.update(ready_ids)
+        for sid in ready_ids:
+            del remaining[sid]
+
+    return batches

--- a/packages/agentforge/src/agentforge/strategies/multi_agent.py
+++ b/packages/agentforge/src/agentforge/strategies/multi_agent.py
@@ -1,0 +1,460 @@
+"""`MultiAgentSupervisor` — supervisor delegates to worker strategies.
+
+Per feat-002 §4.4:
+
+  PHASE 1 — DELEGATE
+    Supervisor LLM call decides which workers to invoke and what
+    subtask each should solve. Returns a typed `_DelegationPlan`
+    (Pydantic) listing one `_WorkerAssignment(worker, task)` per
+    invocation. Unknown worker names are dropped with a logged
+    warning rather than crashing the run.
+
+  PHASE 2 — EXECUTE WORKERS
+    Workers run concurrently (asyncio.Semaphore caps at
+    `max_parallel_workers`). Each worker receives:
+      - A fresh `AgentState` with a derived `run_id`
+        (`"{parent_run_id}/{worker}-{idx}"`) and its own
+        sub-`task` from the assignment
+      - A sub-`RuntimeContext` with a *proportional* `BudgetPolicy`:
+        the parent's *remaining* USD is split evenly among workers
+        in this batch (so collective worker spend cannot exceed the
+        parent's remaining budget)
+      - The shared parent `MemoryStore` (workers can publish
+        findings to the same store)
+
+    Per-worker spend is committed back to the parent budget after
+    the worker finishes (`parent.budget.commit(worker_spend)`),
+    keeping accounting accurate at the supervisor level.
+
+    Worker exceptions are caught and recorded as a `delegate` step
+    with `metadata={"error": ...}`; the supervisor continues with
+    surviving worker outputs.
+
+  PHASE 3 — AGGREGATE
+    Supervisor LLM call synthesises worker outputs into the final
+    answer. If zero workers produced output (all errored, or
+    delegation plan was empty), the supervisor synthesises directly
+    from the original task.
+
+Modern: structured Pydantic delegation plan (no free-form parsing);
+proportional budget split with parent-budget reconciliation;
+graceful degradation on worker failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.values.messages import Message
+from agentforge_core.values.state import AgentState
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from agentforge.resolver_register import register_strategy
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies._base import StrategyBase, get_runtime
+
+log = logging.getLogger(__name__)
+
+DELEGATE_SYSTEM_PROMPT = (
+    "You are a supervisor coordinating specialist worker agents. The "
+    "available workers are listed below with short descriptions. Decide "
+    "which workers to invoke and what subtask each should solve. Return "
+    "ONLY a JSON object matching this schema (no other text):\n\n"
+    '  {{"assignments": [{{"worker": "<name>", "task": "<subtask text>"}}, ...]}}\n\n'
+    "Workers available:\n{worker_catalog}\n\n"
+    "Rules:\n"
+    "- Only assign workers from the list above (case-sensitive).\n"
+    "- Each subtask should be self-contained; workers do not see each "
+    "other's outputs.\n"
+    "- Prefer parallel independent subtasks. You may assign the same "
+    "worker more than once if it makes sense."
+)
+
+AGGREGATE_SYSTEM_PROMPT = (
+    "You are a supervisor synthesising the final answer from your "
+    "workers' outputs. Read the user's task and the per-worker results "
+    "below, then produce a clear, complete answer to the original task. "
+    "Do not introduce claims unsupported by the worker outputs."
+)
+
+
+# ----------------------------------------------------------------------
+# LLM I/O schemas
+# ----------------------------------------------------------------------
+
+
+class _WorkerAssignment(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    worker: str = Field(min_length=1)
+    task: str = Field(min_length=1)
+
+
+class _DelegationPlan(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    assignments: list[_WorkerAssignment] = Field(default_factory=list)
+
+
+# ----------------------------------------------------------------------
+# Worker output
+# ----------------------------------------------------------------------
+
+
+class _WorkerResult(BaseModel):
+    """Result of one worker invocation, recorded as a `delegate` step."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+    worker: str
+    task: str
+    output: str = ""
+    error: str | None = None
+    cost_usd: float = 0.0
+
+
+# ----------------------------------------------------------------------
+# Strategy
+# ----------------------------------------------------------------------
+
+
+@register_strategy("multi-agent")
+class MultiAgentSupervisor(StrategyBase):
+    """Supervisor that delegates subtasks to worker strategies.
+
+    Per feat-002 §4.2 the constructor surface is locked at v0.1:
+
+    Args:
+        workers: Mapping from worker name (used in the delegation
+            plan) to a `ReasoningStrategy` instance that solves the
+            subtask. The same strategy class can appear under
+            different names (e.g. `"researcher"` and `"summariser"`
+            both `ReActLoop`s with different system prompts in
+            future). Required and non-empty.
+        max_parallel_workers: Max workers that may run concurrently.
+            Default 4.
+        max_rounds: Number of delegation rounds. Default 1 (one
+            delegation + one aggregation). Multi-round delegation
+            (supervisor revises plan after seeing partial results)
+            is reserved for v0.2.
+        worker_descriptions: Optional human-readable descriptions
+            shown to the supervisor LLM in the delegation prompt.
+            Maps worker name → description. Workers not in the dict
+            get a generic "general-purpose worker" description.
+    """
+
+    def __init__(
+        self,
+        *,
+        workers: dict[str, ReasoningStrategy],
+        max_parallel_workers: int = 4,
+        max_rounds: int = 1,
+        worker_descriptions: dict[str, str] | None = None,
+    ) -> None:
+        if not workers:
+            raise ValueError("workers must be a non-empty dict")
+        for name in workers:
+            if not name or not isinstance(name, str):
+                raise ValueError(f"worker name must be a non-empty string, got {name!r}")
+        if max_parallel_workers < 1:
+            raise ValueError("max_parallel_workers must be >= 1")
+        if max_rounds < 1:
+            raise ValueError("max_rounds must be >= 1")
+        self._workers = dict(workers)
+        self._max_parallel_workers = max_parallel_workers
+        self._max_rounds = max_rounds
+        self._worker_descriptions = dict(worker_descriptions or {})
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = get_runtime(state)
+        round_idx = 0
+        all_results: list[_WorkerResult] = []
+
+        while round_idx < self._max_rounds:
+            self._check_guardrails(state)
+
+            # PHASE 1 — DELEGATE
+            plan = await self._delegate(state, round_idx, prior=all_results)
+            assignments = self._filter_assignments(plan.assignments)
+            if not assignments:
+                log.info(
+                    "MultiAgentSupervisor: round %d produced no valid "
+                    "assignments; proceeding to aggregation.",
+                    round_idx,
+                )
+                break
+
+            # PHASE 2 — EXECUTE WORKERS (proportional budget split)
+            results = await self._execute_workers(state, runtime, assignments, round_idx=round_idx)
+            all_results.extend(results)
+            round_idx += 1
+
+            if not any(r.error is None for r in results):
+                # Every worker failed in this round; nothing useful to
+                # iterate on. Bail out to aggregation rather than
+                # spinning the supervisor on the same failure.
+                log.warning(
+                    "MultiAgentSupervisor: every worker errored in round "
+                    "%d; aggregating with no successful outputs.",
+                    round_idx - 1,
+                )
+                break
+
+        # PHASE 3 — AGGREGATE
+        await self._aggregate(state, round_idx + 1, all_results)
+        return state
+
+    # ------------------------------------------------------------------
+    # Phase 1 — delegate
+    # ------------------------------------------------------------------
+
+    async def _delegate(
+        self,
+        state: AgentState,
+        round_idx: int,
+        *,
+        prior: list[_WorkerResult],
+    ) -> _DelegationPlan:
+        """Ask the supervisor LLM for a delegation plan."""
+        catalog = "\n".join(
+            f"  - {name}: {self._worker_descriptions.get(name, 'general-purpose worker')}"
+            for name in self._workers
+        )
+        prompt = DELEGATE_SYSTEM_PROMPT.format(worker_catalog=catalog)
+        messages: list[Message] = [Message(role="user", content=state.task)]
+        if prior:
+            prior_text = "\n".join(
+                f"- {r.worker}: {r.output if r.error is None else f'ERROR: {r.error}'}"
+                for r in prior
+            )
+            messages.append(
+                Message(
+                    role="assistant",
+                    content=f"Prior worker outputs from earlier rounds:\n{prior_text}",
+                )
+            )
+        response = await self._call_llm(
+            state,
+            iteration=round_idx + 1,
+            system=prompt,
+            messages=messages,
+            kind="plan",
+        )
+        try:
+            return _DelegationPlan.model_validate_json(_strip_code_fences(response.content))
+        except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+            log.warning(
+                "MultiAgentSupervisor: delegation plan parse failed at round %d: %s",
+                round_idx,
+                exc,
+            )
+            return _DelegationPlan(assignments=[])
+
+    def _filter_assignments(self, assignments: list[_WorkerAssignment]) -> list[_WorkerAssignment]:
+        """Drop assignments referring to unknown workers (logged)."""
+        kept: list[_WorkerAssignment] = []
+        for a in assignments:
+            if a.worker in self._workers:
+                kept.append(a)
+            else:
+                log.warning(
+                    "MultiAgentSupervisor: dropping assignment for unknown worker %r",
+                    a.worker,
+                )
+        return kept
+
+    # ------------------------------------------------------------------
+    # Phase 2 — execute workers
+    # ------------------------------------------------------------------
+
+    async def _execute_workers(
+        self,
+        state: AgentState,
+        runtime: RuntimeContext,
+        assignments: list[_WorkerAssignment],
+        *,
+        round_idx: int,
+    ) -> list[_WorkerResult]:
+        """Run all assigned workers in parallel under a semaphore."""
+        per_worker_budget = self._derive_per_worker_budget(runtime.budget, len(assignments))
+        sem = asyncio.Semaphore(self._max_parallel_workers)
+
+        async def _one(idx: int, assignment: _WorkerAssignment) -> _WorkerResult:
+            async with sem:
+                return await self._run_worker(
+                    state,
+                    runtime,
+                    assignment,
+                    sub_budget_usd=per_worker_budget,
+                    idx=idx,
+                )
+
+        results = await asyncio.gather(
+            *(_one(i, a) for i, a in enumerate(assignments)),
+            return_exceptions=False,
+        )
+        # Record one `delegate` step per worker outcome.
+        for r in results:
+            content: dict[str, object] = {
+                "worker": r.worker,
+                "task": r.task,
+                "output": r.output,
+                "cost_usd": r.cost_usd,
+            }
+            if r.error is not None:
+                content["error"] = r.error
+            self._record_step(
+                state,
+                iteration=round_idx + 1,
+                kind="delegate",
+                content=content,
+                cost_usd=r.cost_usd,
+            )
+        return list(results)
+
+    def _derive_per_worker_budget(self, parent: BudgetPolicy, n_workers: int) -> float:
+        """Split the parent's *remaining* USD evenly among workers."""
+        if n_workers <= 0:
+            return 0.0
+        return parent.remaining_usd() / n_workers
+
+    async def _run_worker(
+        self,
+        state: AgentState,
+        runtime: RuntimeContext,
+        assignment: _WorkerAssignment,
+        *,
+        sub_budget_usd: float,
+        idx: int,
+    ) -> _WorkerResult:
+        """Run a single worker with a sub-RuntimeContext.
+
+        On exception, returns a `_WorkerResult` with `error` populated
+        rather than propagating — the supervisor's contract is to keep
+        running with surviving workers.
+        """
+        worker = self._workers[assignment.worker]
+        sub_budget = BudgetPolicy(
+            usd=sub_budget_usd,
+            max_tokens=runtime.budget.max_tokens,
+            max_iterations=runtime.budget.max_iterations,
+            error_streak_limit=runtime.budget.error_streak_limit,
+        )
+        sub_runtime = RuntimeContext(
+            llm=runtime.llm,
+            tools=runtime.tools,
+            memory=runtime.memory,
+            budget=sub_budget,
+            system_prompt=runtime.system_prompt,
+        )
+        sub_run_id = f"{state.run_id}/{assignment.worker}-{idx}"
+        sub_state = AgentState(
+            run_id=sub_run_id,
+            task=assignment.task,
+            metadata={RUNTIME_KEY: sub_runtime},
+        )
+        try:
+            await worker.run(sub_state)
+        except Exception as exc:
+            # Roll the worker's spend back into the parent budget even on failure.
+            runtime.budget.commit(sub_budget.spent_usd, sub_budget.consumed_tokens)
+            log.warning(
+                "MultiAgentSupervisor: worker %r failed on subtask %r: %s",
+                assignment.worker,
+                assignment.task,
+                exc,
+            )
+            return _WorkerResult(
+                worker=assignment.worker,
+                task=assignment.task,
+                output="",
+                error=f"{type(exc).__name__}: {exc}",
+                cost_usd=sub_budget.spent_usd,
+            )
+
+        # Reconcile the sub-budget's spend into the parent budget. The
+        # _call_llm helper already committed against `sub_budget`; we
+        # mirror that into the parent so the supervisor's accounting is
+        # accurate (and so subsequent rounds see the spend).
+        runtime.budget.commit(sub_budget.spent_usd, sub_budget.consumed_tokens)
+
+        output = _extract_output(sub_state)
+        return _WorkerResult(
+            worker=assignment.worker,
+            task=assignment.task,
+            output=output,
+            error=None,
+            cost_usd=sub_budget.spent_usd,
+        )
+
+    # ------------------------------------------------------------------
+    # Phase 3 — aggregate
+    # ------------------------------------------------------------------
+
+    async def _aggregate(
+        self,
+        state: AgentState,
+        iteration: int,
+        results: list[_WorkerResult],
+    ) -> None:
+        """Synthesise worker outputs into a final answer."""
+        if results:
+            results_text = "\n\n".join(
+                f"--- {r.worker} ({'OK' if r.error is None else 'ERROR'}) ---\n"
+                f"Task: {r.task}\n"
+                f"Output: {r.output if r.error is None else r.error}"
+                for r in results
+            )
+            assistant_msg = Message(role="assistant", content=f"Worker outputs:\n{results_text}")
+            messages: list[Message] = [
+                Message(role="user", content=state.task),
+                assistant_msg,
+            ]
+        else:
+            messages = [Message(role="user", content=state.task)]
+
+        await self._call_llm(
+            state,
+            iteration=iteration,
+            system=AGGREGATE_SYSTEM_PROMPT,
+            messages=messages,
+            kind="synthesize",
+        )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _extract_output(sub_state: AgentState) -> str:
+    """Pull the final text output from a worker's sub-state.
+
+    Workers terminate with a `synthesize` or `think` step; we take the
+    last step's textual content as the worker's output.
+    """
+    if not sub_state.steps:
+        return ""
+    last = sub_state.steps[-1]
+    content = last.content
+    if isinstance(content, str):
+        return content
+    return json.dumps(content)
+
+
+def _strip_code_fences(content: str) -> str:
+    """Strip ```json ... ``` fences if the LLM wrapped the JSON in them."""
+    text = content.strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline == -1:
+            return text
+        body = text[first_newline + 1 :]
+        if body.endswith("```"):
+            body = body[: -len("```")]
+        return body.strip()
+    return text
+
+
+__all__ = ["MultiAgentSupervisor"]

--- a/packages/agentforge/src/agentforge/strategies/plan_execute.py
+++ b/packages/agentforge/src/agentforge/strategies/plan_execute.py
@@ -1,0 +1,388 @@
+"""`PlanExecuteLoop` — modern plan-and-solve strategy.
+
+Per feat-002 §4.3:
+
+  PHASE 1 — PLAN
+    LLM call returns a typed `Plan(steps=[...])` as JSON. Validated
+    via Pydantic; cycles and dangling deps caught at parse time. On
+    invalid plan: optional re-plan with the error fed back, up to
+    `max_replans` retries.
+
+  PHASE 2 — EXECUTE (topological batches)
+    Steps grouped into batches by dependencies. Each batch runs
+    concurrently (asyncio.Semaphore caps at `max_parallel_steps`).
+    Tool steps invoke the named tool; "think" steps (tool=None) make
+    one LLM call about the step description.
+
+  PHASE 3 — SYNTHESIZE
+    Final LLM call: observations[] → final answer.
+
+Modern: structured Pydantic plan instead of free-form JSON parsing.
+The LLM is asked to emit JSON matching the schema; validation errors
+are recoverable via re-plan rather than crashing the run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.messages import Message
+from agentforge_core.values.state import AgentState
+from pydantic import ValidationError
+
+from agentforge.resolver_register import register_strategy
+from agentforge.strategies._base import StrategyBase, get_runtime
+from agentforge.strategies._plan import Plan, PlanStep, _topological_batches
+
+PLAN_SYSTEM_PROMPT = (
+    "You are a planning assistant. Decompose the user's task into a "
+    "structured execution plan. Return ONLY a JSON object matching this "
+    "schema (no other text):\n\n"
+    '  {"steps": ['
+    '{"id": "<unique id>", '
+    '"description": "<what this step does>", '
+    '"tool": "<tool name or null>", '
+    '"arguments": {<keyword args for the tool>}, '
+    '"depends_on": [<earlier step ids>]'
+    "}, ...]}\n\n"
+    "Rules:\n"
+    "- Each step.id must be unique within the plan.\n"
+    "- depends_on must reference earlier step ids only.\n"
+    "- Steps with tool=null are think-only; an LLM will reason about "
+    "the description.\n"
+    "- Keep the plan concise; prefer parallelisable independent steps."
+)
+
+SYNTHESIS_SYSTEM_PROMPT = (
+    "You synthesize a final answer from a structured execution trace. "
+    "Read the user's task and the per-step observations, then produce "
+    "a clear, complete answer to the original task."
+)
+
+
+@register_strategy("plan-execute")
+class PlanExecuteLoop(StrategyBase):
+    """Plan-and-solve loop with topological execution and re-planning.
+
+    Per feat-002 §4.2 the constructor surface is locked at v0.1:
+
+    Args:
+        max_parallel_steps: Max steps that may execute concurrently
+            within a batch. Default 4. Defends against tool fan-out
+            blowing past resource limits.
+        replan_on_failure: When a step raises during execution, ask
+            the LLM to re-plan from scratch with the error context.
+            Default True.
+        max_replans: Maximum number of full re-plan cycles. Default 1
+            (one initial plan + one re-plan).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_parallel_steps: int = 4,
+        replan_on_failure: bool = True,
+        max_replans: int = 1,
+    ) -> None:
+        if max_parallel_steps < 1:
+            raise ValueError("max_parallel_steps must be >= 1")
+        if max_replans < 0:
+            raise ValueError("max_replans must be >= 0")
+        self._max_parallel_steps = max_parallel_steps
+        self._replan_on_failure = replan_on_failure
+        self._max_replans = max_replans
+
+    async def run(self, state: AgentState) -> AgentState:
+        # Verify the runtime is bound (raises clear error otherwise);
+        # actual access happens in helpers via `get_runtime(state)`.
+        get_runtime(state)
+        replans = 0
+        plan_messages: list[Message] = [Message(role="user", content=state.task)]
+
+        while True:
+            # PHASE 1 — Plan (with retry on parse / validation failure)
+            plan = await self._build_plan(state, plan_messages, replans_done=replans)
+            self._record_step(
+                state,
+                iteration=0,
+                kind="plan",
+                content={"steps": [step.model_dump() for step in plan.steps]},
+            )
+
+            # PHASE 2 — Execute
+            try:
+                observations = await self._execute_plan(state, plan)
+                break
+            except _StepFailure as failure:
+                if not self._replan_on_failure or replans >= self._max_replans:
+                    # Surface the failure as a final observation; don't crash.
+                    observations = failure.observations_so_far
+                    self._record_step(
+                        state,
+                        iteration=len(plan.steps),
+                        kind="observe",
+                        content=(
+                            f"Plan execution failed at step {failure.failed_step.id!r}: "
+                            f"{failure.error}. No further re-plan attempts."
+                        ),
+                    )
+                    break
+                replans += 1
+                # Feed the failure context back so the LLM can revise the plan.
+                plan_messages.append(Message(role="assistant", content=plan.model_dump_json()))
+                plan_messages.append(
+                    Message(
+                        role="user",
+                        content=(
+                            f"The plan failed at step {failure.failed_step.id!r} "
+                            f"({failure.failed_step.description!r}): {failure.error}. "
+                            f"Please re-plan."
+                        ),
+                    )
+                )
+
+        # PHASE 3 — Synthesize
+        synth_messages: list[Message] = [
+            Message(role="user", content=state.task),
+            Message(
+                role="assistant",
+                content=(
+                    "Plan executed with the following observations:\n"
+                    + "\n".join(f"- {step_id}: {obs}" for step_id, obs in observations.items())
+                ),
+            ),
+        ]
+        await self._call_llm(
+            state,
+            iteration=len(plan.steps) + 1,
+            system=SYNTHESIS_SYSTEM_PROMPT,
+            messages=synth_messages,
+            kind="synthesize",
+        )
+
+        return state
+
+    # ------------------------------------------------------------------
+    # Phase helpers
+    # ------------------------------------------------------------------
+
+    async def _build_plan(
+        self,
+        state: AgentState,
+        messages: list[Message],
+        *,
+        replans_done: int,
+    ) -> Plan:
+        """Ask the LLM for a Plan; validate; retry-on-error up to
+        `max_replans` total attempts."""
+        attempts_left = (self._max_replans - replans_done) + 1
+        last_error: str | None = None
+
+        for attempt in range(attempts_left):
+            response = await self._call_llm(
+                state,
+                iteration=0,
+                system=PLAN_SYSTEM_PROMPT,
+                messages=messages,
+                kind="think",
+            )
+            try:
+                return _parse_plan(response.content)
+            except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                last_error = str(exc)
+                if attempt >= attempts_left - 1:
+                    break
+                # Feed the parse error back as user-role correction.
+                messages.append(Message(role="assistant", content=response.content))
+                messages.append(
+                    Message(
+                        role="user",
+                        content=(
+                            f"That plan was invalid: {exc}. "
+                            f"Please return a valid JSON plan matching the schema."
+                        ),
+                    )
+                )
+
+        raise _PlanInvalidError(f"Plan invalid after retries: {last_error}")
+
+    async def _execute_plan(self, state: AgentState, plan: Plan) -> dict[str, str]:
+        """Execute the plan in topological batches.
+
+        Returns a mapping of `step_id -> observation`.
+        Raises `_StepFailure` (caught by `run`) on any step exception
+        when `replan_on_failure` is True; otherwise records the
+        failure as an observation and continues.
+        """
+        runtime = get_runtime(state)
+        batches = _topological_batches(plan.steps)
+        observations: dict[str, str] = {}
+        sem = asyncio.Semaphore(self._max_parallel_steps)
+
+        for batch_idx, batch in enumerate(batches, start=1):
+            self._check_guardrails(state)
+
+            async def execute_one(
+                step: PlanStep, *, batch_idx: int = batch_idx
+            ) -> tuple[PlanStep, str | Exception]:
+                async with sem:
+                    try:
+                        observation = await self._run_step(state, batch_idx=batch_idx, step=step)
+                    except Exception as exc:
+                        return step, exc
+                    return step, observation
+
+            results = await asyncio.gather(*(execute_one(step) for step in batch))
+
+            for step, result in results:
+                if isinstance(result, Exception):
+                    runtime.budget.record_error()
+                    if self._replan_on_failure:
+                        raise _StepFailure(
+                            failed_step=step,
+                            error=f"{type(result).__name__}: {result}",
+                            observations_so_far=observations,
+                        )
+                    error_msg = f"Error: {type(result).__name__}: {result}"
+                    self._record_step(
+                        state,
+                        iteration=batch_idx,
+                        kind="observe",
+                        content=error_msg,
+                    )
+                    observations[step.id] = error_msg
+                else:
+                    runtime.budget.record_success()
+                    observations[step.id] = result
+                    self._record_step(
+                        state,
+                        iteration=batch_idx,
+                        kind="observe",
+                        content={"step_id": step.id, "observation": result},
+                    )
+
+        return observations
+
+    async def _run_step(
+        self,
+        state: AgentState,
+        *,
+        batch_idx: int,
+        step: PlanStep,
+    ) -> str:
+        """Execute one PlanStep. Returns observation text."""
+        runtime = get_runtime(state)
+        started_ms = time.monotonic()
+
+        if step.tool is None:
+            # "Think" step — LLM call about the step's description.
+            response = await self._call_llm(
+                state,
+                iteration=batch_idx,
+                system=(
+                    "You are reasoning about one step of a larger plan. "
+                    "Provide a concise outcome for the step described."
+                ),
+                messages=[Message(role="user", content=step.description)],
+                kind="act",
+            )
+            return response.content
+
+        # Tool step
+        tool = _find_tool(runtime.tools, step.tool)
+        if tool is None:
+            raise _ToolNotFoundError(
+                f"tool {step.tool!r} (referenced by step {step.id!r}) is "
+                f"not registered on the agent"
+            )
+
+        # Record an `act` step for the tool dispatch.
+        self._record_step(
+            state,
+            iteration=batch_idx,
+            kind="act",
+            content={
+                "step_id": step.id,
+                "tool": step.tool,
+                "arguments": step.arguments,
+            },
+        )
+
+        raw = await tool.run(**step.arguments)
+        duration_ms = int((time.monotonic() - started_ms) * 1000)
+        # Note duration is approximate (records before the observe step
+        # is appended); kept on the act step's metadata if needed.
+        del duration_ms
+        return raw if isinstance(raw, str) else str(raw)
+
+
+def _parse_plan(content: str) -> Plan:
+    """Parse JSON-encoded plan from the LLM response."""
+    cleaned = _strip_code_fences(content)
+    return Plan.model_validate_json(cleaned)
+
+
+def _strip_code_fences(content: str) -> str:
+    """Strip ```json ... ``` fences if the LLM wrapped the JSON in them."""
+    text = content.strip()
+    if text.startswith("```"):
+        # Remove leading fence (with optional language tag) and trailing fence.
+        first_newline = text.find("\n")
+        if first_newline == -1:
+            return text
+        body = text[first_newline + 1 :]
+        if body.endswith("```"):
+            body = body[: -len("```")]
+        return body.strip()
+    return text
+
+
+def _find_tool(tools: tuple[Tool, ...], name: str) -> Tool | None:
+    for tool in tools:
+        if type(tool).name == name:
+            return tool
+    return None
+
+
+# ----------------------------------------------------------------------
+# Internal exceptions (caught by run; never raised to callers).
+# ----------------------------------------------------------------------
+
+
+class _PlanInvalidError(Exception):
+    """LLM produced an invalid plan after all retries."""
+
+
+class _ToolNotFoundError(Exception):
+    """A plan step referenced an unregistered tool name."""
+
+
+class _StepFailure(Exception):  # noqa: N818 — internal sentinel, not user-visible
+    """Wraps a step's exception for the run-level retry logic."""
+
+    def __init__(
+        self,
+        *,
+        failed_step: PlanStep,
+        error: str,
+        observations_so_far: dict[str, str],
+    ) -> None:
+        super().__init__(error)
+        self.failed_step = failed_step
+        self.error = error
+        self.observations_so_far = observations_so_far
+
+
+# ----------------------------------------------------------------------
+# Public re-exports.
+# ----------------------------------------------------------------------
+
+
+__all__ = ["Plan", "PlanExecuteLoop", "PlanStep"]
+
+
+_: Any = None  # silence "unused import" for re-exports

--- a/packages/agentforge/src/agentforge/strategies/react.py
+++ b/packages/agentforge/src/agentforge/strategies/react.py
@@ -1,0 +1,127 @@
+"""`ReActLoop` — modern reasoning + acting loop.
+
+Per feat-002 §4.3: a single LLM call per iteration that may return
+zero or more *structured* tool calls. The loop terminates when the
+LLM returns a response with no tool calls (modern Anthropic / OpenAI
+tool-calling pattern — `stop_reason="end_turn"` with empty
+`tool_calls`). No special "finish" tool is needed.
+
+Step shape: each iteration produces one `think` step (the LLM's
+content), one `act` step per tool call, and one `observe` step per
+tool result. Tool-execution errors are surfaced to the LLM as
+observations (counted toward `error_streak_limit`).
+"""
+
+from __future__ import annotations
+
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.messages import Message
+from agentforge_core.values.state import AgentState
+
+from agentforge.resolver_register import register_strategy
+from agentforge.strategies._base import StrategyBase, get_runtime
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a helpful AI assistant. You can use tools when they help "
+    "answer the user's question. Provide a final answer without calling "
+    "tools when you have everything you need."
+)
+
+
+@register_strategy("react")
+class ReActLoop(StrategyBase):
+    """Think → act → observe loop with structured tool calls.
+
+    Per feat-002 §4.2 the constructor surface is locked at v0.1:
+
+    Args:
+        max_iterations: Per-loop iteration cap. If `None`, the
+            strategy uses `BudgetPolicy.max_iterations` from the
+            runtime context. The override applies only to this
+            run; the agent's configured budget caps are preserved.
+    """
+
+    def __init__(self, *, max_iterations: int | None = None) -> None:
+        self._max_iterations_override: int | None = max_iterations
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = get_runtime(state)
+        if self._max_iterations_override is not None:
+            runtime.budget.max_iterations = self._max_iterations_override
+
+        system_prompt = runtime.system_prompt or DEFAULT_SYSTEM_PROMPT
+        tool_specs = [tool.to_spec() for tool in runtime.tools] if runtime.tools else None
+        messages: list[Message] = [Message(role="user", content=state.task)]
+        iteration = 0
+
+        while True:
+            self._check_guardrails(state)
+
+            response = await self._call_llm(
+                state,
+                iteration=iteration,
+                system=system_prompt,
+                messages=messages,
+                tools=tool_specs,
+                kind="think",
+            )
+
+            # Modern termination: no tool calls means the LLM is done.
+            if not response.tool_calls:
+                break
+
+            # Record the assistant's turn for the next iteration's context.
+            messages.append(Message(role="assistant", content=response.content))
+
+            # Dispatch every tool call the LLM emitted.
+            for tool_call in response.tool_calls:
+                self._record_step(
+                    state,
+                    iteration=iteration,
+                    kind="act",
+                    content={
+                        "tool": tool_call.name,
+                        "arguments": tool_call.arguments,
+                    },
+                    tool_call=tool_call,
+                )
+
+                tool = _find_tool(runtime.tools, tool_call.name)
+                if tool is None:
+                    observation = f"Error: tool {tool_call.name!r} is not registered on this agent."
+                    runtime.budget.record_error()
+                else:
+                    try:
+                        raw = await tool.run(**tool_call.arguments)
+                    except Exception as exc:
+                        observation = f"Error: {type(exc).__name__}: {exc}"
+                        runtime.budget.record_error()
+                    else:
+                        observation = raw if isinstance(raw, str) else str(raw)
+                        runtime.budget.record_success()
+
+                self._record_step(
+                    state,
+                    iteration=iteration,
+                    kind="observe",
+                    content=observation,
+                    tool_call=tool_call,
+                )
+                messages.append(
+                    Message(
+                        role="tool",
+                        content=observation,
+                        tool_call_id=tool_call.id,
+                    )
+                )
+
+            iteration += 1
+
+        return state
+
+
+def _find_tool(tools: tuple[Tool, ...], name: str) -> Tool | None:
+    for tool in tools:
+        if type(tool).name == name:
+            return tool
+    return None

--- a/packages/agentforge/src/agentforge/strategies/tot.py
+++ b/packages/agentforge/src/agentforge/strategies/tot.py
@@ -1,0 +1,376 @@
+"""`TreeOfThoughts` — beam-search reasoning with scored branches.
+
+Per feat-002 §4.3:
+
+  GENERATE:  one LLM call returns `branch_factor` candidate thoughts
+             at the current depth.
+  SCORE:     each thought is scored 0..1 by the LLM ("self") or by
+             a cheap judge model ("judge").
+  PRUNE:     keep thoughts above `score_threshold`. If `beam_width`
+             is set, additionally keep only the top-K.
+  EXPAND:    recurse on survivors to depth=`depth`.
+  SYNTHESIZE: best leaf → final answer.
+
+Modern: structured Pydantic schemas for branch generation and
+scoring (no free-form parsing); budget-aware graceful degradation
+(if the next level's estimated cost would exceed the remaining
+budget, the strategy synthesises with what it has rather than
+crashing).
+
+`scorer="judge"` in v0.1 falls back to "self" — a separate cheap
+judge model is introduced in feat-006 (`agentforge-eval-geval`).
+The constructor accepts the value so the API surface is locked at
+v0.1; the implementation upgrades transparently when feat-006 lands.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+from uuid import uuid4
+
+from agentforge_core.values.messages import Message
+from agentforge_core.values.state import AgentState
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from agentforge.resolver_register import register_strategy
+from agentforge.runtime import RuntimeContext
+from agentforge.strategies._base import StrategyBase, get_runtime
+
+log = logging.getLogger(__name__)
+
+ScorerKind = Literal["self", "judge"]
+
+GENERATE_SYSTEM_PROMPT = (
+    "You are exploring multiple plausible reasoning paths for a task. "
+    "Generate {branch_factor} distinct candidate thoughts. Each thought "
+    "should be a different angle, approach, or partial solution. Return "
+    "ONLY a JSON object matching this schema (no other text):\n\n"
+    '  {{"thoughts": [{{"id": "<unique id>", "content": "<thought text>"}}, ...]}}\n\n'
+    "Provide exactly {branch_factor} thoughts."
+)
+
+SCORE_SYSTEM_PROMPT = (
+    "Score each of the candidate thoughts below from 0.0 (irrelevant / "
+    "wrong) to 1.0 (excellent / correct) for how well it advances the "
+    "user's task. Return ONLY a JSON object matching this schema (no "
+    "other text):\n\n"
+    '  {"scores": [{"branch_id": "<id>", "score": <0..1>, "reasoning": "<why>"}, ...]}'
+)
+
+SYNTHESIZE_SYSTEM_PROMPT = (
+    "You have explored multiple reasoning paths and selected the best "
+    "one. Produce the final answer based on the path's content; do not "
+    "introduce new claims unsupported by the path."
+)
+
+
+# ----------------------------------------------------------------------
+# LLM I/O schemas
+# ----------------------------------------------------------------------
+
+
+class _Thought(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    id: str = Field(min_length=1)
+    content: str = Field(min_length=1)
+
+
+class _ThoughtList(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    thoughts: list[_Thought] = Field(min_length=1)
+
+
+class _BranchScore(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    branch_id: str
+    score: float = Field(ge=0.0, le=1.0)
+    reasoning: str = ""
+
+
+class _BranchScoreList(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+    scores: list[_BranchScore]
+
+
+# ----------------------------------------------------------------------
+# Internal node + tree
+# ----------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _Node:
+    """One thought in the search tree."""
+
+    id: str
+    parent_id: str | None
+    depth: int
+    content: str
+    score: float = 0.0
+    children: list[_Node] = field(default_factory=list)
+
+
+def _path_to_root(leaf: _Node, by_id: dict[str, _Node]) -> list[_Node]:
+    path: list[_Node] = []
+    cursor: _Node | None = leaf
+    while cursor is not None:
+        path.append(cursor)
+        cursor = by_id.get(cursor.parent_id) if cursor.parent_id else None
+    return list(reversed(path))
+
+
+# ----------------------------------------------------------------------
+# Strategy
+# ----------------------------------------------------------------------
+
+
+@register_strategy("tot")
+class TreeOfThoughts(StrategyBase):
+    """Beam-search reasoning over scored branches.
+
+    Per feat-002 §4.2 the constructor surface is locked at v0.1:
+
+    Args:
+        branch_factor: Number of candidate thoughts generated per
+            level. Default 3.
+        depth: Number of expansion levels (root + depth-1 expansions).
+            Default 2.
+        score_threshold: Minimum score for a branch to survive
+            pruning. Range [0, 1]. Default 0.5.
+        scorer: "self" uses the agent's primary LLM to score; "judge"
+            (deferred to feat-006) will use a cheap-judge model. Both
+            values currently behave identically.
+        beam_width: If set, keep at most this many of the highest-
+            scoring survivors per level. None = no top-K cap (only
+            score_threshold applies). Default None.
+    """
+
+    def __init__(
+        self,
+        *,
+        branch_factor: int = 3,
+        depth: int = 2,
+        score_threshold: float = 0.5,
+        scorer: ScorerKind = "self",
+        beam_width: int | None = None,
+    ) -> None:
+        if branch_factor < 1:
+            raise ValueError("branch_factor must be >= 1")
+        if depth < 1:
+            raise ValueError("depth must be >= 1")
+        if not 0.0 <= score_threshold <= 1.0:
+            raise ValueError("score_threshold must be in [0, 1]")
+        if scorer not in ("self", "judge"):
+            raise ValueError(f"scorer must be 'self' or 'judge', got {scorer!r}")
+        if beam_width is not None and beam_width < 1:
+            raise ValueError("beam_width must be >= 1 when set")
+        self._branch_factor = branch_factor
+        self._depth = depth
+        self._score_threshold = score_threshold
+        self._scorer: ScorerKind = scorer
+        self._beam_width = beam_width
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = get_runtime(state)
+        by_id: dict[str, _Node] = {}
+
+        # Root — start from the task itself; no LLM call yet.
+        root = _Node(id=str(uuid4()), parent_id=None, depth=0, content=state.task, score=1.0)
+        by_id[root.id] = root
+
+        survivors: list[_Node] = [root]
+        current_depth = 0
+
+        while current_depth < self._depth and survivors:
+            self._check_guardrails(state)
+
+            # Budget-aware graceful degradation: estimate the cost of
+            # the next level (branch + score per survivor); if it would
+            # exceed remaining budget, stop expanding and synthesise.
+            if not self._can_afford_next_level(runtime, len(survivors)):
+                log.warning(
+                    "TreeOfThoughts: estimated next-level cost exceeds "
+                    "remaining budget; synthesising with current best."
+                )
+                break
+
+            new_survivors: list[_Node] = []
+            for parent in survivors:
+                self._check_guardrails(state)
+
+                # GENERATE candidates for this parent
+                candidates = await self._generate(state, parent, current_depth)
+                if not candidates:
+                    continue
+
+                # SCORE candidates
+                scored = await self._score(state, candidates, current_depth)
+
+                # Build child nodes + record branch step
+                for thought, score in scored:
+                    child = _Node(
+                        id=thought.id,
+                        parent_id=parent.id,
+                        depth=current_depth + 1,
+                        content=thought.content,
+                        score=score,
+                    )
+                    parent.children.append(child)
+                    by_id[child.id] = child
+                    self._record_step(
+                        state,
+                        iteration=current_depth + 1,
+                        kind="branch",
+                        content={
+                            "branch_id": child.id,
+                            "parent_id": parent.id,
+                            "score": score,
+                            "thought": thought.content,
+                        },
+                    )
+
+                # PRUNE: above threshold; optionally top-K (beam_width)
+                kept = [by_id[t.id] for (t, s) in scored if s >= self._score_threshold]
+                kept.sort(key=lambda n: n.score, reverse=True)
+                if self._beam_width is not None:
+                    kept = kept[: self._beam_width]
+                new_survivors.extend(kept)
+
+            # Across all parents at this level, also bound the global
+            # beam if set.
+            new_survivors.sort(key=lambda n: n.score, reverse=True)
+            if self._beam_width is not None:
+                new_survivors = new_survivors[: self._beam_width]
+
+            survivors = new_survivors
+            current_depth += 1
+
+        # Pick the best leaf overall — the best surviving node, or the
+        # root if no level survived pruning.
+        best = max(by_id.values(), key=lambda n: n.score) if by_id else root
+        path = _path_to_root(best, by_id)
+        path_text = "\n".join(f"  depth={n.depth} score={n.score:.2f}: {n.content}" for n in path)
+
+        # SYNTHESIZE the final answer from the best path.
+        await self._call_llm(
+            state,
+            iteration=current_depth + 1,
+            system=SYNTHESIZE_SYSTEM_PROMPT,
+            messages=[
+                Message(role="user", content=state.task),
+                Message(
+                    role="assistant",
+                    content=f"Best path explored:\n{path_text}",
+                ),
+            ],
+            kind="synthesize",
+        )
+
+        return state
+
+    # ------------------------------------------------------------------
+    # Phase helpers
+    # ------------------------------------------------------------------
+
+    async def _generate(
+        self, state: AgentState, parent: _Node, current_depth: int
+    ) -> list[_Thought]:
+        """Generate `branch_factor` candidate thoughts as children of `parent`."""
+        prompt = GENERATE_SYSTEM_PROMPT.format(branch_factor=self._branch_factor)
+        messages: list[Message] = [
+            Message(role="user", content=state.task),
+        ]
+        if parent.depth > 0:
+            messages.append(
+                Message(
+                    role="assistant",
+                    content=(
+                        f"Building on prior thought (score {parent.score:.2f}): {parent.content}"
+                    ),
+                )
+            )
+        response = await self._call_llm(
+            state,
+            iteration=current_depth + 1,
+            system=prompt,
+            messages=messages,
+            kind="think",
+        )
+        try:
+            thought_list = _ThoughtList.model_validate_json(_strip_code_fences(response.content))
+        except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+            log.warning(
+                "TreeOfThoughts: candidate generation parse failed at depth %d: %s",
+                current_depth,
+                exc,
+            )
+            return []
+        return list(thought_list.thoughts)
+
+    async def _score(
+        self,
+        state: AgentState,
+        candidates: list[_Thought],
+        current_depth: int,
+    ) -> list[tuple[_Thought, float]]:
+        """Score each candidate; returns list of (thought, score)."""
+        # scorer="judge" deferred to feat-006; falls back to "self" for now.
+        candidate_text = "\n".join(f"- {t.id}: {t.content}" for t in candidates)
+        messages: list[Message] = [
+            Message(role="user", content=state.task),
+            Message(role="assistant", content=f"Candidate thoughts:\n{candidate_text}"),
+        ]
+        response = await self._call_llm(
+            state,
+            iteration=current_depth + 1,
+            system=SCORE_SYSTEM_PROMPT,
+            messages=messages,
+            kind="think",
+        )
+        try:
+            score_list = _BranchScoreList.model_validate_json(_strip_code_fences(response.content))
+        except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+            log.warning(
+                "TreeOfThoughts: scoring parse failed at depth %d: %s. "
+                "Defaulting all candidates to neutral score 0.5.",
+                current_depth,
+                exc,
+            )
+            return [(t, 0.5) for t in candidates]
+
+        score_by_id = {s.branch_id: s.score for s in score_list.scores}
+        # Any candidate the LLM didn't score gets the threshold-1 default
+        # so it's pruned unless explicitly above-threshold.
+        return [(t, score_by_id.get(t.id, 0.0)) for t in candidates]
+
+    def _can_afford_next_level(self, runtime: RuntimeContext, n_survivors: int) -> bool:
+        """Estimate next-level cost; return True if it fits in remaining budget.
+
+        Estimate: each survivor needs (1 generate call + 1 score call).
+        Average cost is `spent_usd / iteration` so far, with a safety
+        floor; if no LLM calls have happened yet, assume a small
+        nonzero cost.
+        """
+        budget = runtime.budget
+        avg = budget.spent_usd / max(1, budget.iteration) if budget.iteration else 0.001
+        estimated = n_survivors * 2 * avg
+        return bool(estimated <= budget.remaining_usd())
+
+
+def _strip_code_fences(content: str) -> str:
+    """Strip ```json ... ``` fences if the LLM wrapped the JSON in them."""
+    text = content.strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline == -1:
+            return text
+        body = text[first_newline + 1 :]
+        if body.endswith("```"):
+            body = body[: -len("```")]
+        return body.strip()
+    return text
+
+
+__all__ = ["TreeOfThoughts"]

--- a/packages/agentforge/tests/unit/test_plan.py
+++ b/packages/agentforge/tests/unit/test_plan.py
@@ -1,0 +1,146 @@
+"""Unit tests for `Plan`, `PlanStep`, and `_topological_batches`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge.strategies._plan import Plan, PlanStep, _topological_batches
+from pydantic import ValidationError
+
+# ---- PlanStep ----
+
+
+def test_plan_step_basic() -> None:
+    step = PlanStep(id="s1", description="do thing", tool="ping")
+    assert step.id == "s1"
+    assert step.tool == "ping"
+    assert step.depends_on == []
+    assert step.arguments == {}
+
+
+def test_plan_step_is_frozen() -> None:
+    step = PlanStep(id="s1", description="x")
+    with pytest.raises(ValidationError):
+        step.id = "s2"  # type: ignore[misc]
+
+
+def test_plan_step_empty_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PlanStep(id="", description="x")
+
+
+def test_plan_step_tool_optional() -> None:
+    step = PlanStep(id="s1", description="think")
+    assert step.tool is None
+
+
+# ---- Plan validation ----
+
+
+def test_plan_basic() -> None:
+    plan = Plan(steps=[PlanStep(id="a", description="a")])
+    assert len(plan.steps) == 1
+
+
+def test_plan_requires_at_least_one_step() -> None:
+    with pytest.raises(ValidationError):
+        Plan(steps=[])
+
+
+def test_plan_rejects_duplicate_ids() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        Plan(
+            steps=[
+                PlanStep(id="a", description="x"),
+                PlanStep(id="a", description="y"),
+            ]
+        )
+
+
+def test_plan_rejects_dangling_dependency() -> None:
+    with pytest.raises(ValidationError, match="not a plan step id"):
+        Plan(
+            steps=[
+                PlanStep(id="a", description="x", depends_on=["nope"]),
+            ]
+        )
+
+
+def test_plan_rejects_self_dependency() -> None:
+    with pytest.raises(ValidationError, match="depends on itself"):
+        Plan(
+            steps=[
+                PlanStep(id="a", description="x", depends_on=["a"]),
+            ]
+        )
+
+
+def test_plan_rejects_cycle() -> None:
+    with pytest.raises(ValidationError, match="Cycle"):
+        Plan(
+            steps=[
+                PlanStep(id="a", description="x", depends_on=["b"]),
+                PlanStep(id="b", description="y", depends_on=["a"]),
+            ]
+        )
+
+
+def test_plan_accepts_chain() -> None:
+    plan = Plan(
+        steps=[
+            PlanStep(id="a", description="step 1"),
+            PlanStep(id="b", description="step 2", depends_on=["a"]),
+            PlanStep(id="c", description="step 3", depends_on=["b"]),
+        ]
+    )
+    assert len(plan.steps) == 3
+
+
+# ---- _topological_batches ----
+
+
+def test_topological_batches_independent_steps_one_batch() -> None:
+    steps = [
+        PlanStep(id="a", description="x"),
+        PlanStep(id="b", description="y"),
+        PlanStep(id="c", description="z"),
+    ]
+    batches = _topological_batches(steps)
+    assert len(batches) == 1
+    assert {s.id for s in batches[0]} == {"a", "b", "c"}
+
+
+def test_topological_batches_chain_one_per_batch() -> None:
+    steps = [
+        PlanStep(id="a", description="x"),
+        PlanStep(id="b", description="y", depends_on=["a"]),
+        PlanStep(id="c", description="z", depends_on=["b"]),
+    ]
+    batches = _topological_batches(steps)
+    assert len(batches) == 3
+    assert [s.id for batch in batches for s in batch] == ["a", "b", "c"]
+
+
+def test_topological_batches_diamond() -> None:
+    """a → {b, c} → d   (b and c independent)"""
+    steps = [
+        PlanStep(id="a", description="root"),
+        PlanStep(id="b", description="left", depends_on=["a"]),
+        PlanStep(id="c", description="right", depends_on=["a"]),
+        PlanStep(id="d", description="join", depends_on=["b", "c"]),
+    ]
+    batches = _topological_batches(steps)
+    assert len(batches) == 3
+    assert [s.id for s in batches[0]] == ["a"]
+    assert {s.id for s in batches[1]} == {"b", "c"}
+    assert [s.id for s in batches[2]] == ["d"]
+
+
+def test_topological_batches_raises_on_cycle() -> None:
+    """Cycle wouldn't pass Plan's model_validator, but the helper itself
+    must also surface the error if called directly with raw steps."""
+    steps = [
+        PlanStep(id="a", description="x", depends_on=["b"]),
+        PlanStep(id="b", description="y", depends_on=["a"]),
+    ]
+    with pytest.raises(ValueError, match="Cycle"):
+        _topological_batches(steps)

--- a/packages/agentforge/tests/unit/test_runtime.py
+++ b/packages/agentforge/tests/unit/test_runtime.py
@@ -1,0 +1,57 @@
+"""Unit tests for `RuntimeContext` + `RUNTIME_KEY`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge_core import BudgetPolicy
+
+
+def _make_runtime() -> RuntimeContext:
+    return RuntimeContext(
+        llm=FakeLLMClient(responses=[]),
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(),
+    )
+
+
+def test_runtime_context_stores_components() -> None:
+    rt = _make_runtime()
+    assert isinstance(rt.llm, FakeLLMClient)
+    assert rt.tools == ()
+    assert isinstance(rt.memory, InMemoryStore)
+    assert isinstance(rt.budget, BudgetPolicy)
+    assert rt.system_prompt is None
+
+
+def test_runtime_context_is_frozen() -> None:
+    rt = _make_runtime()
+    with pytest.raises((AttributeError, Exception)):
+        rt.system_prompt = "different"  # type: ignore[misc]
+
+
+def test_runtime_context_uses_slots() -> None:
+    rt = _make_runtime()
+    assert not hasattr(rt, "__dict__")
+
+
+def test_runtime_key_is_stable_string() -> None:
+    """The metadata key is part of the framework's internal API; pin it
+    via a regression test so an accidental rename surfaces."""
+    assert RUNTIME_KEY == "__agentforge_runtime__"
+
+
+def test_system_prompt_optional() -> None:
+    rt = _make_runtime()
+    assert rt.system_prompt is None
+    rt2 = RuntimeContext(
+        llm=FakeLLMClient(),
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(),
+        system_prompt="You are careful.",
+    )
+    assert rt2.system_prompt == "You are careful."

--- a/packages/agentforge/tests/unit/test_strategies_base.py
+++ b/packages/agentforge/tests/unit/test_strategies_base.py
@@ -1,0 +1,131 @@
+"""Unit tests for `StrategyBase` and `get_runtime`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient, echo_response
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import StrategyBase, get_runtime
+from agentforge_core import BudgetExceeded, BudgetPolicy
+from agentforge_core.values.messages import Message
+from agentforge_core.values.state import AgentState
+
+
+class _DemoStrategy(StrategyBase):
+    """Test-only strategy: one LLM call via `_call_llm`, no tools."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        await self._call_llm(
+            state,
+            iteration=0,
+            system="sys",
+            messages=[Message(role="user", content=state.task)],
+        )
+        return state
+
+
+def _state_with_runtime(llm: FakeLLMClient | None = None) -> AgentState:
+    rt = RuntimeContext(
+        llm=llm if llm is not None else FakeLLMClient(),
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(usd=1.0, max_iterations=5),
+    )
+    return AgentState(run_id="r1", task="hi", metadata={RUNTIME_KEY: rt})
+
+
+# ---- get_runtime ----
+
+
+def test_get_runtime_returns_bound_context() -> None:
+    state = _state_with_runtime()
+    rt = get_runtime(state)
+    assert isinstance(rt, RuntimeContext)
+
+
+def test_get_runtime_raises_when_unbound() -> None:
+    state = AgentState(run_id="r", task="t")
+    with pytest.raises(RuntimeError, match="no RuntimeContext"):
+        get_runtime(state)
+
+
+def test_get_runtime_raises_when_wrong_type() -> None:
+    state = AgentState(run_id="r", task="t", metadata={RUNTIME_KEY: "not a context"})
+    with pytest.raises(TypeError, match="not a RuntimeContext"):
+        get_runtime(state)
+
+
+# ---- StrategyBase ----
+
+
+def test_strategybase_is_abstract() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        StrategyBase()  # type: ignore[abstract]
+
+
+@pytest.mark.asyncio
+async def test_call_llm_records_step_and_commits_cost() -> None:
+    fake = FakeLLMClient(
+        responses=[echo_response(content="answer", input_tokens=10, output_tokens=5, cost_usd=0.01)]
+    )
+    state = _state_with_runtime(llm=fake)
+    strategy = _DemoStrategy()
+
+    result = await strategy.run(state)
+
+    assert result is state
+    assert len(state.steps) == 1
+    step = state.steps[0]
+    assert step.kind == "think"
+    assert step.content == "answer"
+    assert step.tokens_in == 10
+    assert step.tokens_out == 5
+    assert step.cost_usd == pytest.approx(0.01)
+
+    rt = get_runtime(state)
+    assert rt.budget.spent_usd == pytest.approx(0.01)
+    assert rt.budget.consumed_tokens == 15
+    assert rt.budget.iteration == 1
+
+
+@pytest.mark.asyncio
+async def test_call_llm_checks_guardrails_first() -> None:
+    """If budget is exhausted, _call_llm must not invoke the LLM."""
+    fake = FakeLLMClient(responses=[echo_response()])
+    rt = RuntimeContext(
+        llm=fake,
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(usd=0.0),  # zero budget — already at cap
+    )
+    rt.budget.commit(0.001)  # nudge over
+    state = AgentState(run_id="r", task="t", metadata={RUNTIME_KEY: rt})
+    strategy = _DemoStrategy()
+
+    with pytest.raises(BudgetExceeded):
+        await strategy.run(state)
+    assert fake.call_count == 0  # never reached the LLM
+
+
+@pytest.mark.asyncio
+async def test_record_step_appends_to_state() -> None:
+    state = _state_with_runtime()
+    strategy = _DemoStrategy()
+    step = strategy._record_step(state, iteration=2, kind="observe", content="ok")
+    assert state.steps[-1] is step
+    assert step.iteration == 2
+    assert step.kind == "observe"
+
+
+def test_check_guardrails_calls_budget_check() -> None:
+    state = _state_with_runtime()
+
+    class _S(StrategyBase):
+        async def run(self, state: AgentState) -> AgentState:
+            return state
+
+    s = _S()
+    s._check_guardrails(state)
+    rt = get_runtime(state)
+    assert rt.budget.iteration == 0  # check doesn't increment

--- a/packages/agentforge/tests/unit/test_strategies_budget_properties.py
+++ b/packages/agentforge/tests/unit/test_strategies_budget_properties.py
@@ -1,0 +1,185 @@
+"""Property tests — budget invariants hold across all four strategies.
+
+For every shipped reasoning strategy, regardless of the LLM responses
+(or per-call cost), the run must either:
+
+  - Terminate cleanly with `spent_usd <= cap`, or
+  - Raise `BudgetExceeded` / `GuardrailViolation` (which the runtime
+    converts into a `finish_reason` at the Agent level), with
+    `spent_usd <= cap + max_call_cost` (one over-spend is allowed at
+    the moment of commit; subsequent calls are blocked by `check`).
+
+Every shipped strategy honours the same invariant — this test
+fixture exercises ReAct, Plan-Execute, ToT, and Multi-Agent over a
+range of budgets and call costs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import (
+    MultiAgentSupervisor,
+    PlanExecuteLoop,
+    ReActLoop,
+    TreeOfThoughts,
+)
+from agentforge_core import BudgetPolicy
+from agentforge_core.production.exceptions import BudgetExceeded, GuardrailViolation
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from agentforge_core.values.state import AgentState
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+
+def _resp(content: str = "", *, cost: float = 0.001) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _make_state(fake: FakeLLMClient, *, budget: BudgetPolicy) -> tuple[AgentState, RuntimeContext]:
+    rt = RuntimeContext(
+        llm=fake,
+        tools=(),
+        memory=InMemoryStore(),
+        budget=budget,
+    )
+    state = AgentState(run_id="prop-r", task="solve", metadata={RUNTIME_KEY: rt})
+    return state, rt
+
+
+# Precanned valid JSON outputs — random costs, fixed-shape content
+# so the strategies parse successfully and exercise the full path.
+def _react_responses(costs: list[float]) -> list[LLMResponse]:
+    return [_resp("done", cost=c) for c in costs]
+
+
+def _plan_responses(costs: list[float]) -> list[LLMResponse]:
+    plan_json = (
+        '{"steps": [{"id": "s1", "description": "think", '
+        '"tool": null, "arguments": {}, "depends_on": []}]}'
+    )
+    out: list[LLMResponse] = [_resp(plan_json, cost=costs[0] if costs else 0.001)]
+    out.append(_resp("step1 thought", cost=costs[1] if len(costs) > 1 else 0.001))
+    out.append(_resp("done", cost=costs[2] if len(costs) > 2 else 0.001))
+    return out
+
+
+def _tot_responses(costs: list[float]) -> list[LLMResponse]:
+    thoughts = '{"thoughts": [{"id": "t1", "content": "x"}]}'
+    scores = '{"scores": [{"branch_id": "t1", "score": 0.8, "reasoning": ""}]}'
+    return [
+        _resp(thoughts, cost=costs[0] if costs else 0.001),
+        _resp(scores, cost=costs[1] if len(costs) > 1 else 0.001),
+        _resp("done", cost=costs[2] if len(costs) > 2 else 0.001),
+    ]
+
+
+def _multi_agent_responses(costs: list[float]) -> list[LLMResponse]:
+    plan = '{"assignments": [{"worker": "w", "task": "t"}]}'
+    return [
+        _resp(plan, cost=costs[0] if costs else 0.001),
+        _resp("worker thought", cost=costs[1] if len(costs) > 1 else 0.001),
+        _resp("aggregated", cost=costs[2] if len(costs) > 2 else 0.001),
+    ]
+
+
+def _assert_invariant(budget: BudgetPolicy, raised: bool, max_call_cost: float) -> None:
+    """Either the run completed cleanly, or `BudgetExceeded` /
+    `GuardrailViolation` raised. In both cases `spent_usd` cannot
+    exceed the cap by more than ONE in-flight call's cost — the
+    policy's `check()` runs *before* a call but `commit()` runs
+    *after*, so a single call may push spend over the cap; subsequent
+    calls are then blocked.
+    """
+    assert budget.spent_usd >= 0
+    assert budget.spent_usd <= budget.usd + max_call_cost + 1e-9
+    if raised:
+        # The strategy stopped — must have actually hit some cap.
+        # Either USD or iteration cap was reached.
+        usd_capped = budget.spent_usd + 1e-9 >= budget.usd
+        iter_capped = budget.iteration >= budget.max_iterations
+        assert usd_capped or iter_capped
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    cap=st.floats(min_value=0.001, max_value=0.5),
+    costs=st.lists(st.floats(min_value=0.0, max_value=0.2), min_size=3, max_size=10),
+)
+@pytest.mark.asyncio
+async def test_react_budget_invariant(cap: float, costs: list[float]) -> None:
+    fake = FakeLLMClient(responses=_react_responses(costs))
+    state, _ = _make_state(fake, budget=BudgetPolicy(usd=cap, max_iterations=10))
+    raised = False
+    try:
+        await ReActLoop(max_iterations=5).run(state)
+    except (BudgetExceeded, GuardrailViolation):
+        raised = True
+    _assert_invariant(state.metadata[RUNTIME_KEY].budget, raised, max(costs, default=0.0))
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    cap=st.floats(min_value=0.001, max_value=0.5),
+    costs=st.lists(st.floats(min_value=0.0, max_value=0.2), min_size=3, max_size=6),
+)
+@pytest.mark.asyncio
+async def test_plan_execute_budget_invariant(cap: float, costs: list[float]) -> None:
+    fake = FakeLLMClient(responses=_plan_responses(costs))
+    state, _ = _make_state(fake, budget=BudgetPolicy(usd=cap, max_iterations=10))
+    raised = False
+    try:
+        await PlanExecuteLoop(max_replans=0).run(state)
+    except (BudgetExceeded, GuardrailViolation):
+        raised = True
+    _assert_invariant(state.metadata[RUNTIME_KEY].budget, raised, max(costs, default=0.0))
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    cap=st.floats(min_value=0.001, max_value=0.5),
+    costs=st.lists(st.floats(min_value=0.0, max_value=0.2), min_size=3, max_size=6),
+)
+@pytest.mark.asyncio
+async def test_tot_budget_invariant(cap: float, costs: list[float]) -> None:
+    fake = FakeLLMClient(responses=_tot_responses(costs))
+    state, _ = _make_state(fake, budget=BudgetPolicy(usd=cap, max_iterations=10))
+    raised = False
+    try:
+        await TreeOfThoughts(branch_factor=1, depth=1).run(state)
+    except (BudgetExceeded, GuardrailViolation):
+        raised = True
+    _assert_invariant(state.metadata[RUNTIME_KEY].budget, raised, max(costs, default=0.0))
+
+
+class _NoopWorker:
+    """A worker that does nothing (no LLM call). For property tests."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        return state
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    cap=st.floats(min_value=0.001, max_value=0.5),
+    costs=st.lists(st.floats(min_value=0.0, max_value=0.2), min_size=3, max_size=6),
+)
+@pytest.mark.asyncio
+async def test_multi_agent_budget_invariant(cap: float, costs: list[float]) -> None:
+    fake = FakeLLMClient(responses=_multi_agent_responses(costs))
+    state, _ = _make_state(fake, budget=BudgetPolicy(usd=cap, max_iterations=10))
+    raised = False
+    try:
+        await MultiAgentSupervisor(workers={"w": _NoopWorker()}).run(state)  # type: ignore[arg-type]
+    except (BudgetExceeded, GuardrailViolation):
+        raised = True
+    _assert_invariant(state.metadata[RUNTIME_KEY].budget, raised, max(costs, default=0.0))

--- a/packages/agentforge/tests/unit/test_strategies_multi_agent.py
+++ b/packages/agentforge/tests/unit/test_strategies_multi_agent.py
@@ -1,0 +1,361 @@
+"""Unit tests for `MultiAgentSupervisor`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import MultiAgentSupervisor, ReActLoop
+from agentforge.strategies._base import get_runtime
+from agentforge_core import BudgetPolicy
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.resolver import Resolver
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from agentforge_core.values.state import AgentState, Step
+
+# ---- Fixtures ----
+
+
+def _resp(content: str = "", *, cost: float = 0.001) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _state(fake: FakeLLMClient, *, budget: BudgetPolicy | None = None) -> AgentState:
+    rt = RuntimeContext(
+        llm=fake,
+        tools=(),
+        memory=InMemoryStore(),
+        budget=budget if budget is not None else BudgetPolicy(usd=5.0, max_iterations=20),
+    )
+    return AgentState(run_id="r1", task="big task", metadata={RUNTIME_KEY: rt})
+
+
+class _ScriptedWorker(ReasoningStrategy):
+    """Worker that just appends a synthesize step with a fixed reply."""
+
+    def __init__(self, reply: str = "worker output", *, raises: Exception | None = None) -> None:
+        self.reply = reply
+        self.raises = raises
+        self.calls = 0
+
+    async def run(self, state: AgentState) -> AgentState:
+        self.calls += 1
+        if self.raises is not None:
+            raise self.raises
+        rt = get_runtime(state)
+        rt.budget.check()
+        state.steps.append(Step(iteration=1, kind="synthesize", content=self.reply, cost_usd=0.0))
+        return state
+
+
+def _delegation(workers: list[tuple[str, str]]) -> str:
+    """Build a JSON delegation plan."""
+    items = [f'{{"worker": "{w}", "task": "{t}"}}' for w, t in workers]
+    return '{"assignments": [' + ", ".join(items) + "]}"
+
+
+# ---- Constructor validation ----
+
+
+def test_constructor_rejects_empty_workers() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        MultiAgentSupervisor(workers={})
+
+
+def test_constructor_validates_max_parallel_workers() -> None:
+    with pytest.raises(ValueError, match="max_parallel_workers"):
+        MultiAgentSupervisor(workers={"a": _ScriptedWorker()}, max_parallel_workers=0)
+
+
+def test_constructor_validates_max_rounds() -> None:
+    with pytest.raises(ValueError, match="max_rounds"):
+        MultiAgentSupervisor(workers={"a": _ScriptedWorker()}, max_rounds=0)
+
+
+def test_registered_under_strategies_multi_agent() -> None:
+    cls = Resolver.global_().resolve("strategies", "multi-agent")
+    assert cls is MultiAgentSupervisor
+
+
+# ---- Single-round happy path ----
+
+
+@pytest.mark.asyncio
+async def test_single_round_delegation_and_aggregation() -> None:
+    """plan → 2 workers run → aggregate. 2 LLM calls (delegate + aggregate)."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("researcher", "find facts"), ("writer", "draft summary")])),
+            _resp("final aggregated answer"),
+        ]
+    )
+    state = _state(fake)
+    researcher = _ScriptedWorker(reply="facts found")
+    writer = _ScriptedWorker(reply="summary drafted")
+    await MultiAgentSupervisor(
+        workers={"researcher": researcher, "writer": writer},
+    ).run(state)
+
+    assert fake.call_count == 2
+    assert researcher.calls == 1
+    assert writer.calls == 1
+    delegates = [s for s in state.steps if s.kind == "delegate"]
+    assert len(delegates) == 2
+    synth = [s for s in state.steps if s.kind == "synthesize"]
+    assert len(synth) == 1
+
+
+# ---- Unknown worker filtering ----
+
+
+@pytest.mark.asyncio
+async def test_unknown_worker_in_plan_is_dropped() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("known", "do it"), ("ghost", "vanish")])),
+            _resp("final"),
+        ]
+    )
+    state = _state(fake)
+    known = _ScriptedWorker()
+    await MultiAgentSupervisor(workers={"known": known}).run(state)
+
+    assert known.calls == 1
+    delegates = [s for s in state.steps if s.kind == "delegate"]
+    assert len(delegates) == 1
+
+
+# ---- Empty plan → straight to aggregation ----
+
+
+@pytest.mark.asyncio
+async def test_empty_plan_skips_to_aggregation() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp('{"assignments": []}'),
+            _resp("answered without workers"),
+        ]
+    )
+    state = _state(fake)
+    worker = _ScriptedWorker()
+    await MultiAgentSupervisor(workers={"a": worker}).run(state)
+    assert worker.calls == 0
+    assert fake.call_count == 2
+
+
+# ---- Worker failure → recorded as delegate.error, supervisor continues ----
+
+
+@pytest.mark.asyncio
+async def test_worker_exception_is_caught_and_recorded() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("ok", "task1"), ("bad", "task2")])),
+            _resp("aggregated despite one failure"),
+        ]
+    )
+    state = _state(fake)
+    ok = _ScriptedWorker(reply="ok output")
+    bad = _ScriptedWorker(raises=RuntimeError("kaboom"))
+    await MultiAgentSupervisor(workers={"ok": ok, "bad": bad}).run(state)
+
+    delegates = [s for s in state.steps if s.kind == "delegate"]
+    assert len(delegates) == 2
+    error_steps = [s for s in delegates if isinstance(s.content, dict) and "error" in s.content]
+    assert len(error_steps) == 1
+
+
+# ---- All workers fail → supervisor stops looping, aggregates ----
+
+
+@pytest.mark.asyncio
+async def test_all_workers_fail_aggregates_with_no_outputs() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("a", "x"), ("b", "y")])),
+            _resp("synthesised from errors"),
+        ]
+    )
+    state = _state(fake)
+    a = _ScriptedWorker(raises=ValueError("fail-a"))
+    b = _ScriptedWorker(raises=ValueError("fail-b"))
+    await MultiAgentSupervisor(
+        workers={"a": a, "b": b},
+        max_rounds=2,  # would loop again, but bails
+    ).run(state)
+    # Aggregation runs exactly once even though max_rounds=2
+    synth = [s for s in state.steps if s.kind == "synthesize"]
+    assert len(synth) == 1
+
+
+# ---- Parse-error fallback ----
+
+
+@pytest.mark.asyncio
+async def test_invalid_delegation_json_yields_no_workers() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp("not valid JSON"),
+            _resp("aggregated without delegation"),
+        ]
+    )
+    state = _state(fake)
+    worker = _ScriptedWorker()
+    await MultiAgentSupervisor(workers={"a": worker}).run(state)
+    assert worker.calls == 0
+    assert fake.call_count == 2
+
+
+# ---- Code-fence stripping ----
+
+
+@pytest.mark.asyncio
+async def test_strips_code_fences_from_delegation() -> None:
+    fenced = "```json\n" + _delegation([("a", "task1")]) + "\n```"
+    fake = FakeLLMClient(responses=[_resp(fenced), _resp("done")])
+    state = _state(fake)
+    worker = _ScriptedWorker()
+    await MultiAgentSupervisor(workers={"a": worker}).run(state)
+    assert worker.calls == 1
+    assert fake.call_count == 2
+
+
+# ---- Budget split: each worker gets a fraction of remaining USD ----
+
+
+@pytest.mark.asyncio
+async def test_budget_split_proportional_among_workers() -> None:
+    """Each worker's sub-budget caps spend at remaining/N."""
+    captured_caps: list[float] = []
+
+    class _BudgetCapturingWorker(ReasoningStrategy):
+        async def run(self, state: AgentState) -> AgentState:
+            rt = get_runtime(state)
+            captured_caps.append(rt.budget.usd)
+            return state
+
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("w1", "t1"), ("w2", "t2"), ("w3", "t3")]), cost=0.5),
+            _resp("done"),
+        ]
+    )
+    state = _state(fake, budget=BudgetPolicy(usd=4.0, max_iterations=20))
+    await MultiAgentSupervisor(
+        workers={
+            "w1": _BudgetCapturingWorker(),
+            "w2": _BudgetCapturingWorker(),
+            "w3": _BudgetCapturingWorker(),
+        }
+    ).run(state)
+    # After delegate call (cost=0.5), remaining=3.5; split 3 ways = ~1.166 each
+    assert len(captured_caps) == 3
+    assert all(abs(c - (3.5 / 3)) < 1e-6 for c in captured_caps)
+
+
+# ---- Recursive composition: worker is itself a ReActLoop ----
+
+
+@pytest.mark.asyncio
+async def test_worker_can_be_real_strategy() -> None:
+    """Workers can be any ReasoningStrategy — exercise composition with ReActLoop."""
+    fake = FakeLLMClient(
+        responses=[
+            # supervisor delegate plan
+            _resp(_delegation([("solver", "subtask")])),
+            # ReActLoop worker: terminates on first end_turn
+            _resp("worker thinks and ends"),
+            # supervisor aggregate
+            _resp("final aggregated"),
+        ]
+    )
+    state = _state(fake)
+    await MultiAgentSupervisor(
+        workers={"solver": ReActLoop(max_iterations=3)},
+    ).run(state)
+    assert fake.call_count == 3
+
+
+# ---- Multi-round delegation: prior results fed back to supervisor ----
+
+
+@pytest.mark.asyncio
+async def test_multi_round_passes_prior_results_to_supervisor() -> None:
+    """max_rounds=2 with successes — second delegate call sees prior outputs."""
+    captured_messages: list[list[object]] = []
+
+    def capture_delegate(system: str, messages: list[object], tools: object = None) -> LLMResponse:
+        captured_messages.append(list(messages))
+        # First call: assign work; second call: empty plan (so we exit cleanly)
+        if len(captured_messages) == 1:
+            return _resp(_delegation([("a", "round-1 task")]))
+        return _resp('{"assignments": []}')
+
+    fake = FakeLLMClient(responses=[capture_delegate, capture_delegate, _resp("aggregated")])
+    state = _state(fake)
+    worker = _ScriptedWorker(reply="round-1 result")
+    await MultiAgentSupervisor(workers={"a": worker}, max_rounds=2).run(state)
+
+    # Second delegate call must include an assistant message carrying
+    # the prior worker output.
+    assert len(captured_messages) == 2
+    second_call_msgs = captured_messages[1]
+    assert any(
+        getattr(m, "role", None) == "assistant" and "round-1 result" in getattr(m, "content", "")
+        for m in second_call_msgs
+    )
+
+
+# ---- Worker output extraction handles dict-content steps ----
+
+
+@pytest.mark.asyncio
+async def test_worker_output_extracted_from_dict_step_content() -> None:
+    """Workers whose last step has dict content get serialised to JSON."""
+
+    class _DictWorker(ReasoningStrategy):
+        async def run(self, state: AgentState) -> AgentState:
+            state.steps.append(Step(iteration=1, kind="synthesize", content={"answer": 42}))
+            return state
+
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_delegation([("d", "do")])),
+            _resp("aggregated"),
+        ]
+    )
+    state = _state(fake)
+    await MultiAgentSupervisor(workers={"d": _DictWorker()}).run(state)
+    delegates = [s for s in state.steps if s.kind == "delegate"]
+    assert len(delegates) == 1
+    assert isinstance(delegates[0].content, dict)
+    assert '"answer": 42' in str(delegates[0].content["output"])
+
+
+# ---- Worker descriptions appear in the supervisor prompt ----
+
+
+@pytest.mark.asyncio
+async def test_worker_descriptions_passed_to_supervisor_prompt() -> None:
+    """Custom descriptions show up in the delegate-prompt system text."""
+    captured: list[str] = []
+
+    def capture(system: str, messages: object, tools: object = None) -> LLMResponse:
+        captured.append(system)
+        return _resp(_delegation([("a", "t")]))
+
+    fake = FakeLLMClient(responses=[capture, _resp("done")])
+    state = _state(fake)
+    await MultiAgentSupervisor(
+        workers={"a": _ScriptedWorker()},
+        worker_descriptions={"a": "expert assistant"},
+    ).run(state)
+    assert any("expert assistant" in s for s in captured)

--- a/packages/agentforge/tests/unit/test_strategies_plan_execute.py
+++ b/packages/agentforge/tests/unit/test_strategies_plan_execute.py
@@ -1,0 +1,269 @@
+"""Unit tests for `PlanExecuteLoop`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import PlanExecuteLoop
+from agentforge_core import BudgetPolicy
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.resolver import Resolver
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from agentforge_core.values.state import AgentState
+from pydantic import BaseModel
+
+# ---- Fixtures ----
+
+
+class _AddInput(BaseModel):
+    a: int
+    b: int
+
+
+class _AddTool(Tool):
+    name = "add"
+    description = "Add two integers."
+    input_schema = _AddInput
+
+    async def run(self, a: int, b: int) -> dict[str, Any]:
+        return {"sum": a + b}
+
+
+class _BoomInput(BaseModel):
+    pass
+
+
+class _BoomTool(Tool):
+    name = "boom"
+    description = "Always raises."
+    input_schema = _BoomInput
+
+    async def run(self) -> Any:
+        raise RuntimeError("kaboom")
+
+
+def _resp(content: str = "") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=0.001,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _state_for(
+    fake: FakeLLMClient,
+    *,
+    tools: tuple[Tool, ...] = (),
+    budget: BudgetPolicy | None = None,
+) -> AgentState:
+    rt = RuntimeContext(
+        llm=fake,
+        tools=tools,
+        memory=InMemoryStore(),
+        budget=budget if budget is not None else BudgetPolicy(usd=10.0, max_iterations=20),
+    )
+    return AgentState(run_id="r1", task="add 2 + 3", metadata={RUNTIME_KEY: rt})
+
+
+_VALID_PLAN_JSON = (
+    '{"steps": ['
+    '{"id": "step-1", "description": "add 2+3", '
+    '"tool": "add", "arguments": {"a": 2, "b": 3}, "depends_on": []}'
+    "]}"
+)
+
+_PARALLEL_PLAN_JSON = (
+    '{"steps": ['
+    '{"id": "a", "description": "add 1+1", "tool": "add", '
+    '"arguments": {"a": 1, "b": 1}, "depends_on": []},'
+    '{"id": "b", "description": "add 2+2", "tool": "add", '
+    '"arguments": {"a": 2, "b": 2}, "depends_on": []}'
+    "]}"
+)
+
+
+# ---- Tests ----
+
+
+def test_constructor_validates_max_parallel_steps() -> None:
+    with pytest.raises(ValueError, match="max_parallel_steps"):
+        PlanExecuteLoop(max_parallel_steps=0)
+
+
+def test_constructor_validates_max_replans() -> None:
+    with pytest.raises(ValueError, match="max_replans"):
+        PlanExecuteLoop(max_replans=-1)
+
+
+def test_registered_under_strategies_plan_execute() -> None:
+    cls = Resolver.global_().resolve("strategies", "plan-execute")
+    assert cls is PlanExecuteLoop
+
+
+@pytest.mark.asyncio
+async def test_single_step_plan_executes_and_synthesizes() -> None:
+    """One-step plan: plan → execute (1 step) → synthesize."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_VALID_PLAN_JSON),
+            _resp("Final answer: 5."),
+        ]
+    )
+    state = _state_for(fake, tools=(_AddTool(),))
+    await PlanExecuteLoop().run(state)
+
+    assert fake.call_count == 2  # plan call + synthesis call
+    kinds = [s.kind for s in state.steps]
+    assert "plan" in kinds
+    assert "act" in kinds
+    assert "observe" in kinds
+    assert "synthesize" in kinds
+
+
+@pytest.mark.asyncio
+async def test_parallel_independent_steps_in_one_batch() -> None:
+    """Two independent steps run in the same batch."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_PARALLEL_PLAN_JSON),
+            _resp("Both done."),
+        ]
+    )
+    state = _state_for(fake, tools=(_AddTool(),))
+    await PlanExecuteLoop(max_parallel_steps=2).run(state)
+
+    # Two `act` steps + two `observe` steps for the parallel batch.
+    acts = [s for s in state.steps if s.kind == "act"]
+    observes = [s for s in state.steps if s.kind == "observe"]
+    assert len(acts) == 2
+    assert len(observes) == 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_plan_triggers_replan() -> None:
+    """First plan is malformed JSON; LLM corrects on retry."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp("not valid JSON"),
+            _resp(_VALID_PLAN_JSON),
+            _resp("Done."),
+        ]
+    )
+    state = _state_for(fake, tools=(_AddTool(),))
+    await PlanExecuteLoop(max_replans=1).run(state)
+
+    assert fake.call_count == 3  # malformed + corrected + synthesis
+
+
+@pytest.mark.asyncio
+async def test_invalid_plan_after_max_replans_raises() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp("not valid"),
+            _resp("still not valid"),
+        ]
+    )
+    state = _state_for(fake, tools=(_AddTool(),))
+    with pytest.raises(Exception, match="invalid"):
+        await PlanExecuteLoop(max_replans=1).run(state)
+
+
+@pytest.mark.asyncio
+async def test_step_failure_triggers_replan() -> None:
+    """First plan uses a failing tool; replan with a different plan."""
+    bad_plan = (
+        '{"steps": [{"id": "x", "description": "boom", '
+        '"tool": "boom", "arguments": {}, "depends_on": []}]}'
+    )
+    fake = FakeLLMClient(
+        responses=[
+            _resp(bad_plan),
+            _resp(_VALID_PLAN_JSON),
+            _resp("Done."),
+        ]
+    )
+    state = _state_for(fake, tools=(_AddTool(), _BoomTool()))
+    await PlanExecuteLoop(replan_on_failure=True, max_replans=1).run(state)
+
+    assert fake.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_step_failure_without_replan_records_error_and_synthesizes() -> None:
+    bad_plan = (
+        '{"steps": [{"id": "x", "description": "boom", '
+        '"tool": "boom", "arguments": {}, "depends_on": []}]}'
+    )
+    fake = FakeLLMClient(
+        responses=[
+            _resp(bad_plan),
+            _resp("Failure synthesized."),
+        ]
+    )
+    state = _state_for(fake, tools=(_BoomTool(),))
+    await PlanExecuteLoop(replan_on_failure=False).run(state)
+
+    # Strategy continues despite the failure
+    assert fake.call_count == 2
+    error_observes = [s for s in state.steps if s.kind == "observe" and "Error" in str(s.content)]
+    assert len(error_observes) >= 1
+
+
+@pytest.mark.asyncio
+async def test_think_only_step_no_tool() -> None:
+    """A step with tool=None makes one LLM call and records its content."""
+    plan_json = (
+        '{"steps": [{"id": "a", "description": "think about life", '
+        '"tool": null, "arguments": {}, "depends_on": []}]}'
+    )
+    fake = FakeLLMClient(
+        responses=[
+            _resp(plan_json),
+            _resp("the answer is 42"),  # think step
+            _resp("Final synthesis."),
+        ]
+    )
+    state = _state_for(fake)
+    await PlanExecuteLoop().run(state)
+
+    assert fake.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_max_parallel_steps_respected() -> None:
+    """Three independent steps with max_parallel_steps=1 → still one batch
+    by topology, but execution serialises through the semaphore."""
+    plan_json = (
+        '{"steps": ['
+        '{"id": "a", "description": "x", "tool": "add", '
+        '"arguments": {"a": 1, "b": 1}, "depends_on": []},'
+        '{"id": "b", "description": "y", "tool": "add", '
+        '"arguments": {"a": 2, "b": 2}, "depends_on": []},'
+        '{"id": "c", "description": "z", "tool": "add", '
+        '"arguments": {"a": 3, "b": 3}, "depends_on": []}'
+        "]}"
+    )
+    fake = FakeLLMClient(responses=[_resp(plan_json), _resp("done")])
+    state = _state_for(fake, tools=(_AddTool(),))
+    await PlanExecuteLoop(max_parallel_steps=1).run(state)
+
+    # All three steps should still execute and observe.
+    observes = [s for s in state.steps if s.kind == "observe"]
+    assert len(observes) == 3
+
+
+@pytest.mark.asyncio
+async def test_strips_code_fences_from_llm_plan_output() -> None:
+    """LLMs sometimes wrap JSON in ```json ... ``` fences. Parser handles."""
+    fenced = "```json\n" + _VALID_PLAN_JSON + "\n```"
+    fake = FakeLLMClient(responses=[_resp(fenced), _resp("done")])
+    state = _state_for(fake, tools=(_AddTool(),))
+    await PlanExecuteLoop().run(state)
+    assert fake.call_count == 2

--- a/packages/agentforge/tests/unit/test_strategies_react.py
+++ b/packages/agentforge/tests/unit/test_strategies_react.py
@@ -1,0 +1,279 @@
+"""Unit tests for `ReActLoop`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import ReActLoop
+from agentforge.strategies.react import DEFAULT_SYSTEM_PROMPT
+from agentforge_core import (
+    BudgetExceeded,
+    BudgetPolicy,
+    GuardrailViolation,
+)
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.resolver import Resolver
+from agentforge_core.values.messages import (
+    LLMResponse,
+    TokenUsage,
+    ToolCall,
+)
+from agentforge_core.values.state import AgentState
+from pydantic import BaseModel
+
+# ---- Test fixtures ----
+
+
+class _PingInput(BaseModel):
+    target: str
+
+
+class _PingTool(Tool):
+    name = "ping"
+    description = "Ping a target."
+    input_schema = _PingInput
+
+    async def run(self, target: str) -> dict[str, Any]:
+        return {"target": target, "ok": True}
+
+
+class _BoomInput(BaseModel):
+    pass
+
+
+class _BoomTool(Tool):
+    """Tool that raises — exercises the error-streak path."""
+
+    name = "boom"
+    description = "Always raises."
+    input_schema = _BoomInput
+
+    async def run(self) -> Any:
+        raise RuntimeError("kaboom")
+
+
+def _resp(
+    *,
+    content: str = "",
+    tool_calls: tuple[ToolCall, ...] = (),
+    stop_reason: str = "end_turn",
+    cost: float = 0.001,
+    tokens_in: int = 5,
+    tokens_out: int = 3,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls,
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        usage=TokenUsage(input_tokens=tokens_in, output_tokens=tokens_out),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _state_for(
+    fake: FakeLLMClient,
+    *,
+    tools: tuple[Tool, ...] = (),
+    budget: BudgetPolicy | None = None,
+    system_prompt: str | None = None,
+) -> AgentState:
+    rt = RuntimeContext(
+        llm=fake,
+        tools=tools,
+        memory=InMemoryStore(),
+        budget=budget if budget is not None else BudgetPolicy(usd=1.0, max_iterations=10),
+        system_prompt=system_prompt,
+    )
+    return AgentState(run_id="r1", task="ping example.com", metadata={RUNTIME_KEY: rt})
+
+
+# ---- Tests ----
+
+
+@pytest.mark.asyncio
+async def test_terminates_immediately_when_no_tool_calls() -> None:
+    """LLM returns final answer with no tool calls — loop exits."""
+    fake = FakeLLMClient(responses=[_resp(content="The answer is 42.")])
+    state = _state_for(fake)
+
+    await ReActLoop().run(state)
+
+    assert fake.call_count == 1
+    assert len(state.steps) == 1
+    assert state.steps[0].kind == "think"
+    assert state.steps[0].content == "The answer is 42."
+
+
+@pytest.mark.asyncio
+async def test_dispatches_tool_call_then_finishes() -> None:
+    """One tool call, then LLM returns no tool call → finished."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(
+                content="I'll ping example.com.",
+                tool_calls=(ToolCall(id="t1", name="ping", arguments={"target": "example.com"}),),
+                stop_reason="tool_use",
+            ),
+            _resp(content="example.com is up."),
+        ]
+    )
+    state = _state_for(fake, tools=(_PingTool(),))
+
+    await ReActLoop().run(state)
+
+    assert fake.call_count == 2
+    kinds = [s.kind for s in state.steps]
+    assert kinds == ["think", "act", "observe", "think"]
+    # observe step content includes the tool result
+    observe = state.steps[2]
+    assert "example.com" in str(observe.content)
+    assert observe.tool_call is not None
+    assert observe.tool_call.id == "t1"
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_recorded_as_error_observation() -> None:
+    """LLM emits a tool name that isn't in the agent's catalogue —
+    recorded as observation; error_streak increments; agent continues."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(
+                content="trying nonexistent",
+                tool_calls=(ToolCall(id="t1", name="not_registered", arguments={}),),
+                stop_reason="tool_use",
+            ),
+            _resp(content="ok, giving up."),
+        ]
+    )
+    state = _state_for(fake, tools=())
+
+    await ReActLoop().run(state)
+
+    # The observe step contains the error message
+    observe = state.steps[2]
+    assert observe.kind == "observe"
+    assert "not_registered" in str(observe.content)
+    # Error streak incremented
+    rt = state.metadata[RUNTIME_KEY]
+    assert rt.budget.error_streak >= 1
+
+
+@pytest.mark.asyncio
+async def test_tool_exception_surfaced_as_observation() -> None:
+    """Tool raises → observation contains 'Error:'; error_streak increments."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(
+                content="trying boom",
+                tool_calls=(ToolCall(id="t1", name="boom", arguments={}),),
+                stop_reason="tool_use",
+            ),
+            _resp(content="recovered."),
+        ]
+    )
+    state = _state_for(fake, tools=(_BoomTool(),))
+
+    await ReActLoop().run(state)
+
+    observe = state.steps[2]
+    assert "Error" in str(observe.content)
+    assert "kaboom" in str(observe.content)
+
+
+@pytest.mark.asyncio
+async def test_guardrail_iteration_cap_terminates_loop() -> None:
+    """Reaches max_iterations; loop bails with GuardrailViolation."""
+    # Always emit a tool call so the loop never naturally finishes.
+    looper = lambda **_: _resp(  # noqa: E731
+        content="loop",
+        tool_calls=(ToolCall(id=f"t{id(_)}", name="ping", arguments={"target": "x"}),),
+        stop_reason="tool_use",
+    )
+    fake = FakeLLMClient(responses=[looper] * 20)
+    state = _state_for(fake, tools=(_PingTool(),), budget=BudgetPolicy(usd=10.0, max_iterations=2))
+
+    with pytest.raises(GuardrailViolation):
+        await ReActLoop().run(state)
+
+
+@pytest.mark.asyncio
+async def test_budget_cap_terminates_loop() -> None:
+    """Each LLM call costs more than the cap; second iteration trips it."""
+    expensive = _resp(
+        content="thinking",
+        tool_calls=(ToolCall(id="t1", name="ping", arguments={"target": "x"}),),
+        stop_reason="tool_use",
+        cost=0.6,
+    )
+    fake = FakeLLMClient(responses=[expensive, expensive, expensive])
+    state = _state_for(fake, tools=(_PingTool(),), budget=BudgetPolicy(usd=1.0, max_iterations=10))
+
+    with pytest.raises(BudgetExceeded):
+        await ReActLoop().run(state)
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_override() -> None:
+    """Constructor max_iterations overrides BudgetPolicy.max_iterations."""
+    looper = lambda **_: _resp(  # noqa: E731
+        tool_calls=(ToolCall(id=f"t{id(_)}", name="ping", arguments={"target": "x"}),),
+        stop_reason="tool_use",
+    )
+    fake = FakeLLMClient(responses=[looper] * 20)
+    state = _state_for(fake, tools=(_PingTool(),), budget=BudgetPolicy(usd=10.0, max_iterations=10))
+
+    with pytest.raises(GuardrailViolation):
+        await ReActLoop(max_iterations=2).run(state)
+    rt = state.metadata[RUNTIME_KEY]
+    assert rt.budget.max_iterations == 2
+
+
+@pytest.mark.asyncio
+async def test_uses_runtime_system_prompt() -> None:
+    fake = FakeLLMClient(responses=[_resp(content="ok")])
+    state = _state_for(fake, system_prompt="Custom system prompt.")
+    await ReActLoop().run(state)
+    captured_system, _, _ = fake.captured[0]
+    assert captured_system == "Custom system prompt."
+
+
+@pytest.mark.asyncio
+async def test_default_system_prompt_used_when_runtime_unset() -> None:
+    fake = FakeLLMClient(responses=[_resp(content="ok")])
+    state = _state_for(fake)
+    await ReActLoop().run(state)
+    captured_system, _, _ = fake.captured[0]
+    assert captured_system == DEFAULT_SYSTEM_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_passes_tool_specs_to_llm() -> None:
+    fake = FakeLLMClient(responses=[_resp(content="ok")])
+    state = _state_for(fake, tools=(_PingTool(),))
+    await ReActLoop().run(state)
+    _, _, tools = fake.captured[0]
+    assert tools is not None
+    assert len(tools) == 1
+    assert tools[0].name == "ping"
+
+
+@pytest.mark.asyncio
+async def test_no_tools_passes_none_to_llm() -> None:
+    fake = FakeLLMClient(responses=[_resp(content="ok")])
+    state = _state_for(fake, tools=())
+    await ReActLoop().run(state)
+    _, _, tools = fake.captured[0]
+    assert tools is None
+
+
+def test_react_registered_under_strategies_react() -> None:
+    """The @register_strategy('react') decorator at class-definition
+    time registers ReActLoop with the global resolver."""
+    cls = Resolver.global_().resolve("strategies", "react")
+    assert cls is ReActLoop

--- a/packages/agentforge/tests/unit/test_strategies_tot.py
+++ b/packages/agentforge/tests/unit/test_strategies_tot.py
@@ -1,0 +1,238 @@
+"""Unit tests for `TreeOfThoughts`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import TreeOfThoughts
+from agentforge_core import BudgetPolicy
+from agentforge_core.resolver import Resolver
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from agentforge_core.values.state import AgentState
+
+
+def _resp(content: str = "", *, cost: float = 0.001) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _state(fake: FakeLLMClient, *, budget: BudgetPolicy | None = None) -> AgentState:
+    rt = RuntimeContext(
+        llm=fake,
+        tools=(),
+        memory=InMemoryStore(),
+        budget=budget if budget is not None else BudgetPolicy(usd=2.0, max_iterations=20),
+    )
+    return AgentState(run_id="r1", task="solve x", metadata={RUNTIME_KEY: rt})
+
+
+def _thoughts(branch_factor: int) -> str:
+    """Build a valid `_ThoughtList` JSON for the given branch_factor."""
+    items = [f'{{"id": "t{i}", "content": "thought {i}"}}' for i in range(1, branch_factor + 1)]
+    return '{"thoughts": [' + ", ".join(items) + "]}"
+
+
+def _scores(scores_by_id: dict[str, float]) -> str:
+    items = [
+        f'{{"branch_id": "{k}", "score": {v}, "reasoning": "..."}}' for k, v in scores_by_id.items()
+    ]
+    return '{"scores": [' + ", ".join(items) + "]}"
+
+
+# ---- Constructor validation ----
+
+
+def test_constructor_validates_branch_factor() -> None:
+    with pytest.raises(ValueError, match="branch_factor"):
+        TreeOfThoughts(branch_factor=0)
+
+
+def test_constructor_validates_depth() -> None:
+    with pytest.raises(ValueError, match="depth"):
+        TreeOfThoughts(depth=0)
+
+
+def test_constructor_validates_score_threshold() -> None:
+    with pytest.raises(ValueError, match="score_threshold"):
+        TreeOfThoughts(score_threshold=1.5)
+
+
+def test_constructor_validates_scorer() -> None:
+    with pytest.raises(ValueError, match="scorer"):
+        TreeOfThoughts(scorer="bogus")  # type: ignore[arg-type]
+
+
+def test_constructor_validates_beam_width() -> None:
+    with pytest.raises(ValueError, match="beam_width"):
+        TreeOfThoughts(beam_width=0)
+
+
+def test_registered_under_strategies_tot() -> None:
+    cls = Resolver.global_().resolve("strategies", "tot")
+    assert cls is TreeOfThoughts
+
+
+# ---- Single-level happy path ----
+
+
+@pytest.mark.asyncio
+async def test_single_depth_with_three_branches() -> None:
+    """depth=1, branch_factor=3 → 1 generate + 1 score + 1 synthesize."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(3)),
+            _resp(_scores({"t1": 0.9, "t2": 0.4, "t3": 0.7})),
+            _resp("Final answer based on best branch."),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=3, depth=1, score_threshold=0.5).run(state)
+
+    assert fake.call_count == 3
+    branches = [s for s in state.steps if s.kind == "branch"]
+    assert len(branches) == 3
+    synth = [s for s in state.steps if s.kind == "synthesize"]
+    assert len(synth) == 1
+
+
+# ---- Beam width pruning ----
+
+
+@pytest.mark.asyncio
+async def test_beam_width_keeps_top_k() -> None:
+    """beam_width=1 — only highest-scored branch survives the level."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(3)),
+            _resp(_scores({"t1": 0.9, "t2": 0.4, "t3": 0.7})),
+            # depth=2: only t1 should expand
+            _resp(_thoughts(2)),  # at child level: 2 candidates
+            _resp(_scores({"t1": 0.85, "t2": 0.4})),
+            _resp("done"),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=3, depth=2, score_threshold=0.5, beam_width=1).run(state)
+    # 3 (level-1 branches) + 2 (level-2 branches under t1) = 5
+    branches = [s for s in state.steps if s.kind == "branch"]
+    assert len(branches) == 5
+
+
+# ---- Score-threshold pruning ----
+
+
+@pytest.mark.asyncio
+async def test_score_threshold_prunes_weak_branches() -> None:
+    """All branches below threshold → no survivors → synthesise from root."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(3)),
+            _resp(_scores({"t1": 0.1, "t2": 0.2, "t3": 0.05})),
+            _resp("synthesis from root"),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=3, depth=2, score_threshold=0.5).run(state)
+    # No level-2 expansion happens because no level-1 survivors
+    assert fake.call_count == 3
+
+
+# ---- Graceful degradation on budget ----
+
+
+@pytest.mark.asyncio
+async def test_budget_aware_graceful_degradation() -> None:
+    """Tight budget — strategy synthesises with what it has rather
+    than tripping BudgetExceeded mid-search."""
+    expensive = _resp(_thoughts(2), cost=0.4)
+    fake = FakeLLMClient(
+        responses=[
+            expensive,
+            _resp(_scores({"t1": 0.9, "t2": 0.8}), cost=0.4),
+            _resp("partial synthesis", cost=0.05),
+        ]
+    )
+    state = _state(fake, budget=BudgetPolicy(usd=1.0, max_iterations=20))
+    await TreeOfThoughts(branch_factor=2, depth=3, score_threshold=0.5).run(state)
+    # Depth=3 is requested but budget runs out after the first level;
+    # strategy synthesises what it has rather than crashing.
+    synth = [s for s in state.steps if s.kind == "synthesize"]
+    assert len(synth) == 1
+
+
+# ---- Parse-error fallback ----
+
+
+@pytest.mark.asyncio
+async def test_invalid_thoughts_json_yields_no_branches() -> None:
+    """Generation parse failure → no branches at this level; synthesise root."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp("not valid JSON for thoughts"),
+            _resp("synthesis"),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=2, depth=1).run(state)
+    assert fake.call_count == 2
+    branches = [s for s in state.steps if s.kind == "branch"]
+    assert branches == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_scores_json_defaults_neutral() -> None:
+    """Score parse failure → all candidates default to 0.5 (logged warning)."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(2)),
+            _resp("scores parse error"),
+            _resp("synthesis"),
+        ]
+    )
+    state = _state(fake)
+    # threshold=0.5 with default-0.5 scores — exactly threshold; survives
+    await TreeOfThoughts(branch_factor=2, depth=1, score_threshold=0.5).run(state)
+    assert fake.call_count == 3
+
+
+# ---- Code-fence stripping ----
+
+
+@pytest.mark.asyncio
+async def test_strips_code_fences_from_generation() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _resp("```json\n" + _thoughts(2) + "\n```"),
+            _resp("```json\n" + _scores({"t1": 0.9, "t2": 0.7}) + "\n```"),
+            _resp("done"),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=2, depth=1).run(state)
+    assert fake.call_count == 3
+
+
+# ---- scorer="judge" alias ----
+
+
+@pytest.mark.asyncio
+async def test_scorer_judge_falls_back_to_self() -> None:
+    """scorer="judge" deferred to feat-006; for v0.1 it behaves like 'self'."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(2)),
+            _resp(_scores({"t1": 0.9, "t2": 0.6})),
+            _resp("done"),
+        ]
+    )
+    state = _state(fake)
+    await TreeOfThoughts(branch_factor=2, depth=1, scorer="judge").run(state)
+    assert fake.call_count == 3

--- a/packages/agentforge/tests/unit/test_testing_fake_llm.py
+++ b/packages/agentforge/tests/unit/test_testing_fake_llm.py
@@ -1,0 +1,94 @@
+"""Unit tests for `FakeLLMClient`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge._testing import FakeLLMClient
+from agentforge._testing.fake_llm import echo_response
+from agentforge_core.values.messages import LLMResponse, Message, TokenUsage
+
+
+def _resp(content: str = "ok") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=1, output_tokens=1),
+        cost_usd=0.0,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_scripted_responses_in_order() -> None:
+    fake = FakeLLMClient(responses=[_resp("a"), _resp("b")])
+    a = await fake.call("sys", [Message(role="user", content="x")])
+    b = await fake.call("sys", [Message(role="user", content="y")])
+    assert a.content == "a"
+    assert b.content == "b"
+    assert fake.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_raises() -> None:
+    fake = FakeLLMClient(responses=[_resp("only")])
+    await fake.call("sys", [Message(role="user", content="x")])
+    with pytest.raises(RuntimeError, match="exhausted"):
+        await fake.call("sys", [Message(role="user", content="y")])
+
+
+@pytest.mark.asyncio
+async def test_callable_response_spec() -> None:
+    def builder(*, system, messages, tools=None) -> LLMResponse:
+        return _resp(content=f"echo:{messages[-1].content}")
+
+    fake = FakeLLMClient(responses=[builder])
+    response = await fake.call("sys", [Message(role="user", content="hello")])
+    assert response.content == "echo:hello"
+
+
+@pytest.mark.asyncio
+async def test_captures_call_arguments() -> None:
+    fake = FakeLLMClient(responses=[_resp(), _resp()])
+    msgs1 = [Message(role="user", content="first")]
+    msgs2 = [Message(role="user", content="second")]
+    await fake.call("sys-a", msgs1)
+    await fake.call("sys-b", msgs2)
+    captured = fake.captured
+    assert len(captured) == 2
+    assert captured[0][0] == "sys-a"
+    assert captured[0][1] == msgs1
+    assert captured[1][0] == "sys-b"
+
+
+@pytest.mark.asyncio
+async def test_close_marks_closed_and_subsequent_calls_raise() -> None:
+    fake = FakeLLMClient(responses=[_resp()])
+    await fake.close()
+    with pytest.raises(RuntimeError, match="close"):
+        await fake.call("sys", [])
+
+
+def test_capabilities_default_empty() -> None:
+    assert FakeLLMClient().capabilities() == set()
+
+
+def test_capabilities_round_trip() -> None:
+    fake = FakeLLMClient(capabilities={"caching", "thinking"})
+    assert fake.capabilities() == {"caching", "thinking"}
+    assert fake.supports("caching") is True
+    assert fake.supports("streaming") is False
+
+
+def test_echo_response_defaults() -> None:
+    r = echo_response()
+    assert r.content == "ok"
+    assert r.stop_reason == "end_turn"
+    assert r.usage.input_tokens == 1
+
+
+def test_echo_response_overrides() -> None:
+    r = echo_response(content="custom", input_tokens=42, cost_usd=0.05)
+    assert r.content == "custom"
+    assert r.usage.input_tokens == 42
+    assert r.cost_usd == pytest.approx(0.05)

--- a/tests/integration/test_multi_agent_with_fake_llm.py
+++ b/tests/integration/test_multi_agent_with_fake_llm.py
@@ -1,0 +1,80 @@
+"""Integration test — Agent + MultiAgentSupervisor end-to-end."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent, MultiAgentSupervisor, ReActLoop
+from agentforge._testing import FakeLLMClient
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+
+
+def _r(content: str = "") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=0.001,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_string_strategy_multi_agent_runs_end_to_end() -> None:
+    """Default-ish multi-agent: 1 supervisor delegate + 2 workers + 1 aggregate."""
+    fake = FakeLLMClient(
+        responses=[
+            # Supervisor delegation plan
+            _r(
+                '{"assignments": ['
+                '{"worker": "researcher", "task": "find facts"}, '
+                '{"worker": "writer", "task": "summarise"}'
+                "]}"
+            ),
+            # researcher (ReActLoop) — one think, terminates
+            _r("researcher thinks and finishes"),
+            # writer (ReActLoop) — one think, terminates
+            _r("writer thinks and finishes"),
+            # supervisor aggregation
+            _r("Final answer combining both."),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        strategy=MultiAgentSupervisor(
+            workers={
+                "researcher": ReActLoop(max_iterations=3),
+                "writer": ReActLoop(max_iterations=3),
+            }
+        ),
+        budget_usd=5.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("Investigate and summarise topic X.")
+
+    assert result.output == "Final answer combining both."
+    assert result.finish_reason == "completed"
+    kinds = {s.kind for s in result.steps}
+    assert "delegate" in kinds
+    assert "synthesize" in kinds
+
+
+@pytest.mark.asyncio
+async def test_typed_multi_agent_instance_with_descriptions() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _r('{"assignments": [{"worker": "solo", "task": "do it"}]}'),
+            _r("solo finished"),
+            _r("aggregated."),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        strategy=MultiAgentSupervisor(
+            workers={"solo": ReActLoop(max_iterations=2)},
+            worker_descriptions={"solo": "lone specialist"},
+        ),
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("test")
+    assert result.output == "aggregated."

--- a/tests/integration/test_plan_execute_with_fake_llm.py
+++ b/tests/integration/test_plan_execute_with_fake_llm.py
@@ -1,0 +1,100 @@
+"""Integration test — Agent + PlanExecuteLoop end-to-end."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge import Agent, PlanExecuteLoop
+from agentforge._testing import FakeLLMClient
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from pydantic import BaseModel
+
+
+class _MultInput(BaseModel):
+    a: int
+    b: int
+
+
+class _MultTool(Tool):
+    name = "multiply"
+    description = "Multiply two integers."
+    input_schema = _MultInput
+
+    async def run(self, a: int, b: int) -> dict[str, Any]:
+        return {"product": a * b}
+
+
+def _r(content: str = "") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=8, output_tokens=4),
+        cost_usd=0.001,
+        model="fake",
+        provider="fake",
+    )
+
+
+_PARALLEL_PLAN = (
+    '{"steps": ['
+    '{"id": "p1", "description": "2*3", "tool": "multiply", '
+    '"arguments": {"a": 2, "b": 3}, "depends_on": []},'
+    '{"id": "p2", "description": "4*5", "tool": "multiply", '
+    '"arguments": {"a": 4, "b": 5}, "depends_on": []},'
+    '{"id": "p3", "description": "sum", "tool": null, '
+    '"arguments": {}, "depends_on": ["p1", "p2"]}'
+    "]}"
+)
+
+
+@pytest.mark.asyncio
+async def test_string_strategy_plan_execute_runs_full_pipeline() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _r(_PARALLEL_PLAN),
+            _r("p3 thought: sum is 6 + 20 = 26"),
+            _r("Final answer: 26."),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        tools=[_MultTool()],
+        strategy="plan-execute",
+        budget_usd=2.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("Compute 2*3 + 4*5")
+
+    assert result.output == "Final answer: 26."
+    assert result.finish_reason == "completed"
+    assert fake.call_count == 3  # plan + p3 think + synthesis
+    # Expect plan + 2 acts + 2 observes (parallel batch) + 1 observe (think) + synthesize
+    kinds = {s.kind for s in result.steps}
+    assert "plan" in kinds
+    assert "act" in kinds
+    assert "observe" in kinds
+    assert "synthesize" in kinds
+
+
+@pytest.mark.asyncio
+async def test_typed_plan_execute_instance() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _r(
+                '{"steps": [{"id": "x", "description": "do", '
+                '"tool": null, "arguments": {}, "depends_on": []}]}'
+            ),
+            _r("did it"),
+            _r("ok"),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        strategy=PlanExecuteLoop(max_parallel_steps=2, max_replans=0),
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("test")
+
+    assert result.output == "ok"

--- a/tests/integration/test_react_with_fake_llm.py
+++ b/tests/integration/test_react_with_fake_llm.py
@@ -1,0 +1,111 @@
+"""Integration test — `Agent + ReActLoop + FakeLLM + real tools + InMemoryStore`.
+
+End-to-end exercise of feat-002 chunk 2 against the framework wiring
+shipped in feat-001 chunk 1. Verifies that string-resolved
+`strategy="react"` works end to end (resolver lookup → instance →
+runtime injection → loop → result).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge import Agent, ReActLoop
+from agentforge._testing import FakeLLMClient
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.messages import LLMResponse, TokenUsage, ToolCall
+from pydantic import BaseModel
+
+
+class _AddInput(BaseModel):
+    a: int
+    b: int
+
+
+class _AddTool(Tool):
+    name = "add"
+    description = "Add two integers."
+    input_schema = _AddInput
+
+    async def run(self, a: int, b: int) -> dict[str, Any]:
+        return {"sum": a + b}
+
+
+def _r(
+    *,
+    content: str = "",
+    tool_calls: tuple[ToolCall, ...] = (),
+    stop_reason: str = "end_turn",
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls,
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=0.001,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_string_strategy_react_runs_full_loop() -> None:
+    """Agent(strategy='react') wires up the registered ReActLoop and
+    runs a full think → act → observe → think (final) cycle."""
+    fake = FakeLLMClient(
+        responses=[
+            _r(
+                content="I will add 17 and 25.",
+                tool_calls=(ToolCall(id="t1", name="add", arguments={"a": 17, "b": 25}),),
+                stop_reason="tool_use",
+            ),
+            _r(content="The answer is 42."),
+        ]
+    )
+
+    async with Agent(
+        model=fake,
+        tools=[_AddTool()],
+        strategy="react",
+        budget_usd=1.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("What is 17 + 25?")
+
+    assert result.output == "The answer is 42."
+    assert result.cost_usd == pytest.approx(0.002)  # 2 LLM calls at 0.001 each
+    assert result.tokens_in == 20
+    assert result.tokens_out == 10
+    assert result.finish_reason == "completed"
+    # Step trace: think (call 1) → act → observe → think (call 2)
+    kinds = [s.kind for s in result.steps]
+    assert kinds == ["think", "act", "observe", "think"]
+
+
+@pytest.mark.asyncio
+async def test_typed_react_instance_runs() -> None:
+    """Passing a typed ReActLoop instance also works (escape hatch)."""
+    fake = FakeLLMClient(responses=[_r(content="done.")])
+    async with Agent(
+        model=fake,
+        strategy=ReActLoop(max_iterations=10),
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("hi")
+    assert result.output == "done."
+
+
+@pytest.mark.asyncio
+async def test_repeated_runs_get_fresh_budget() -> None:
+    """Bug-carry from feat-001: each Agent.run() must use a fresh
+    BudgetPolicy so spent_usd doesn't leak across runs."""
+    fake = FakeLLMClient(responses=[_r(content="r1"), _r(content="r2")])
+    async with Agent(
+        model=fake, strategy="react", budget_usd=1.0, install_log_filter=False
+    ) as agent:
+        r1 = await agent.run("first")
+        r2 = await agent.run("second")
+    # Each run cost the same (~0.001). r2 should not see r1's spend.
+    assert r1.cost_usd == pytest.approx(0.001)
+    assert r2.cost_usd == pytest.approx(0.001)

--- a/tests/integration/test_tot_with_fake_llm.py
+++ b/tests/integration/test_tot_with_fake_llm.py
@@ -1,0 +1,106 @@
+"""Integration test — Agent + TreeOfThoughts end-to-end."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent, TreeOfThoughts
+from agentforge._testing import FakeLLMClient
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+
+
+def _r(content: str = "") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=5, output_tokens=3),
+        cost_usd=0.001,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_string_strategy_tot_runs_full_search() -> None:
+    """Default ToT (branch_factor=3, depth=2, score_threshold=0.5):
+    level 1 generate + score + level 2 generate + score + synthesize."""
+    fake = FakeLLMClient(
+        responses=[
+            # Level 1
+            _r(
+                '{"thoughts": ['
+                '{"id": "a", "content": "approach A"}, '
+                '{"id": "b", "content": "approach B"}, '
+                '{"id": "c", "content": "approach C"}'
+                "]}"
+            ),
+            _r(
+                '{"scores": ['
+                '{"branch_id": "a", "score": 0.9, "reasoning": "x"}, '
+                '{"branch_id": "b", "score": 0.4, "reasoning": "y"}, '
+                '{"branch_id": "c", "score": 0.7, "reasoning": "z"}'
+                "]}"
+            ),
+            # Level 2 (only "a" and "c" survive 0.5 threshold; both expand
+            # in the same level-2 phase)
+            _r(
+                '{"thoughts": ['
+                '{"id": "a1", "content": "refine A"}, '
+                '{"id": "a2", "content": "alt A"}, '
+                '{"id": "a3", "content": "third A"}'
+                "]}"
+            ),
+            _r(
+                '{"scores": ['
+                '{"branch_id": "a1", "score": 0.95, "reasoning": ""}, '
+                '{"branch_id": "a2", "score": 0.6, "reasoning": ""}, '
+                '{"branch_id": "a3", "score": 0.3, "reasoning": ""}'
+                "]}"
+            ),
+            _r(
+                '{"thoughts": ['
+                '{"id": "c1", "content": "refine C"}, '
+                '{"id": "c2", "content": "alt C"}, '
+                '{"id": "c3", "content": "third C"}'
+                "]}"
+            ),
+            _r(
+                '{"scores": ['
+                '{"branch_id": "c1", "score": 0.55, "reasoning": ""}, '
+                '{"branch_id": "c2", "score": 0.4, "reasoning": ""}, '
+                '{"branch_id": "c3", "score": 0.5, "reasoning": ""}'
+                "]}"
+            ),
+            _r("Final answer using best path."),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        strategy="tot",
+        budget_usd=5.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("Solve this problem.")
+
+    assert result.output == "Final answer using best path."
+    assert result.finish_reason == "completed"
+    kinds = {s.kind for s in result.steps}
+    assert "branch" in kinds
+    assert "synthesize" in kinds
+
+
+@pytest.mark.asyncio
+async def test_typed_tot_instance() -> None:
+    fake = FakeLLMClient(
+        responses=[
+            _r('{"thoughts": [{"id": "a", "content": "x"}]}'),
+            _r('{"scores": [{"branch_id": "a", "score": 0.9, "reasoning": ""}]}'),
+            _r("done"),
+        ]
+    )
+    async with Agent(
+        model=fake,
+        strategy=TreeOfThoughts(branch_factor=1, depth=1, score_threshold=0.5),
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("test")
+    assert result.output == "done"


### PR DESCRIPTION
## Summary

Ships all four reasoning strategies as production-stable in `agentforge.strategies`, per ADR-0008 / feat-002. No experimental package — every strategy is locked at v0.1.

- **`ReActLoop`** — modern reasoning + acting with structured tool calls; terminates on `stop_reason="end_turn"`.
- **`PlanExecuteLoop`** — typed Pydantic plan, topological execution batches with `asyncio.Semaphore`-capped concurrency, replan on parse / execution failure.
- **`TreeOfThoughts`** — beam-search reasoning over scored branches with budget-aware graceful degradation.
- **`MultiAgentSupervisor`** — supervisor delegates subtasks to worker strategies running in parallel under a proportional budget split; workers can be any `ReasoningStrategy` (recursive composition supported).

Plus shared infrastructure (chunk 1): `RuntimeContext`, `StrategyBase`, `get_runtime`, `FakeLLMClient`, and `run_strategy_conformance`. Plus Hypothesis property tests proving the budget invariant holds across all four strategies (chunk 6).

## Test plan

- [x] 302 tests pass (unit + integration + Hypothesis property tests)
- [x] ~96% line + branch coverage on the diff
- [x] mypy --strict clean
- [x] ruff check + format clean
- [x] bandit clean
- [x] pre-commit hook passes end-to-end
- [x] Conformance suite covers every shipped strategy
- [ ] Manual smoke test against AWS Bedrock (deferred to feat-003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)