### PR TITLE
feat(memory+rag): persistent memory + vector search + RAG (feat-007)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
       - name: Mypy strict
-        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src
+        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src
       - name: Bandit
         # -c pyproject.toml so [tool.bandit] (skips B101) is honoured;
         # without it, the conformance suite's asserts in
         # agentforge_core.testing.conformance trip B101.
-        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src
+        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -61,7 +61,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
       - name: Pytest unit
-        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit tests/unit
+        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit tests/unit
       - name: Pytest integration
         run: uv run pytest -q -m "not live" packages/agentforge-bedrock/tests/integration tests/integration
       - name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,78 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-007 — Persistent memory + vector search + RAG.** Lifts agents
+  from "process-local memory only" to "persistent state across runs"
+  and adds semantic retrieval so agents can ground answers in indexed
+  documents. Validates the three-tier package model end-to-end.
+
+  *New core contracts (`agentforge-core`):*
+  - **`VectorStore` ABC** under `agentforge_core.contracts.vector_store`.
+    Methods: `upsert`, `search`, `delete`, `close`, `dimensions`,
+    `capabilities`, `supports`. Distinct from `MemoryStore` (claim
+    audit log) — the shapes don't unify cleanly. Cosine scores
+    normalised to `[0, 1]` (1 = identical direction; 0 = orthogonal-
+    or-anti-correlated).
+  - **`VectorItem`** and **`VectorMatch`** frozen Pydantic value types.
+    Vectors are `tuple[float, ...]` for immutability + hashability.
+  - **`run_vector_conformance(store)`** suite in
+    `agentforge_core.testing`. Pytest-free; verifies the locked
+    invariants every driver must respect: dimensions positive,
+    upsert is write-through, results sorted desc, exact-match
+    scores ≈ 1.0, dimension mismatch raises ValueError, metadata
+    filter is conjunctive AND, delete returns actual count.
+
+  *New runtime helpers (`agentforge`):*
+  - **`InMemoryVectorStore`** — process-local reference impl. Brute-
+    force cosine over an `OrderedDict`. L2-normalises on upsert so
+    search math is a plain dot product. Suitable for tests, demos,
+    small RAG corpora; production swaps to a persistent driver.
+  - **`Retriever`** — high-level adapter wrapping `VectorStore` +
+    `EmbeddingClient`. `add_documents(texts, *, ids=None,
+    metadata=None, batch_size=32)` with auto-ULID generation.
+    `retrieve(query, *, top_k=None, filter_metadata=None)` embeds
+    the query and forwards to `VectorStore.search`. Constructor
+    enforces dimension parity between store and embedder up-front.
+  - **`Agent(retriever=...)`** kwarg threads a `Retriever` through
+    `RuntimeContext.retriever` so strategies can do RAG via
+    `get_runtime(state).retriever.retrieve(...)` without the caller
+    having to thread store/embedder manually. Existing `Agent(...)`
+    constructions keep working — the field is optional.
+
+  *New persistence package (`agentforge-memory-sqlite`):*
+  - **`SqliteMemoryStore`** — persistent `MemoryStore` over
+    `aiosqlite`. Single-table schema with composite indices on
+    `(project, agent)`, `run_id`, and `category`. JSON payload
+    serialisation, supersede() preserves history. `from_path(path)`
+    handles `:memory:` and filesystem databases; async context
+    manager closes the connection.
+  - **`SqliteVectorStore`** — persistent `VectorStore` over
+    `aiosqlite`. Vectors stored as fixed-width float64 BLOBs
+    (`struct.pack '<Nd'`), brute-force cosine scan in Python
+    (~10k vectors fine; v0.2 will add an opt-in `sqlite-vec`
+    extension path declared via the `"native_ann"` capability).
+    Dimensions pinned per database in a `vector_meta` table — re-
+    opening with a different value raises `ValueError` rather than
+    silently corrupting.
+  - Both stores pass the framework's conformance suites verbatim.
+
+  *Tests:* 89 new unit tests covering value-type validation,
+  ABC default behaviour, the in-memory impl, the `Retriever`
+  adapter (auto-ULID, batching, length-mismatch validation,
+  metadata forwarding), `SqliteMemoryStore` (conformance + edge
+  cases + persistence across reconnects), `SqliteVectorStore`
+  (conformance + dimension pinning + BLOB roundtrip), and Agent
+  retriever wiring. Plus 7 Hypothesis property tests for vector
+  invariants (cosine direction-only, dimension enforcement, sort
+  order, bounded result count, delete round-trip) and a 3-test
+  integration suite that wires the full RAG pipeline end-to-end
+  (Embedder → VectorStore → Retriever → Agent).
+
+  *Postgres deferred to feat-008.* SQLite covers the v0.1 use
+  cases (development, single-host deployments, small-to-medium
+  RAG corpora). A production Postgres driver with `pgvector` and
+  `asyncpg` ships in feat-008 once we have actual deployment plans.
+
 - **feat-003 — `agentforge-bedrock` provider + capability extensions.**
   First concrete LLM provider for AgentForge. AWS Bedrock support
   (Anthropic, Titan, Cohere) over the Converse / ConverseStream /

--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ Credentials follow the standard AWS chain (`~/.aws/credentials`,
 (`us.…`, `eu.…`, `apac.…`, `global.…`) are passed through to
 Bedrock unchanged.
 
+### Retrieval-augmented generation (feat-007)
+
+```python
+from agentforge import Agent, InMemoryVectorStore, Retriever
+from agentforge_bedrock import BedrockEmbeddingClient
+
+embedder = BedrockEmbeddingClient(model_id="amazon.titan-embed-text-v2:0")
+store = InMemoryVectorStore(dimensions=embedder.dimensions())
+retriever = Retriever(store=store, embedder=embedder)
+
+await retriever.add_documents([
+    "AgentForge is an open-source agentic framework.",
+    "It ships four reasoning strategies stable in v0.1.",
+])
+
+async with Agent(
+    model="bedrock:us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    strategy="react",
+    retriever=retriever,
+) as agent:
+    result = await agent.run("What strategies does AgentForge ship?")
+    print(result.output)
+```
+
+For persistence beyond a single process, swap `InMemoryVectorStore`
+for `SqliteVectorStore` from `agentforge-memory-sqlite` — same
+contract, file-backed.
+
 ## Repository structure
 
 This is a **uv workspace** — one git repo, multiple installable
@@ -47,7 +75,8 @@ agentforge-py/
 ├── packages/
 │   ├── agentforge-core/            stable contracts (ABCs, value types)
 │   ├── agentforge/                 default runtime (Agent, defaults)
-│   └── agentforge-bedrock/         AWS Bedrock provider (LLM + embeddings)
+│   ├── agentforge-bedrock/         AWS Bedrock provider (LLM + embeddings)
+│   └── agentforge-memory-sqlite/   SQLite memory + vector drivers
 ├── tests/                          cross-package integration / conformance
 └── .github/workflows/              CI
 ```

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -20,6 +20,7 @@ from agentforge_core.contracts import (
     MemoryStore,
     ReasoningStrategy,
     Tool,
+    VectorStore,
 )
 from agentforge_core.production import (
     AgentForgeError,
@@ -67,6 +68,8 @@ from agentforge_core.values import (
     TokenUsage,
     ToolCall,
     ToolSpec,
+    VectorItem,
+    VectorMatch,
 )
 
 __version__ = "0.0.0"
@@ -111,6 +114,9 @@ __all__ = [
     "Tool",
     "ToolCall",
     "ToolSpec",
+    "VectorItem",
+    "VectorMatch",
+    "VectorStore",
     "__version__",
     "bind_run",
     "current_run",

--- a/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
@@ -14,6 +14,7 @@ from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.memory import MemoryStore
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.contracts.tool import Tool
+from agentforge_core.contracts.vector_store import VectorStore
 
 __all__ = [
     "EmbeddingClient",
@@ -24,4 +25,5 @@ __all__ = [
     "MemoryStore",
     "ReasoningStrategy",
     "Tool",
+    "VectorStore",
 ]

--- a/packages/agentforge-core/src/agentforge_core/contracts/vector_store.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/vector_store.py
@@ -1,0 +1,110 @@
+"""`VectorStore` — locked semantic-search ABC.
+
+A vector store is distinct from `MemoryStore` (the claim audit log):
+the shapes don't unify cleanly. Vectors search by similarity; claims
+filter by structured metadata + monotonic ULID ordering. We keep two
+separate ABCs and a user who wants similarity over claims puts the
+claim text into a vector store with `metadata={"claim_id": <id>}`.
+
+Per ADR-0007 the surface is locked at v0.1: adding a method is a
+major version bump. Optional capabilities (e.g. native ANN indexes,
+hybrid search) layer the same way as `LLMClient` capabilities —
+declared via `capabilities()` and gated via `supports()`.
+
+Conformance: every shipped or third-party driver must pass
+`agentforge_core.testing.run_vector_conformance` (lands alongside
+this contract).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from agentforge_core.values.vector import VectorItem, VectorMatch
+
+
+class VectorStore(ABC):
+    """Provider-agnostic vector index.
+
+    Implementations:
+      - declare a fixed `dimensions()` — every upserted vector and
+        every search vector must match
+      - normalise scores to cosine similarity in `[0, 1]` regardless
+        of internal distance metric (drivers convert at the boundary)
+      - implement metadata filtering as conjunctive equality on every
+        key/value pair the caller passes
+
+    Cross-driver invariants enforced by the conformance suite:
+      - upsert(id=X) followed by upsert(id=X) replaces the prior
+        record (write-through semantics)
+      - search returns at most `limit` items, sorted by score desc
+      - dimension mismatch on upsert or search raises `ValueError`
+    """
+
+    @abstractmethod
+    async def upsert(self, items: list[VectorItem]) -> None:
+        """Insert or replace `items`.
+
+        If two items in `items` share an id, the last one wins. Callers
+        wanting transactional all-or-nothing semantics should batch via
+        a single `upsert` call (drivers may still split the request
+        internally).
+
+        Raises:
+            ValueError: a vector's length does not match `dimensions()`.
+        """
+
+    @abstractmethod
+    async def search(
+        self,
+        query_vector: tuple[float, ...],
+        *,
+        limit: int = 5,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        """Return the top-`limit` items by cosine similarity.
+
+        Args:
+            query_vector: Length must equal `dimensions()`.
+            limit: Maximum results to return. Drivers may return fewer.
+            filter_metadata: Conjunctive equality filter on the items'
+                `metadata` dict. `None` means no filtering.
+
+        Raises:
+            ValueError: dimension mismatch or `limit < 1`.
+        """
+
+    @abstractmethod
+    async def delete(self, ids: list[str]) -> int:
+        """Delete by id. Returns the number of items actually removed.
+
+        Unknown ids are silently ignored (no exception). Empty `ids`
+        list returns 0.
+        """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release backing resources (connections, file handles)."""
+
+    @abstractmethod
+    def dimensions(self) -> int:
+        """The fixed vector dimensionality this store accepts.
+
+        Synchronous so callers can size storage / validate input
+        without a network round-trip.
+        """
+
+    def capabilities(self) -> set[str]:
+        """Optional capabilities this driver supports.
+
+        Default empty set. Closed vocabulary (additions are minor
+        bumps): `"native_ann"` (driver uses an ANN index rather than
+        brute force), `"hybrid_search"` (BM25 + vector fusion),
+        `"transactions"` (multi-statement atomic upserts).
+        """
+        return set()
+
+    def supports(self, capability: str) -> bool:
+        """True if this driver declares the given capability."""
+        return capability in self.capabilities()

--- a/packages/agentforge-core/src/agentforge_core/testing/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/__init__.py
@@ -16,10 +16,12 @@ from agentforge_core.testing.conformance import (
     run_embedding_conformance,
     run_memory_conformance,
     run_strategy_conformance,
+    run_vector_conformance,
 )
 
 __all__ = [
     "run_embedding_conformance",
     "run_memory_conformance",
     "run_strategy_conformance",
+    "run_vector_conformance",
 ]

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -18,14 +18,18 @@ Usage in a driver's tests:
 
 from __future__ import annotations
 
+import itertools
+import math
 import typing
 from collections.abc import AsyncIterator, Awaitable, Callable
 
 from agentforge_core.contracts.embedding import EmbeddingClient
 from agentforge_core.contracts.memory import MemoryStore
 from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.contracts.vector_store import VectorStore
 from agentforge_core.values.claim import Claim
 from agentforge_core.values.state import AgentState, StepKind
+from agentforge_core.values.vector import VectorItem
 
 _VALID_STEP_KINDS: frozenset[str] = frozenset(typing.get_args(StepKind))
 """Closed enum mirror of `StepKind`. Used by `run_strategy_conformance`."""
@@ -291,3 +295,137 @@ async def run_embedding_conformance(client: EmbeddingClient) -> None:
 
     # 8. supports() is honest about unknown capabilities
     assert client.supports("definitely-not-a-capability-2026") is False
+
+
+# ----------------------------------------------------------------------
+# Vector store conformance — feat-007.
+# ----------------------------------------------------------------------
+
+
+async def run_vector_conformance(store: VectorStore) -> None:
+    """Run the shared `VectorStore` conformance suite.
+
+    The store must be empty when this is called and is left empty when
+    the function returns (every item upserted is also deleted).
+
+    Verifies the locked invariants of `VectorStore`:
+
+      1. `dimensions()` returns a positive int with no network call.
+      2. `upsert` accepts items whose vectors match `dimensions()`;
+         dimension mismatch raises `ValueError`.
+      3. `search` returns at most `limit` matches sorted by score
+         descending, with scores in `[0, 1]`.
+      4. `search`'s top hit on a query identical to an upserted
+         vector returns that item with score ≈ 1.0.
+      5. `upsert` is write-through: re-upserting an existing id
+         replaces the prior record (no duplicate ids in results).
+      6. `delete` returns the count of items actually removed; unknown
+         ids are silently dropped (no exception).
+      7. `filter_metadata` AND-matches every key/value in the dict.
+      8. `search(limit=0)` raises `ValueError`.
+      9. `supports("not-a-real-capability")` returns False.
+
+    Drivers may issue real network calls; the suite is async. Tests are
+    responsible for arranging fixtures (e.g. running Postgres) before
+    calling this helper.
+
+    Raises:
+        AssertionError: a contract was violated.
+    """
+    _ITEM_COUNT = 3  # noqa: N806 — local constant in this function only
+
+    dim = store.dimensions()
+    assert isinstance(dim, int), "dimensions() must return an int"
+    assert dim >= 1, f"dimensions() must be >= 1, got {dim}"
+
+    # 2. dimension-mismatch on upsert
+    bad = VectorItem(id="bad", vector=tuple([0.1] * (dim + 1)), text="bad", metadata={})
+    raised_dim_error = False
+    try:
+        await store.upsert([bad])
+    except ValueError:
+        raised_dim_error = True
+    assert raised_dim_error, "upsert with mismatched vector length must raise ValueError"
+
+    # 3-5. happy-path upsert + search
+    items = [
+        VectorItem(
+            id=f"id-{i}",
+            vector=tuple(_unit_vector(dim, seed=i)),
+            text=f"text {i}",
+            metadata={"category": "doc" if i < 2 else "note", "n": i},  # noqa: PLR2004
+        )
+        for i in range(_ITEM_COUNT)
+    ]
+    await store.upsert(items)
+
+    # Searching with the same vector as item-0 should put item-0 first.
+    results = await store.search(items[0].vector, limit=_ITEM_COUNT)
+    assert len(results) == _ITEM_COUNT, f"expected {_ITEM_COUNT} results, got {len(results)}"
+    # Sorted by score descending, all in [0, 1]
+    for prev, nxt in itertools.pairwise(results):
+        assert prev.score >= nxt.score, f"results not sorted desc: {prev.score} before {nxt.score}"
+    for r in results:
+        assert 0.0 <= r.score <= 1.0, f"score out of range: {r.score}"
+    assert results[0].id == "id-0", (
+        f"top result must be the exact-match upsert, got {results[0].id!r}"
+    )
+    score_tolerance = 1e-3
+    assert abs(results[0].score - 1.0) < score_tolerance, (
+        f"exact-match score must be ~1.0, got {results[0].score}"
+    )
+
+    # 5. write-through: replace id-0 and search again
+    replacement = VectorItem(
+        id="id-0",
+        vector=tuple(_unit_vector(dim, seed=99)),
+        text="replaced",
+        metadata={"category": "doc", "n": 0},
+    )
+    await store.upsert([replacement])
+    after = await store.search(items[0].vector, limit=10)
+    # No two results may share an id.
+    seen_ids = [r.id for r in after]
+    assert len(seen_ids) == len(set(seen_ids)), (
+        f"upsert must replace prior records, but got duplicate ids: {seen_ids}"
+    )
+
+    # 7. metadata filtering
+    filtered = await store.search(items[0].vector, limit=10, filter_metadata={"category": "doc"})
+    for r in filtered:
+        assert r.metadata.get("category") == "doc", (
+            f"filter_metadata broken: returned {r.metadata!r}"
+        )
+
+    # 8. limit < 1 raises
+    raised_limit_error = False
+    try:
+        await store.search(items[0].vector, limit=0)
+    except ValueError:
+        raised_limit_error = True
+    assert raised_limit_error, "search(limit=0) must raise ValueError"
+
+    # 6. delete: known + unknown ids
+    deleted = await store.delete([item.id for item in items] + ["never-existed"])
+    assert deleted == _ITEM_COUNT, (
+        f"delete should report {_ITEM_COUNT} actual removals "
+        f"(the {_ITEM_COUNT} we upserted), got {deleted}"
+    )
+    # Empty list returns 0
+    assert await store.delete([]) == 0
+
+    # 9. supports honesty
+    assert store.supports("definitely-not-a-capability-2026") is False
+
+
+def _unit_vector(dim: int, *, seed: int) -> list[float]:
+    """Build a deterministic unit vector for conformance tests.
+
+    Returns a one-hot-like vector with the seed-th component set high
+    and a small uniform background, then L2-normalised so cosine
+    similarity computations are stable across drivers.
+    """
+    raw = [0.01] * dim
+    raw[seed % dim] = 1.0
+    norm = math.sqrt(sum(x * x for x in raw))
+    return [x / norm for x in raw]

--- a/packages/agentforge-core/src/agentforge_core/values/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/values/__init__.py
@@ -27,6 +27,7 @@ from agentforge_core.values.state import (
     Step,
     StepKind,
 )
+from agentforge_core.values.vector import VectorItem, VectorMatch
 
 __all__ = [
     "AgentState",
@@ -45,4 +46,6 @@ __all__ = [
     "TokenUsage",
     "ToolCall",
     "ToolSpec",
+    "VectorItem",
+    "VectorMatch",
 ]

--- a/packages/agentforge-core/src/agentforge_core/values/vector.py
+++ b/packages/agentforge-core/src/agentforge_core/values/vector.py
@@ -1,0 +1,59 @@
+"""Frozen value types for the `VectorStore` contract.
+
+`VectorItem` is what callers upsert into a vector store; `VectorMatch`
+is what searches return. Both are immutable Pydantic models so they
+can be freely passed across async boundaries without aliasing bugs.
+
+Per ADR-0007 these shapes are part of the framework's locked surface.
+Adding a field is a minor bump; removing or renaming requires a major
+bump.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VectorItem(BaseModel):
+    """One indexable record in a `VectorStore`.
+
+    Attributes:
+        id: Caller-controlled identifier. Re-upserting an existing id
+            replaces the prior record (write-through, not append).
+        vector: The embedding. Length must match the store's declared
+            `dimensions()`; mismatch raises on `upsert`.
+        text: The source text the vector was computed from. Surfaced on
+            `VectorMatch` so callers don't have to keep a parallel
+            text store. Empty strings are allowed but discouraged.
+        metadata: Free-form key-value tags. Used by `search`'s
+            `filter_metadata=` argument for AND-style filtering. Kept
+            as a plain dict (not frozen) so Pydantic doesn't have to
+            recurse into arbitrary user payloads.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str = Field(min_length=1)
+    vector: tuple[float, ...]
+    text: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class VectorMatch(BaseModel):
+    """One result from `VectorStore.search`.
+
+    `score` is normalised cosine similarity in `[0, 1]`:
+      - 1.0 means identical direction (highest relevance)
+      - 0.0 means orthogonal (effectively unrelated)
+      - the contract is store-agnostic; drivers that return raw cosine
+        distance or negative inner-product convert at the boundary.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str
+    text: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    score: float = Field(ge=0.0, le=1.0)

--- a/packages/agentforge-core/tests/unit/test_values_vector.py
+++ b/packages/agentforge-core/tests/unit/test_values_vector.py
@@ -1,0 +1,85 @@
+"""Unit tests for the `VectorItem` and `VectorMatch` value types."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.values.vector import VectorItem, VectorMatch
+from pydantic import ValidationError
+
+# ---- VectorItem ----
+
+
+def test_vector_item_basic() -> None:
+    item = VectorItem(id="x", vector=(1.0, 0.0, 0.0), text="hello")
+    assert item.id == "x"
+    assert item.vector == (1.0, 0.0, 0.0)
+    assert item.text == "hello"
+    assert item.metadata == {}
+
+
+def test_vector_item_rejects_empty_id() -> None:
+    with pytest.raises(ValidationError):
+        VectorItem(id="", vector=(1.0,), text="x")
+
+
+def test_vector_item_is_frozen() -> None:
+    item = VectorItem(id="x", vector=(0.5,), text="x")
+    with pytest.raises(ValidationError):
+        item.text = "mutated"  # type: ignore[misc]
+
+
+def test_vector_item_metadata_defaults_to_empty_dict() -> None:
+    item = VectorItem(id="x", vector=(1.0,), text="x")
+    assert item.metadata == {}
+
+
+def test_vector_item_metadata_accepts_arbitrary_payload() -> None:
+    item = VectorItem(
+        id="x",
+        vector=(1.0,),
+        text="x",
+        metadata={"category": "doc", "year": 2024, "tags": ["a", "b"]},
+    )
+    assert item.metadata["category"] == "doc"
+    assert item.metadata["tags"] == ["a", "b"]
+
+
+def test_vector_item_vector_must_be_a_tuple() -> None:
+    """Strict-mode pydantic rejects lists where tuples are declared.
+    Forces callers to think about immutability — vectors should be
+    `tuple[float, ...]`, not mutable lists that might be aliased
+    elsewhere."""
+    with pytest.raises(ValidationError):
+        VectorItem(id="x", vector=[1.0, 2.0, 3.0], text="x")  # type: ignore[arg-type]
+
+
+# ---- VectorMatch ----
+
+
+def test_vector_match_basic() -> None:
+    m = VectorMatch(id="x", text="hello", score=0.85)
+    assert m.id == "x"
+    assert m.score == 0.85
+
+
+def test_vector_match_rejects_score_above_one() -> None:
+    with pytest.raises(ValidationError):
+        VectorMatch(id="x", text="hello", score=1.5)
+
+
+def test_vector_match_rejects_negative_score() -> None:
+    with pytest.raises(ValidationError):
+        VectorMatch(id="x", text="hello", score=-0.1)
+
+
+def test_vector_match_score_at_zero_and_one_allowed() -> None:
+    """Boundary values must be allowed — orthogonal (0) and identical
+    (1) are both legitimate scores under the contract."""
+    VectorMatch(id="x", text="x", score=0.0)
+    VectorMatch(id="x", text="x", score=1.0)
+
+
+def test_vector_match_is_frozen() -> None:
+    m = VectorMatch(id="x", text="x", score=0.5)
+    with pytest.raises(ValidationError):
+        m.score = 0.9  # type: ignore[misc]

--- a/packages/agentforge-core/tests/unit/test_vector_store_contract.py
+++ b/packages/agentforge-core/tests/unit/test_vector_store_contract.py
@@ -1,0 +1,96 @@
+"""Unit tests for the `VectorStore` ABC default behaviours.
+
+The ABC itself is abstract, so most behaviour testing happens via the
+conformance suite against concrete drivers. Here we cover the
+default-method behaviours that don't require a concrete impl.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge_core.contracts.vector_store import VectorStore
+from agentforge_core.values.vector import VectorItem, VectorMatch
+
+
+class _MinimalStore(VectorStore):
+    """Minimal concrete impl with no extra capabilities."""
+
+    def __init__(self, *, dim: int = 4) -> None:
+        self._dim = dim
+
+    def dimensions(self) -> int:
+        return self._dim
+
+    async def upsert(self, items: list[VectorItem]) -> None: ...
+
+    async def search(
+        self,
+        query_vector: tuple[float, ...],
+        *,
+        limit: int = 5,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        return []
+
+    async def delete(self, ids: list[str]) -> int:
+        return 0
+
+    async def close(self) -> None: ...
+
+
+class _AnnStore(_MinimalStore):
+    """Driver that declares native ANN support."""
+
+    def capabilities(self) -> set[str]:
+        return {"native_ann"}
+
+
+# ---- Default capabilities ----
+
+
+def test_default_store_declares_no_capabilities() -> None:
+    store = _MinimalStore()
+    assert store.capabilities() == set()
+    assert store.supports("native_ann") is False
+    assert store.supports("anything") is False
+
+
+def test_ann_store_declares_native_ann() -> None:
+    store = _AnnStore()
+    assert store.supports("native_ann") is True
+    # Other capabilities still report False.
+    assert store.supports("hybrid_search") is False
+
+
+def test_supports_unknown_capability_is_false() -> None:
+    """Per ADR-0009, supports() is honest about unknowns — never
+    optimistically True for capabilities the driver hasn't declared."""
+    assert _AnnStore().supports("not-a-capability-2026") is False
+
+
+# ---- ABC enforces required methods ----
+
+
+def test_abc_rejects_partial_implementation() -> None:
+    """Trying to instantiate a subclass missing required methods
+    raises TypeError at construction (ABC behaviour)."""
+
+    class _Incomplete(VectorStore):
+        async def upsert(self, items: list[VectorItem]) -> None: ...
+
+        # Missing search, delete, close, dimensions.
+
+    with pytest.raises(TypeError, match="abstract"):
+        _Incomplete()  # type: ignore[abstract]
+
+
+# ---- Dimensions accessor ----
+
+
+def test_dimensions_is_sync() -> None:
+    """Callers must be able to size storage without awaiting — the
+    contract says so for every driver."""
+    store = _MinimalStore(dim=1024)
+    assert store.dimensions() == 1024

--- a/packages/agentforge-memory-sqlite/LICENSE
+++ b/packages/agentforge-memory-sqlite/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agentforge-memory-sqlite/NOTICE
+++ b/packages/agentforge-memory-sqlite/NOTICE
@@ -1,0 +1,11 @@
+AgentForge
+Copyright 2026 The AgentForge Authors
+
+This product includes software developed at the AgentForge project
+(https://github.com/Scaffoldic/agentforge-py).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/agentforge-memory-sqlite/README.md
+++ b/packages/agentforge-memory-sqlite/README.md
@@ -1,0 +1,39 @@
+# agentforge-memory-sqlite
+
+SQLite-backed `MemoryStore` and `VectorStore` for [AgentForge](https://github.com/Scaffoldic/agentforge-py).
+
+Zero external services required — the database lives in a single file
+(or `:memory:` for tests). Suitable for development, single-host
+deployments, and small-to-medium RAG corpora (~10k vectors).
+
+## Install
+
+```bash
+uv add agentforge-memory-sqlite
+```
+
+## Usage
+
+```python
+from agentforge_memory_sqlite import SqliteMemoryStore, SqliteVectorStore
+
+# Claim audit log
+async with SqliteMemoryStore.from_path("agent.db") as memory:
+    await memory.put(claim)
+
+# Semantic search
+async with SqliteVectorStore.from_path("agent.db", dimensions=1024) as store:
+    await store.upsert(items)
+    matches = await store.search(query_vector, limit=5)
+```
+
+Both classes pass `agentforge_core.testing.run_memory_conformance` /
+`run_vector_conformance` so they're drop-in replacements for the
+in-memory defaults.
+
+## Performance
+
+`SqliteVectorStore` does brute-force cosine search in Python: O(N) per
+query. Fine for ~10k vectors; sluggish past that. v0.2 will add an
+opt-in `sqlite-vec` extension path declared via the `"native_ann"`
+capability flag.

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -1,0 +1,66 @@
+# agentforge-memory-sqlite — SQLite drivers for AgentForge.
+#
+# Implements MemoryStore (claim audit log) and VectorStore (semantic
+# search) over SQLite via aiosqlite. Zero external services required:
+# the database is a single file (or `:memory:` for tests).
+#
+# Per ADR-0003 (three-tier package model — this is Tier 3, a
+# persistence module) and ADR-0014 (async-first runtime — uses
+# aiosqlite, not stdlib sqlite3).
+
+[project]
+name = "agentforge-memory-sqlite"
+version = "0.0.0"
+description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "The AgentForge Authors"},
+]
+keywords = ["ai", "agent", "memory", "vector", "sqlite", "rag"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "agentforge-core",
+    "aiosqlite>=0.20",
+]
+
+[project.urls]
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Documentation = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Scaffoldic/agentforge-py/issues"
+
+# Entry-point registration — feat-010 will load these.
+[project.entry-points."agentforge.memory"]
+sqlite = "agentforge_memory_sqlite.memory:SqliteMemoryStore"
+
+[project.entry-points."agentforge.vector_stores"]
+sqlite = "agentforge_memory_sqlite.vector:SqliteVectorStore"
+
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentforge_memory_sqlite"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/agentforge_memory_sqlite",
+    "tests",
+    "README.md",
+    "LICENSE",
+]

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
@@ -1,0 +1,17 @@
+"""AgentForge — SQLite memory + vector drivers.
+
+Implements `MemoryStore` (claim audit log) and `VectorStore` (semantic
+search) over SQLite via `aiosqlite`. Zero external services required.
+
+Per ADR-0014 every code path is async — uses `aiosqlite`, never the
+blocking stdlib `sqlite3`, in agent code paths.
+"""
+
+from __future__ import annotations
+
+from agentforge_memory_sqlite.memory import SqliteMemoryStore
+from agentforge_memory_sqlite.vector import SqliteVectorStore
+
+__version__ = "0.0.0"
+
+__all__ = ["SqliteMemoryStore", "SqliteVectorStore", "__version__"]

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/memory.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/memory.py
@@ -1,0 +1,217 @@
+"""`SqliteMemoryStore` — `MemoryStore` over SQLite via aiosqlite.
+
+Single-table schema: every claim is stored as one row keyed by `id`
+with project / agent / category / run_id / supersedes columns and
+the JSON payload as a TEXT blob. Queries hit composite indices on
+the common filter combinations.
+
+Schema is created on first connect via `CREATE TABLE IF NOT EXISTS`.
+No migrations in v0.1 — the table shape is fixed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from datetime import datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+import aiosqlite
+from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.values.claim import Claim
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS claims (
+    id          TEXT PRIMARY KEY,
+    project     TEXT NOT NULL,
+    agent       TEXT NOT NULL,
+    run_id      TEXT NOT NULL,
+    category    TEXT NOT NULL,
+    payload     TEXT NOT NULL,
+    supersedes  TEXT,
+    created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_claims_project_agent
+    ON claims(project, agent);
+CREATE INDEX IF NOT EXISTS idx_claims_run_id
+    ON claims(run_id);
+CREATE INDEX IF NOT EXISTS idx_claims_category
+    ON claims(category);
+"""
+
+
+class SqliteMemoryStore(MemoryStore):
+    """Persistent `MemoryStore` backed by a single SQLite file.
+
+    Use `from_path(path)` for ergonomic construction; the bare
+    constructor accepts an already-opened `aiosqlite.Connection` for
+    callers who manage the connection themselves.
+    """
+
+    def __init__(self, *, connection: aiosqlite.Connection) -> None:
+        self._db = connection
+
+    # ------------------------------------------------------------------
+    # Construction / lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def from_path(cls, path: str | Path) -> SqliteMemoryStore:
+        """Open or create a SQLite database at `path` and return a store.
+
+        `path` may be `":memory:"` for an ephemeral in-process database,
+        or a filesystem path (the parent directory must exist).
+        """
+        connection = await aiosqlite.connect(str(path))
+        connection.row_factory = aiosqlite.Row
+        await connection.executescript(_SCHEMA_SQL)
+        await connection.commit()
+        return cls(connection=connection)
+
+    async def __aenter__(self) -> SqliteMemoryStore:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        await self._db.close()
+
+    # ------------------------------------------------------------------
+    # MemoryStore contract
+    # ------------------------------------------------------------------
+
+    async def put(self, claim: Claim) -> str:
+        await self._db.execute(
+            """INSERT OR REPLACE INTO claims
+               (id, project, agent, run_id, category, payload, supersedes, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                claim.id,
+                claim.project,
+                claim.agent,
+                claim.run_id,
+                claim.category,
+                json.dumps(claim.payload),
+                claim.supersedes,
+                claim.created_at.isoformat(),
+            ),
+        )
+        await self._db.commit()
+        return claim.id
+
+    async def get(self, claim_id: str) -> Claim | None:
+        async with self._db.execute(
+            "SELECT * FROM claims WHERE id = ?",
+            (claim_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return _row_to_claim(row)
+
+    async def query(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+        limit: int = 100,
+    ) -> list[Claim]:
+        sql, params = _build_filter_sql(project, agent, category, run_id, limit)
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        return [_row_to_claim(row) for row in rows]
+
+    async def supersede(self, old_id: str, new_claim: Claim) -> str:
+        existing = await self.get(old_id)
+        if existing is None:
+            raise ModuleError(f"Cannot supersede unknown claim id: {old_id!r}")
+        if new_claim.supersedes is None:
+            new_claim = new_claim.model_copy(update={"supersedes": old_id})
+        elif new_claim.supersedes != old_id:
+            raise ModuleError(
+                f"new_claim.supersedes={new_claim.supersedes!r} does not match old_id={old_id!r}"
+            )
+        return await self.put(new_claim)
+
+    def stream(
+        self,
+        *,
+        project: str | None = None,
+        agent: str | None = None,
+        category: str | None = None,
+        run_id: str | None = None,
+    ) -> AsyncIterator[Claim]:
+        sql, params = _build_filter_sql(project, agent, category, run_id, limit=None)
+
+        async def _agen() -> AsyncIterator[Claim]:
+            async with self._db.execute(sql, params) as cur:
+                async for row in cur:
+                    yield _row_to_claim(row)
+
+        return _agen()
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _row_to_claim(row: Any) -> Claim:
+    """Convert an `aiosqlite.Row` into a `Claim`."""
+    return Claim(
+        id=row["id"],
+        project=row["project"],
+        agent=row["agent"],
+        run_id=row["run_id"],
+        category=row["category"],
+        payload=json.loads(row["payload"]),
+        supersedes=row["supersedes"],
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )
+
+
+def _build_filter_sql(
+    project: str | None,
+    agent: str | None,
+    category: str | None,
+    run_id: str | None,
+    limit: int | None,
+) -> tuple[str, tuple[Any, ...]]:
+    """Compose a SELECT with conjunctive filters and an optional LIMIT."""
+    where: list[str] = []
+    params: list[Any] = []
+    if project is not None:
+        where.append("project = ?")
+        params.append(project)
+    if agent is not None:
+        where.append("agent = ?")
+        params.append(agent)
+    if category is not None:
+        where.append("category = ?")
+        params.append(category)
+    if run_id is not None:
+        where.append("run_id = ?")
+        params.append(run_id)
+
+    sql = "SELECT * FROM claims"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY created_at"
+    if limit is not None:
+        sql += " LIMIT ?"
+        params.append(limit)
+    return sql, tuple(params)
+
+
+__all__ = ["SqliteMemoryStore"]

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/vector.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/vector.py
@@ -1,0 +1,200 @@
+"""`SqliteVectorStore` — `VectorStore` over SQLite via aiosqlite.
+
+Vectors are stored as fixed-width BLOBs (8 bytes per float64, packed
+big-endian). On search the entire table is loaded and cosine
+similarity is computed in Python — O(N) per query. Fine for
+~10k vectors; v0.2 will add an opt-in `sqlite-vec` extension path.
+
+Schema is created on first connect via `CREATE TABLE IF NOT EXISTS`
+and `dimensions` are pinned per database. Re-opening with a
+different dimensions value raises at construction.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+import aiosqlite
+from agentforge_core.contracts.vector_store import VectorStore
+from agentforge_core.values.vector import VectorItem, VectorMatch
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS vectors (
+    id          TEXT PRIMARY KEY,
+    vector      BLOB NOT NULL,
+    text        TEXT NOT NULL,
+    metadata    TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS vector_meta (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL
+);
+"""
+
+
+class SqliteVectorStore(VectorStore):
+    """Persistent `VectorStore` backed by a SQLite file.
+
+    Use `from_path(path, dimensions)` for ergonomic construction. The
+    bare constructor accepts an opened connection plus dimensions for
+    callers who manage their own connection.
+    """
+
+    def __init__(self, *, connection: aiosqlite.Connection, dimensions: int) -> None:
+        if dimensions < 1:
+            raise ValueError(f"dimensions must be >= 1, got {dimensions}")
+        self._db = connection
+        self._dim = dimensions
+
+    @classmethod
+    async def from_path(cls, path: str | Path, *, dimensions: int) -> SqliteVectorStore:
+        """Open or create a vector store at `path` with `dimensions`.
+
+        If the file already contains a vector index with a different
+        dimension, raises `ValueError` — dimensions are pinned per
+        database to prevent silent corruption.
+        """
+        if dimensions < 1:
+            raise ValueError(f"dimensions must be >= 1, got {dimensions}")
+        connection = await aiosqlite.connect(str(path))
+        connection.row_factory = aiosqlite.Row
+        await connection.executescript(_SCHEMA_SQL)
+        # Pin dimensions on first use; verify on re-open.
+        async with connection.execute(
+            "SELECT value FROM vector_meta WHERE key = 'dimensions'"
+        ) as cur:
+            existing = await cur.fetchone()
+        if existing is None:
+            await connection.execute(
+                "INSERT INTO vector_meta(key, value) VALUES ('dimensions', ?)",
+                (str(dimensions),),
+            )
+            await connection.commit()
+        else:
+            stored = int(existing["value"])
+            if stored != dimensions:
+                await connection.close()
+                raise ValueError(
+                    f"vector store at {path!s} has dimensions={stored} "
+                    f"but caller asked for dimensions={dimensions}"
+                )
+        return cls(connection=connection, dimensions=dimensions)
+
+    async def __aenter__(self) -> SqliteVectorStore:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    def dimensions(self) -> int:
+        return self._dim
+
+    async def upsert(self, items: list[VectorItem]) -> None:
+        rows: list[tuple[str, bytes, str, str]] = []
+        for item in items:
+            if len(item.vector) != self._dim:
+                raise ValueError(
+                    f"vector for id={item.id!r} has length {len(item.vector)} "
+                    f"but store dimensions={self._dim}"
+                )
+            normalised = _l2_normalise(item.vector)
+            rows.append(
+                (
+                    item.id,
+                    _pack_vector(normalised),
+                    item.text,
+                    json.dumps(item.metadata),
+                )
+            )
+        await self._db.executemany(
+            "INSERT OR REPLACE INTO vectors(id, vector, text, metadata) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        await self._db.commit()
+
+    async def search(
+        self,
+        query_vector: tuple[float, ...],
+        *,
+        limit: int = 5,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+        if len(query_vector) != self._dim:
+            raise ValueError(
+                f"query vector has length {len(query_vector)} but store dimensions={self._dim}"
+            )
+
+        query = _l2_normalise(query_vector)
+        scored: list[tuple[float, str, str, dict[str, Any]]] = []
+        async with self._db.execute("SELECT * FROM vectors") as cur:
+            async for row in cur:
+                metadata = json.loads(row["metadata"])
+                if filter_metadata is not None and not _matches_filter(metadata, filter_metadata):
+                    continue
+                vec = _unpack_vector(row["vector"], self._dim)
+                similarity = sum(a * b for a, b in zip(query, vec, strict=True))
+                clamped = max(0.0, min(1.0, similarity))
+                scored.append((clamped, row["id"], row["text"], metadata))
+
+        scored.sort(key=lambda r: r[0], reverse=True)
+        return [
+            VectorMatch(id=item_id, text=text, metadata=meta, score=score)
+            for score, item_id, text, meta in scored[:limit]
+        ]
+
+    async def delete(self, ids: list[str]) -> int:
+        if not ids:
+            return 0
+        # `placeholders` is a string of `?` characters, never user
+        # input — `tuple(ids)` is the parametrised payload.
+        placeholders = ",".join("?" for _ in ids)
+        sql = f"DELETE FROM vectors WHERE id IN ({placeholders})"  # noqa: S608  # nosec B608
+        async with self._db.execute(sql, tuple(ids)) as cur:
+            removed = cur.rowcount
+        await self._db.commit()
+        # rowcount is -1 when undefined; coerce to 0 for safety.
+        return max(0, removed)
+
+    async def close(self) -> None:
+        await self._db.close()
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _pack_vector(vector: tuple[float, ...]) -> bytes:
+    """Pack a float tuple into a fixed-width float64 BLOB."""
+    return struct.pack(f"<{len(vector)}d", *vector)
+
+
+def _unpack_vector(blob: bytes, dim: int) -> tuple[float, ...]:
+    """Reverse of `_pack_vector`."""
+    return struct.unpack(f"<{dim}d", blob)
+
+
+def _l2_normalise(vector: tuple[float, ...]) -> tuple[float, ...]:
+    norm = math.sqrt(sum(x * x for x in vector))
+    if norm == 0.0:
+        return vector
+    return tuple(x / norm for x in vector)
+
+
+def _matches_filter(metadata: dict[str, Any], filter_md: dict[str, Any]) -> bool:
+    return all(metadata.get(k) == v for k, v in filter_md.items())
+
+
+__all__ = ["SqliteVectorStore"]

--- a/packages/agentforge-memory-sqlite/tests/unit/test_memory.py
+++ b/packages/agentforge-memory-sqlite/tests/unit/test_memory.py
@@ -1,0 +1,152 @@
+"""Unit tests for `SqliteMemoryStore`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.testing import run_memory_conformance
+from agentforge_core.values.claim import Claim
+from agentforge_memory_sqlite import SqliteMemoryStore
+
+
+@pytest.fixture
+async def memory_store() -> SqliteMemoryStore:
+    """Fresh in-memory SQLite store per test."""
+    store = await SqliteMemoryStore.from_path(":memory:")
+    yield store
+    await store.close()
+
+
+# ---- Conformance suite ----
+
+
+@pytest.mark.asyncio
+async def test_passes_memory_conformance_suite() -> None:
+    """The driver must pass the same suite every other MemoryStore
+    impl is checked against."""
+    store = await SqliteMemoryStore.from_path(":memory:")
+    try:
+        await run_memory_conformance(store)
+    finally:
+        await store.close()
+
+
+# ---- Lifecycle ----
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_connection(tmp_path: Path) -> None:
+    db_path = tmp_path / "agent.db"
+    async with await SqliteMemoryStore.from_path(db_path) as store:
+        await store.put(Claim(run_id="r1", project="p", agent="a", category="x", payload={}))
+    # Re-opening succeeds — file isn't locked.
+    async with await SqliteMemoryStore.from_path(db_path) as store:
+        results = await store.query()
+        assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent_via_context_manager() -> None:
+    """Manual close() on a connection that's already been closed via
+    the context manager should not raise spectacularly."""
+    store = await SqliteMemoryStore.from_path(":memory:")
+    await store.close()
+    # aiosqlite raises on double-close; this is acceptable behaviour
+    # but documented — tests should use the context manager.
+
+
+# ---- Persistence across reconnects ----
+
+
+@pytest.mark.asyncio
+async def test_data_survives_reconnect(tmp_path: Path) -> None:
+    db_path = tmp_path / "agent.db"
+    async with await SqliteMemoryStore.from_path(db_path) as store:
+        await store.put(
+            Claim(run_id="r1", project="p1", agent="a1", category="finding", payload={})
+        )
+    async with await SqliteMemoryStore.from_path(db_path) as reopened:
+        results = await reopened.query(project="p1")
+        assert len(results) == 1
+        assert results[0].project == "p1"
+
+
+# ---- Filter combinations beyond the conformance suite ----
+
+
+@pytest.mark.asyncio
+async def test_query_combines_filters_conjunctively(
+    memory_store: SqliteMemoryStore,
+) -> None:
+    await memory_store.put(Claim(run_id="r1", project="p1", agent="a1", category="doc", payload={}))
+    await memory_store.put(Claim(run_id="r1", project="p1", agent="a2", category="doc", payload={}))
+    await memory_store.put(Claim(run_id="r2", project="p1", agent="a1", category="doc", payload={}))
+    matches = await memory_store.query(project="p1", agent="a1", run_id="r1")
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_limit_caps_result_size(
+    memory_store: SqliteMemoryStore,
+) -> None:
+    for i in range(5):
+        await memory_store.put(
+            Claim(run_id=f"r{i}", project="p", agent="a", category="x", payload={})
+        )
+    matches = await memory_store.query(project="p", limit=2)
+    assert len(matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_each_match(memory_store: SqliteMemoryStore) -> None:
+    for i in range(3):
+        await memory_store.put(
+            Claim(run_id=f"r{i}", project="p", agent="a", category="x", payload={})
+        )
+    seen = [c async for c in memory_store.stream(project="p")]
+    assert len(seen) == 3
+
+
+# ---- supersede edge cases ----
+
+
+@pytest.mark.asyncio
+async def test_supersede_unknown_id_raises(memory_store: SqliteMemoryStore) -> None:
+    new_claim = Claim(run_id="r1", project="p", agent="a", category="x", payload={})
+    with pytest.raises(ModuleError, match="unknown claim id"):
+        await memory_store.supersede("01HX-DOES-NOT-EXIST", new_claim)
+
+
+@pytest.mark.asyncio
+async def test_supersede_with_mismatched_supersedes_raises(
+    memory_store: SqliteMemoryStore,
+) -> None:
+    original = Claim(run_id="r1", project="p", agent="a", category="x", payload={})
+    await memory_store.put(original)
+    new_claim = Claim(
+        run_id="r1",
+        project="p",
+        agent="a",
+        category="x",
+        payload={},
+        supersedes="some-other-id",
+    )
+    with pytest.raises(ModuleError, match="does not match"):
+        await memory_store.supersede(original.id, new_claim)
+
+
+# ---- Payload roundtrip ----
+
+
+@pytest.mark.asyncio
+async def test_payload_roundtrips_through_json(
+    memory_store: SqliteMemoryStore,
+) -> None:
+    payload = {"answer": 42, "tags": ["a", "b"], "nested": {"k": "v"}}
+    claim = Claim(run_id="r1", project="p", agent="a", category="x", payload=payload)
+    await memory_store.put(claim)
+    fetched = await memory_store.get(claim.id)
+    assert fetched is not None
+    assert fetched.payload == payload

--- a/packages/agentforge-memory-sqlite/tests/unit/test_vector.py
+++ b/packages/agentforge-memory-sqlite/tests/unit/test_vector.py
@@ -1,0 +1,185 @@
+"""Unit tests for `SqliteVectorStore`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+from agentforge_core.testing import run_vector_conformance
+from agentforge_core.values.vector import VectorItem
+from agentforge_memory_sqlite import SqliteVectorStore
+
+
+@pytest.fixture
+async def vector_store() -> SqliteVectorStore:
+    store = await SqliteVectorStore.from_path(":memory:", dimensions=8)
+    yield store
+    await store.close()
+
+
+# ---- Conformance suite ----
+
+
+@pytest.mark.asyncio
+async def test_passes_vector_conformance_suite() -> None:
+    store = await SqliteVectorStore.from_path(":memory:", dimensions=8)
+    try:
+        await run_vector_conformance(store)
+    finally:
+        await store.close()
+
+
+# ---- Constructor ----
+
+
+def test_constructor_rejects_zero_dimensions() -> None:
+    """The bare constructor doesn't connect; just rejects bad dim."""
+    fake_conn = aiosqlite.connect(":memory:")  # not yet awaited
+    with pytest.raises(ValueError, match="dimensions"):
+        SqliteVectorStore(connection=fake_conn, dimensions=0)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_from_path_rejects_zero_dimensions(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="dimensions"):
+        await SqliteVectorStore.from_path(tmp_path / "v.db", dimensions=0)
+
+
+@pytest.mark.asyncio
+async def test_from_path_rejects_dimension_change_on_reopen(
+    tmp_path: Path,
+) -> None:
+    """Once a file is created with dimensions=N, re-opening with a
+    different value must fail rather than silently corrupting."""
+    db = tmp_path / "v.db"
+    async with await SqliteVectorStore.from_path(db, dimensions=4):
+        pass
+    with pytest.raises(ValueError, match="dimensions"):
+        await SqliteVectorStore.from_path(db, dimensions=8)
+
+
+# ---- Persistence ----
+
+
+@pytest.mark.asyncio
+async def test_vectors_survive_reconnect(tmp_path: Path) -> None:
+    db = tmp_path / "v.db"
+    async with await SqliteVectorStore.from_path(db, dimensions=4) as store:
+        await store.upsert(
+            [
+                VectorItem(id="a", vector=(1.0, 0.0, 0.0, 0.0), text="alpha"),
+                VectorItem(id="b", vector=(0.0, 1.0, 0.0, 0.0), text="beta"),
+            ]
+        )
+    async with await SqliteVectorStore.from_path(db, dimensions=4) as reopened:
+        results = await reopened.search((1.0, 0.0, 0.0, 0.0), limit=2)
+        ids = sorted(r.id for r in results)
+        assert ids == ["a", "b"]
+        assert results[0].id == "a"  # exact-match wins
+
+
+# ---- Upsert + search basics ----
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces_existing_id(
+    vector_store: SqliteVectorStore,
+) -> None:
+    v1 = VectorItem(id="x", vector=tuple([1.0] + [0.0] * 7), text="first")
+    v2 = VectorItem(id="x", vector=tuple([0.0] * 7 + [1.0]), text="second")
+    await vector_store.upsert([v1])
+    await vector_store.upsert([v2])
+
+    # Searching for the first vector now ranks the replacement low.
+    results = await vector_store.search(tuple([1.0] + [0.0] * 7), limit=10)
+    matching_x = [r for r in results if r.id == "x"]
+    assert len(matching_x) == 1
+    assert matching_x[0].text == "second"
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_dimension_mismatch(
+    vector_store: SqliteVectorStore,
+) -> None:
+    bad = VectorItem(id="bad", vector=(1.0, 0.0), text="x")
+    with pytest.raises(ValueError, match="dimensions"):
+        await vector_store.upsert([bad])
+
+
+# ---- Metadata filter ----
+
+
+@pytest.mark.asyncio
+async def test_filter_metadata_keeps_only_matching_items(
+    vector_store: SqliteVectorStore,
+) -> None:
+    await vector_store.upsert(
+        [
+            VectorItem(
+                id="a",
+                vector=tuple([1.0] + [0.0] * 7),
+                text="a",
+                metadata={"category": "doc"},
+            ),
+            VectorItem(
+                id="b",
+                vector=tuple([1.0] + [0.0] * 7),
+                text="b",
+                metadata={"category": "note"},
+            ),
+        ]
+    )
+    matches = await vector_store.search(
+        tuple([1.0] + [0.0] * 7), limit=10, filter_metadata={"category": "doc"}
+    )
+    assert [m.id for m in matches] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_filter_metadata_complex_payload_roundtrips(
+    vector_store: SqliteVectorStore,
+) -> None:
+    """Metadata is JSON-stored; nested dicts and lists must roundtrip."""
+    await vector_store.upsert(
+        [
+            VectorItem(
+                id="a",
+                vector=tuple([1.0] + [0.0] * 7),
+                text="a",
+                metadata={"tags": ["x", "y"], "nested": {"k": 1}},
+            ),
+        ]
+    )
+    matches = await vector_store.search(tuple([1.0] + [0.0] * 7), limit=1)
+    assert matches[0].metadata == {"tags": ["x", "y"], "nested": {"k": 1}}
+
+
+# ---- Delete ----
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_actual_removal_count(
+    vector_store: SqliteVectorStore,
+) -> None:
+    await vector_store.upsert(
+        [
+            VectorItem(id="a", vector=tuple([1.0] + [0.0] * 7), text="a"),
+            VectorItem(id="b", vector=tuple([0.0, 1.0] + [0.0] * 6), text="b"),
+        ]
+    )
+    assert await vector_store.delete(["a", "b", "ghost"]) == 2
+    assert await vector_store.delete(["a", "b"]) == 0
+    assert await vector_store.delete([]) == 0
+
+
+# ---- Defaults ----
+
+
+def test_default_capabilities_empty() -> None:
+    """Today's impl is brute-force; no native ANN, no hybrid search.
+    A future v0.2 can declare `'native_ann'` after wiring sqlite-vec."""
+    store = SqliteVectorStore.__new__(SqliteVectorStore)
+    store._dim = 4  # type: ignore[attr-defined]
+    assert store.capabilities() == set()
+    assert store.supports("native_ann") is False

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from agentforge.agent import Agent
 from agentforge.config import AgentForgeConfig, load_config
-from agentforge.memory import InMemoryStore
+from agentforge.memory import InMemoryStore, InMemoryVectorStore
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
 from agentforge.strategies import (
     MultiAgentSupervisor,
@@ -41,6 +41,7 @@ __all__ = [
     "Agent",
     "AgentForgeConfig",
     "InMemoryStore",
+    "InMemoryVectorStore",
     "MultiAgentSupervisor",
     "Plan",
     "PlanExecuteLoop",

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from agentforge.agent import Agent
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore, InMemoryVectorStore
+from agentforge.retrieval import Retriever
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
 from agentforge.strategies import (
     MultiAgentSupervisor,
@@ -47,6 +48,7 @@ __all__ = [
     "PlanExecuteLoop",
     "PlanStep",
     "ReActLoop",
+    "Retriever",
     "RuntimeContext",
     "StrategyBase",
     "TreeOfThoughts",

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -52,6 +52,7 @@ from agentforge_core.values.state import AgentState, FinishReason, RunResult
 
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.memory import InMemoryStore
+from agentforge.retrieval import Retriever
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
 
 StepHook = Callable[..., Awaitable[None] | None]
@@ -75,6 +76,7 @@ class Agent:
         tools: list[Tool] | None = None,
         strategy: str | ReasoningStrategy | None = None,
         memory: MemoryStore | None = None,
+        retriever: Retriever | None = None,
         evaluators: list[Evaluator] | None = None,
         system_prompt: str | None = None,
         budget_usd: float | None = None,
@@ -97,6 +99,7 @@ class Agent:
 
         # Defaults: in-memory store, no evaluators, no tools.
         self._memory: MemoryStore = memory if memory is not None else InMemoryStore()
+        self._retriever: Retriever | None = retriever
         self._tools: list[Tool] = list(tools) if tools is not None else []
         self._evaluators: list[Evaluator] = list(evaluators) if evaluators is not None else []
         self._system_prompt: str | None = (
@@ -215,6 +218,7 @@ class Agent:
                     memory=self._memory,
                     budget=run_budget,
                     system_prompt=self._system_prompt,
+                    retriever=self._retriever,
                 )
             state = AgentState(
                 run_id=ctx.run_id,

--- a/packages/agentforge/src/agentforge/memory/__init__.py
+++ b/packages/agentforge/src/agentforge/memory/__init__.py
@@ -1,14 +1,15 @@
 """Default in-process memory implementations.
 
-`InMemoryStore` ships with `agentforge` so a fresh `Agent(...)` has
-durable-shaped state out of the box without external infra. It is
-the safe default; production deployments swap to a real driver
-(`agentforge-memory-sqlite`, `-postgres`, etc.) via `agentforge.yaml`
-once feat-005 lands.
+`InMemoryStore` (claim audit log) and `InMemoryVectorStore` (semantic
+search) ship with `agentforge` so a fresh `Agent(...)` has
+durable-shaped state out of the box without external infra. Both are
+safe defaults; production deployments swap to real drivers
+(`agentforge-memory-sqlite`, `-postgres`) via `agentforge.yaml`.
 """
 
 from __future__ import annotations
 
 from agentforge.memory.in_memory import InMemoryStore
+from agentforge.memory.in_memory_vector import InMemoryVectorStore
 
-__all__ = ["InMemoryStore"]
+__all__ = ["InMemoryStore", "InMemoryVectorStore"]

--- a/packages/agentforge/src/agentforge/memory/in_memory_vector.py
+++ b/packages/agentforge/src/agentforge/memory/in_memory_vector.py
@@ -1,0 +1,117 @@
+"""`InMemoryVectorStore` — process-local `VectorStore` reference impl.
+
+Brute-force cosine similarity over a Python dict. Suitable for tests,
+demos, and small RAG corpora (~hundreds of items). Production
+deployments swap to `agentforge-memory-sqlite` (zero-deps persistent)
+or `agentforge-memory-postgres` (scaled, native ANN) — both pass the
+same `run_vector_conformance` suite.
+
+Design notes:
+
+  - Dimensions are fixed at construction. Mismatched vectors raise
+    `ValueError` immediately, before they can corrupt the index.
+  - Search is O(N) per call — fine for small corpora, sluggish past
+    a few thousand items. The capability vocabulary lets future
+    drivers declare `"native_ann"`; this one does not.
+  - Vectors are L2-normalised before storage so similarity is a
+    plain dot product at search time. Callers don't have to
+    pre-normalise.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+from typing import Any
+
+from agentforge_core.contracts.vector_store import VectorStore
+from agentforge_core.values.vector import VectorItem, VectorMatch
+
+
+class InMemoryVectorStore(VectorStore):
+    """In-process `VectorStore` backed by a dict + brute-force search."""
+
+    def __init__(self, *, dimensions: int) -> None:
+        if dimensions < 1:
+            raise ValueError(f"dimensions must be >= 1, got {dimensions}")
+        self._dim = dimensions
+        # id -> (normalised vector, text, metadata)
+        self._items: OrderedDict[str, tuple[tuple[float, ...], str, dict[str, Any]]] = OrderedDict()
+
+    def dimensions(self) -> int:
+        return self._dim
+
+    async def upsert(self, items: list[VectorItem]) -> None:
+        for item in items:
+            if len(item.vector) != self._dim:
+                raise ValueError(
+                    f"vector for id={item.id!r} has length {len(item.vector)} "
+                    f"but store dimensions={self._dim}"
+                )
+            self._items[item.id] = (
+                _l2_normalise(item.vector),
+                item.text,
+                dict(item.metadata),
+            )
+
+    async def search(
+        self,
+        query_vector: tuple[float, ...],
+        *,
+        limit: int = 5,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+        if len(query_vector) != self._dim:
+            raise ValueError(
+                f"query vector has length {len(query_vector)} but store dimensions={self._dim}"
+            )
+
+        query = _l2_normalise(query_vector)
+        scored: list[tuple[float, str, str, dict[str, Any]]] = []
+        for item_id, (vec, text, meta) in self._items.items():
+            if filter_metadata is not None and not _matches_filter(meta, filter_metadata):
+                continue
+            # Cosine similarity in [-1, 1]. Clamped to [0, 1]: 1.0
+            # means identical direction, 0.0 means orthogonal-or-
+            # anti-correlated. For text embeddings this drops
+            # essentially no information (anti-correlation is rare).
+            similarity = sum(a * b for a, b in zip(query, vec, strict=True))
+            clamped = max(0.0, min(1.0, similarity))
+            scored.append((clamped, item_id, text, meta))
+
+        scored.sort(key=lambda row: row[0], reverse=True)
+        top = scored[:limit]
+        return [
+            VectorMatch(id=item_id, text=text, metadata=dict(meta), score=score)
+            for score, item_id, text, meta in top
+        ]
+
+    async def delete(self, ids: list[str]) -> int:
+        removed = 0
+        for item_id in ids:
+            if self._items.pop(item_id, None) is not None:
+                removed += 1
+        return removed
+
+    async def close(self) -> None:
+        self._items.clear()
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _l2_normalise(vector: tuple[float, ...]) -> tuple[float, ...]:
+    """Return `vector / ||vector||`; falls back to the input if zero."""
+    norm = math.sqrt(sum(x * x for x in vector))
+    if norm == 0.0:
+        return vector
+    return tuple(x / norm for x in vector)
+
+
+def _matches_filter(metadata: dict[str, Any], filter_md: dict[str, Any]) -> bool:
+    """True if every (k, v) in `filter_md` matches `metadata`."""
+    return all(metadata.get(k) == v for k, v in filter_md.items())

--- a/packages/agentforge/src/agentforge/retrieval.py
+++ b/packages/agentforge/src/agentforge/retrieval.py
@@ -1,0 +1,173 @@
+"""`Retriever` — high-level adapter over `VectorStore` + `EmbeddingClient`.
+
+A vector store on its own takes vectors; a retriever takes *text*
+and routes it through an embedder so callers can think in documents
+and queries instead of raw floats.
+
+Typical use:
+
+    retriever = Retriever(store=store, embedder=embedder, top_k=5)
+    await retriever.add_documents([
+        "Paris is the capital of France.",
+        "The Louvre is in Paris.",
+    ])
+    matches = await retriever.retrieve("Where is the Louvre?")
+
+The retriever owns no state of its own — calling `close()` is a
+courtesy that closes the underlying store and embedder for the
+caller. Multi-retriever-over-one-store setups should not call
+`close()` on the retriever.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentforge_core.contracts.embedding import EmbeddingClient
+from agentforge_core.contracts.vector_store import VectorStore
+from agentforge_core.values.vector import VectorItem, VectorMatch
+from ulid import ULID
+
+
+class Retriever:
+    """Wraps `VectorStore` + `EmbeddingClient` for text-in / text-out RAG.
+
+    Args:
+        store: Backing `VectorStore`. Its `dimensions()` must match
+            `embedder.dimensions()`.
+        embedder: Backing `EmbeddingClient`.
+        top_k: Default match count returned by `retrieve()`. Callers
+            can override per-call via the `top_k` kwarg.
+        batch_size: Maximum texts per embedding call when adding
+            documents. Bedrock Titan loops one-at-a-time anyway, but
+            other providers (Cohere, OpenAI) batch natively; tuning
+            this is a per-provider concern.
+
+    Raises:
+        ValueError: store and embedder dimensions don't match, or
+            `top_k`/`batch_size` are not positive.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: VectorStore,
+        embedder: EmbeddingClient,
+        top_k: int = 5,
+        batch_size: int = 32,
+    ) -> None:
+        if top_k < 1:
+            raise ValueError(f"top_k must be >= 1, got {top_k}")
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        if store.dimensions() != embedder.dimensions():
+            raise ValueError(
+                f"store dimensions ({store.dimensions()}) do not match "
+                f"embedder dimensions ({embedder.dimensions()})"
+            )
+        self._store = store
+        self._embedder = embedder
+        self._top_k = top_k
+        self._batch_size = batch_size
+
+    @property
+    def store(self) -> VectorStore:
+        return self._store
+
+    @property
+    def embedder(self) -> EmbeddingClient:
+        return self._embedder
+
+    async def add_documents(
+        self,
+        texts: list[str],
+        *,
+        ids: list[str] | None = None,
+        metadata: list[dict[str, Any]] | None = None,
+    ) -> list[str]:
+        """Embed and upsert `texts` into the store.
+
+        Args:
+            texts: One or more documents to index. Empty list is a no-op.
+            ids: Optional caller-supplied ids. If omitted, ULIDs are
+                generated. Length must match `texts`.
+            metadata: Optional per-document metadata. Length must match
+                `texts`. Defaults to empty dict per document.
+
+        Returns:
+            The list of ids actually stored (caller-supplied or
+            generated), in the order of the input texts.
+
+        Raises:
+            ValueError: `ids` or `metadata` length disagrees with `texts`.
+        """
+        if not texts:
+            return []
+        if ids is not None and len(ids) != len(texts):
+            raise ValueError(f"ids has {len(ids)} entries but texts has {len(texts)}")
+        if metadata is not None and len(metadata) != len(texts):
+            raise ValueError(f"metadata has {len(metadata)} entries but texts has {len(texts)}")
+
+        resolved_ids = ids if ids is not None else [str(ULID()) for _ in texts]
+        resolved_meta = metadata if metadata is not None else [{} for _ in texts]
+
+        # Embed in batches; Cohere supports native batching, Titan
+        # loops internally — driver decides the actual fan-out.
+        items: list[VectorItem] = []
+        for start in range(0, len(texts), self._batch_size):
+            chunk = texts[start : start + self._batch_size]
+            response = await self._embedder.embed(chunk)
+            for offset, vector in enumerate(response.vectors):
+                global_idx = start + offset
+                items.append(
+                    VectorItem(
+                        id=resolved_ids[global_idx],
+                        vector=tuple(vector),
+                        text=chunk[offset],
+                        metadata=resolved_meta[global_idx],
+                    )
+                )
+
+        await self._store.upsert(items)
+        return resolved_ids
+
+    async def retrieve(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[VectorMatch]:
+        """Embed `query` and return the top matches from the store.
+
+        Args:
+            query: The user's question / prompt to embed and search.
+            top_k: Override the constructor's default. Must be >= 1.
+            filter_metadata: Conjunctive equality filter on items'
+                metadata (forwarded to `VectorStore.search`).
+
+        Raises:
+            ValueError: `top_k` < 1.
+        """
+        limit = top_k if top_k is not None else self._top_k
+        if limit < 1:
+            raise ValueError(f"top_k must be >= 1, got {limit}")
+        response = await self._embedder.embed([query])
+        query_vector = tuple(response.vectors[0])
+        return await self._store.search(
+            query_vector,
+            limit=limit,
+            filter_metadata=filter_metadata,
+        )
+
+    async def close(self) -> None:
+        """Close the underlying store and embedder.
+
+        Convenience for callers that own both. If the retriever shares
+        a store/embedder with other components, do NOT call this.
+        """
+        await self._store.close()
+        await self._embedder.close()
+
+
+__all__ = ["Retriever"]

--- a/packages/agentforge/src/agentforge/runtime.py
+++ b/packages/agentforge/src/agentforge/runtime.py
@@ -14,11 +14,15 @@ on `state.metadata` under `RUNTIME_KEY`. Strategies access it via
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.memory import MemoryStore
 from agentforge_core.contracts.tool import Tool
 from agentforge_core.production.budget import BudgetPolicy
+
+if TYPE_CHECKING:
+    from agentforge.retrieval import Retriever
 
 RUNTIME_KEY = "__agentforge_runtime__"
 """Documented key under `AgentState.metadata` where the runtime is bound."""
@@ -44,3 +48,7 @@ class RuntimeContext:
     memory: MemoryStore
     budget: BudgetPolicy
     system_prompt: str | None = None
+    retriever: Retriever | None = None
+    """Optional RAG retriever (feat-007). Strategies that want to
+    ground responses in indexed documents check `runtime.retriever
+    is not None` and call `retriever.retrieve(query)`."""

--- a/packages/agentforge/tests/unit/test_agent_retriever.py
+++ b/packages/agentforge/tests/unit/test_agent_retriever.py
@@ -1,0 +1,183 @@
+"""Unit tests for `Agent`'s retriever integration (feat-007 chunk 4)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from agentforge import Agent, InMemoryStore, InMemoryVectorStore, Retriever
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies._base import get_runtime
+from agentforge_core.contracts.embedding import EmbeddingClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.values.messages import EmbeddingResponse, TokenUsage
+from agentforge_core.values.state import AgentState, Step
+
+
+class _FakeEmbedder(EmbeddingClient):
+    def __init__(self, *, dim: int = 4) -> None:
+        self._dim = dim
+
+    async def embed(self, texts: list[str]) -> EmbeddingResponse:
+        if not texts:
+            raise ValueError("empty")
+        vectors = tuple(_text_to_vector(t, self._dim) for t in texts)
+        return EmbeddingResponse(
+            vectors=vectors,
+            dimensions=self._dim,
+            usage=TokenUsage(input_tokens=1, output_tokens=0),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    async def close(self) -> None: ...
+
+    def dimensions(self) -> int:
+        return self._dim
+
+
+def _text_to_vector(text: str, dim: int) -> tuple[float, ...]:
+    raw = [0.01] * dim
+    for i, ch in enumerate(text):
+        raw[i % dim] += ord(ch)
+    norm = math.sqrt(sum(x * x for x in raw))
+    return tuple(x / norm for x in raw)
+
+
+class _RetrievalStrategy(ReasoningStrategy):
+    """Test-only strategy that pulls one match from the retriever and
+    surfaces it on the state's last step."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = get_runtime(state)
+        if runtime.retriever is None:
+            state.steps.append(Step(iteration=0, kind="observe", content="no retriever"))
+            return state
+        matches = await runtime.retriever.retrieve(state.task, top_k=1)
+        top = matches[0].text if matches else "(no match)"
+        state.steps.append(Step(iteration=0, kind="observe", content=top))
+        return state
+
+
+# ---- Constructor wiring ----
+
+
+def test_agent_without_retriever_keyword_defaults_to_none() -> None:
+    """Existing callers that don't pass `retriever=` keep working."""
+    agent = Agent(strategy=_RetrievalStrategy())
+    assert agent._retriever is None
+
+
+def test_agent_accepts_retriever_keyword() -> None:
+    embedder = _FakeEmbedder(dim=4)
+    store = InMemoryVectorStore(dimensions=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    agent = Agent(strategy=_RetrievalStrategy(), retriever=retriever)
+    assert agent._retriever is retriever
+
+
+# ---- Runtime context plumbing ----
+
+
+@pytest.mark.asyncio
+async def test_strategy_sees_retriever_via_runtime_context() -> None:
+    """End-to-end: Agent builds the RuntimeContext with the retriever
+    we passed; the strategy reads it back via get_runtime(state)."""
+    embedder = _FakeEmbedder(dim=4)
+    store = InMemoryVectorStore(dimensions=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    await retriever.add_documents(
+        ["paris is the capital of france", "the louvre is in paris"],
+        ids=["d1", "d2"],
+    )
+
+    fake_llm = FakeLLMClient(responses=[])
+    async with Agent(
+        model=fake_llm,
+        strategy=_RetrievalStrategy(),
+        retriever=retriever,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("paris is the capital of france")
+
+    assert result.output == "paris is the capital of france"
+
+
+@pytest.mark.asyncio
+async def test_strategy_sees_no_retriever_when_none_passed() -> None:
+    """Without `retriever=`, the runtime context's retriever is None."""
+    fake_llm = FakeLLMClient(responses=[])
+    async with Agent(
+        model=fake_llm,
+        strategy=_RetrievalStrategy(),
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("anything")
+
+    assert result.output == "no retriever"
+
+
+# ---- Direct RuntimeContext shape ----
+
+
+def test_runtime_context_carries_retriever_field() -> None:
+    """Defensive check on the dataclass shape."""
+    embedder = _FakeEmbedder(dim=4)
+    store = InMemoryVectorStore(dimensions=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    rt = RuntimeContext(
+        llm=FakeLLMClient(responses=[]),
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(usd=1.0),
+        retriever=retriever,
+    )
+    assert rt.retriever is retriever
+
+
+def test_runtime_context_retriever_defaults_to_none() -> None:
+    """Existing constructions that omit `retriever=` continue to work."""
+    rt = RuntimeContext(
+        llm=FakeLLMClient(responses=[]),
+        tools=(),
+        memory=InMemoryStore(),
+        budget=BudgetPolicy(usd=1.0),
+    )
+    assert rt.retriever is None
+
+
+# ---- Per-run fresh runtime ----
+
+
+@pytest.mark.asyncio
+async def test_retriever_persists_across_runs_of_same_agent() -> None:
+    """Two `agent.run()` calls share the same retriever instance."""
+    embedder = _FakeEmbedder(dim=4)
+    store = InMemoryVectorStore(dimensions=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    await retriever.add_documents(["alpha"], ids=["d1"])
+
+    captured_retrievers: list[object] = []
+
+    class _CaptureStrategy(ReasoningStrategy):
+        async def run(self, state: AgentState) -> AgentState:
+            captured_retrievers.append(state.metadata[RUNTIME_KEY].retriever)
+            state.steps.append(Step(iteration=0, kind="observe", content="ok"))
+            return state
+
+    fake_llm = FakeLLMClient(responses=[])
+    async with Agent(
+        model=fake_llm,
+        strategy=_CaptureStrategy(),
+        retriever=retriever,
+        install_log_filter=False,
+    ) as agent:
+        await agent.run("first")
+        await agent.run("second")
+
+    assert len(captured_retrievers) == 2
+    assert captured_retrievers[0] is captured_retrievers[1]
+    assert captured_retrievers[0] is retriever

--- a/packages/agentforge/tests/unit/test_in_memory_vector_store.py
+++ b/packages/agentforge/tests/unit/test_in_memory_vector_store.py
@@ -1,0 +1,270 @@
+"""Unit tests for `InMemoryVectorStore` + the conformance suite."""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import pytest
+from agentforge import InMemoryVectorStore
+from agentforge_core.testing import run_vector_conformance
+from agentforge_core.values.vector import VectorItem
+
+
+def _unit(*xs: float) -> tuple[float, ...]:
+    """Return an L2-normalised vector. Inputs assumed nonzero."""
+    norm = math.sqrt(sum(x * x for x in xs))
+    return tuple(x / norm for x in xs)
+
+
+# ---- Constructor ----
+
+
+def test_constructor_rejects_zero_dimensions() -> None:
+    with pytest.raises(ValueError, match="dimensions"):
+        InMemoryVectorStore(dimensions=0)
+
+
+def test_constructor_rejects_negative_dimensions() -> None:
+    with pytest.raises(ValueError, match="dimensions"):
+        InMemoryVectorStore(dimensions=-1)
+
+
+def test_dimensions_returned_synchronously() -> None:
+    store = InMemoryVectorStore(dimensions=128)
+    assert store.dimensions() == 128
+
+
+# ---- Upsert validation ----
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_dimension_mismatch() -> None:
+    store = InMemoryVectorStore(dimensions=3)
+    bad = VectorItem(id="x", vector=(1.0, 0.0), text="x")
+    with pytest.raises(ValueError, match="dimensions"):
+        await store.upsert([bad])
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces_existing_id() -> None:
+    """Re-upserting the same id is write-through — the old record is
+    gone, no duplicates remain in the index."""
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert([VectorItem(id="x", vector=(1.0, 0.0), text="first")])
+    await store.upsert([VectorItem(id="x", vector=(0.0, 1.0), text="second")])
+
+    results = await store.search((1.0, 0.0), limit=10)
+    ids = [r.id for r in results]
+    assert ids.count("x") == 1
+    assert results[0].text == "second"
+
+
+# ---- Search ----
+
+
+@pytest.mark.asyncio
+async def test_search_returns_results_sorted_descending_by_score() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [
+            VectorItem(id="a", vector=_unit(1.0, 0.0), text="a"),  # score=1.0 vs (1,0)
+            VectorItem(id="b", vector=_unit(0.5, 0.5), text="b"),  # ~0.707
+            VectorItem(id="c", vector=_unit(0.0, 1.0), text="c"),  # 0.0 (orthogonal)
+        ]
+    )
+    results = await store.search(_unit(1.0, 0.0), limit=3)
+    assert [r.id for r in results] == ["a", "b", "c"]
+    for prev, nxt in itertools.pairwise(results):
+        assert prev.score >= nxt.score
+
+
+@pytest.mark.asyncio
+async def test_search_top_hit_for_identical_vector_scores_one() -> None:
+    store = InMemoryVectorStore(dimensions=3)
+    await store.upsert([VectorItem(id="x", vector=_unit(1.0, 1.0, 1.0), text="x")])
+    results = await store.search(_unit(1.0, 1.0, 1.0), limit=1)
+    assert results[0].id == "x"
+    assert results[0].score == pytest.approx(1.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_search_orthogonal_scores_zero() -> None:
+    """Orthogonal vectors clamp to 0.0 (per the contract)."""
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert([VectorItem(id="x", vector=(1.0, 0.0), text="x")])
+    results = await store.search((0.0, 1.0), limit=1)
+    assert results[0].score == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_search_anti_correlated_clamps_to_zero() -> None:
+    """A vector pointing the opposite direction has cosine -1; the
+    contract clamps that to 0 so anti-correlation looks the same as
+    'unrelated' (acceptable for text RAG)."""
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert([VectorItem(id="x", vector=(1.0, 0.0), text="x")])
+    results = await store.search((-1.0, 0.0), limit=1)
+    assert results[0].score == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_search_respects_limit() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [VectorItem(id=f"id-{i}", vector=_unit(1.0, float(i)), text="x") for i in range(5)]
+    )
+    assert len(await store.search((1.0, 0.0), limit=2)) == 2
+    assert len(await store.search((1.0, 0.0), limit=10)) == 5
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_zero_or_negative_limit() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    with pytest.raises(ValueError, match="limit"):
+        await store.search((1.0, 0.0), limit=0)
+    with pytest.raises(ValueError, match="limit"):
+        await store.search((1.0, 0.0), limit=-1)
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_dimension_mismatch_on_query() -> None:
+    store = InMemoryVectorStore(dimensions=3)
+    with pytest.raises(ValueError, match="dimensions"):
+        await store.search((1.0, 0.0), limit=1)
+
+
+# ---- Metadata filter ----
+
+
+@pytest.mark.asyncio
+async def test_filter_metadata_keeps_only_matching_items() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [
+            VectorItem(id="a", vector=(1.0, 0.0), text="a", metadata={"cat": "doc"}),
+            VectorItem(id="b", vector=(1.0, 0.0), text="b", metadata={"cat": "note"}),
+            VectorItem(id="c", vector=(1.0, 0.0), text="c", metadata={"cat": "doc"}),
+        ]
+    )
+    results = await store.search((1.0, 0.0), limit=10, filter_metadata={"cat": "doc"})
+    ids = sorted(r.id for r in results)
+    assert ids == ["a", "c"]
+
+
+@pytest.mark.asyncio
+async def test_filter_metadata_requires_all_keys_to_match() -> None:
+    """Multi-key filter is conjunctive (AND) — every (k, v) pair
+    must match."""
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [
+            VectorItem(
+                id="a",
+                vector=(1.0, 0.0),
+                text="a",
+                metadata={"cat": "doc", "year": 2024},
+            ),
+            VectorItem(
+                id="b",
+                vector=(1.0, 0.0),
+                text="b",
+                metadata={"cat": "doc", "year": 2023},
+            ),
+        ]
+    )
+    results = await store.search((1.0, 0.0), limit=10, filter_metadata={"cat": "doc", "year": 2024})
+    assert [r.id for r in results] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_filter_metadata_empty_dict_is_no_op() -> None:
+    """Empty filter_metadata dict matches everything — same as None."""
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [
+            VectorItem(id="a", vector=(1.0, 0.0), text="a", metadata={"cat": "doc"}),
+            VectorItem(id="b", vector=(1.0, 0.0), text="b", metadata={"cat": "note"}),
+        ]
+    )
+    results = await store.search((1.0, 0.0), limit=10, filter_metadata={})
+    assert len(results) == 2
+
+
+# ---- Delete ----
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_count_of_removed_items() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert(
+        [
+            VectorItem(id="a", vector=(1.0, 0.0), text="a"),
+            VectorItem(id="b", vector=(0.0, 1.0), text="b"),
+        ]
+    )
+    assert await store.delete(["a", "b"]) == 2
+    # Already empty — second delete returns 0.
+    assert await store.delete(["a", "b"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_silently_drops_unknown_ids() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert([VectorItem(id="real", vector=(1.0, 0.0), text="x")])
+    # Mix known + unknown — only the known one counts.
+    assert await store.delete(["real", "ghost"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_empty_list_returns_zero() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    assert await store.delete([]) == 0
+
+
+# ---- close() ----
+
+
+@pytest.mark.asyncio
+async def test_close_clears_index() -> None:
+    store = InMemoryVectorStore(dimensions=2)
+    await store.upsert([VectorItem(id="x", vector=(1.0, 0.0), text="x")])
+    await store.close()
+    # After close, search returns nothing.
+    results = await store.search((1.0, 0.0), limit=10)
+    assert results == []
+
+
+# ---- Capabilities (default) ----
+
+
+def test_default_capabilities_empty() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    assert store.capabilities() == set()
+    assert store.supports("native_ann") is False
+    assert store.supports("hybrid_search") is False
+
+
+# ---- Conformance suite ----
+
+
+@pytest.mark.asyncio
+async def test_passes_vector_conformance_suite() -> None:
+    """The reference impl must pass the same suite every third-party
+    driver will be checked against."""
+    store = InMemoryVectorStore(dimensions=8)
+    await run_vector_conformance(store)
+
+
+# ---- Auto-normalisation (calling code doesn't have to pre-normalise) ----
+
+
+@pytest.mark.asyncio
+async def test_unnormalised_vectors_still_score_correctly() -> None:
+    """Callers can pass raw vectors without L2-normalising — the store
+    normalises internally so cosine math is correct."""
+    store = InMemoryVectorStore(dimensions=2)
+    # Two parallel-but-different-magnitude vectors should still match.
+    await store.upsert([VectorItem(id="x", vector=(3.0, 4.0), text="x")])
+    results = await store.search((6.0, 8.0), limit=1)  # 2x the same direction
+    assert results[0].score == pytest.approx(1.0, abs=1e-6)

--- a/packages/agentforge/tests/unit/test_retrieval.py
+++ b/packages/agentforge/tests/unit/test_retrieval.py
@@ -1,0 +1,255 @@
+"""Unit tests for the `Retriever` adapter."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from agentforge import InMemoryVectorStore, Retriever
+from agentforge_core.contracts.embedding import EmbeddingClient
+from agentforge_core.values.messages import EmbeddingResponse, TokenUsage
+
+
+class _FakeEmbedder(EmbeddingClient):
+    """Deterministic per-text embedder for tests.
+
+    Maps each input text to a fixed vector via a simple hash. Same
+    text always yields the same vector, so retrieve() can find an
+    exact match against an indexed document.
+    """
+
+    def __init__(self, *, dim: int = 4) -> None:
+        self._dim = dim
+        self.embed_calls: list[list[str]] = []
+        self.closed = False
+
+    async def embed(self, texts: list[str]) -> EmbeddingResponse:
+        if not texts:
+            raise ValueError("embed() requires at least one text")
+        self.embed_calls.append(list(texts))
+        vectors = tuple(_text_to_vector(t, self._dim) for t in texts)
+        return EmbeddingResponse(
+            vectors=vectors,
+            dimensions=self._dim,
+            usage=TokenUsage(input_tokens=sum(len(t) for t in texts), output_tokens=0),
+            cost_usd=0.0,
+            model="fake-embed",
+            provider="fake",
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def dimensions(self) -> int:
+        return self._dim
+
+
+def _text_to_vector(text: str, dim: int) -> tuple[float, ...]:
+    """Stable text → vector using char codes, L2-normalised."""
+    raw = [0.01] * dim
+    for i, ch in enumerate(text):
+        raw[i % dim] += ord(ch)
+    norm = math.sqrt(sum(x * x for x in raw))
+    return tuple(x / norm for x in raw) if norm > 0 else tuple(raw)
+
+
+# ---- Constructor validation ----
+
+
+def test_constructor_rejects_zero_top_k() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    with pytest.raises(ValueError, match="top_k"):
+        Retriever(store=store, embedder=embedder, top_k=0)
+
+
+def test_constructor_rejects_zero_batch_size() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    with pytest.raises(ValueError, match="batch_size"):
+        Retriever(store=store, embedder=embedder, batch_size=0)
+
+
+def test_constructor_rejects_dimension_mismatch() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=8)
+    with pytest.raises(ValueError, match="dimensions"):
+        Retriever(store=store, embedder=embedder)
+
+
+def test_store_and_embedder_accessors_round_trip() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    assert retriever.store is store
+    assert retriever.embedder is embedder
+
+
+# ---- add_documents ----
+
+
+@pytest.mark.asyncio
+async def test_add_documents_returns_generated_ulids_when_ids_omitted() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+
+    ids = await retriever.add_documents(["alpha", "beta", "gamma"])
+    assert len(ids) == 3
+    # ULIDs are 26 chars; uniqueness comes for free.
+    assert all(len(i) == 26 for i in ids)
+    assert len(set(ids)) == 3
+
+
+@pytest.mark.asyncio
+async def test_add_documents_uses_caller_supplied_ids() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+
+    ids = await retriever.add_documents(["alpha", "beta"], ids=["doc-a", "doc-b"])
+    assert ids == ["doc-a", "doc-b"]
+
+
+@pytest.mark.asyncio
+async def test_add_documents_attaches_metadata() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+
+    await retriever.add_documents(
+        ["alpha", "beta"],
+        ids=["a", "b"],
+        metadata=[{"category": "doc"}, {"category": "note"}],
+    )
+    matches = await retriever.retrieve("alpha", top_k=10)
+    by_id = {m.id: m for m in matches}
+    assert by_id["a"].metadata == {"category": "doc"}
+    assert by_id["b"].metadata == {"category": "note"}
+
+
+@pytest.mark.asyncio
+async def test_add_documents_empty_list_is_no_op() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    ids = await retriever.add_documents([])
+    assert ids == []
+    # Embedder was never called.
+    assert embedder.embed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_add_documents_rejects_id_length_mismatch() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    with pytest.raises(ValueError, match="ids"):
+        await retriever.add_documents(["a", "b"], ids=["only-one"])
+
+
+@pytest.mark.asyncio
+async def test_add_documents_rejects_metadata_length_mismatch() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    with pytest.raises(ValueError, match="metadata"):
+        await retriever.add_documents(["a", "b"], metadata=[{"k": "v"}])
+
+
+@pytest.mark.asyncio
+async def test_add_documents_batches_at_batch_size() -> None:
+    """5 texts with batch_size=2 -> 3 embedder calls (2, 2, 1)."""
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder, batch_size=2)
+
+    await retriever.add_documents([f"text-{i}" for i in range(5)])
+    sizes = [len(call) for call in embedder.embed_calls]
+    assert sizes == [2, 2, 1]
+
+
+# ---- retrieve ----
+
+
+@pytest.mark.asyncio
+async def test_retrieve_top_hit_is_exact_match() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+
+    await retriever.add_documents(
+        ["paris is the capital of france", "the louvre is in paris"],
+        ids=["d1", "d2"],
+    )
+    matches = await retriever.retrieve("paris is the capital of france", top_k=2)
+    assert matches[0].id == "d1"
+    assert matches[0].score == pytest.approx(1.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_uses_constructor_top_k_when_kwarg_omitted() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder, top_k=2)
+
+    await retriever.add_documents([f"text-{i}" for i in range(5)])
+    matches = await retriever.retrieve("text-0")
+    assert len(matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_retrieve_top_k_kwarg_overrides_default() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder, top_k=2)
+
+    await retriever.add_documents([f"text-{i}" for i in range(5)])
+    matches = await retriever.retrieve("text-0", top_k=4)
+    assert len(matches) == 4
+
+
+@pytest.mark.asyncio
+async def test_retrieve_rejects_zero_top_k_kwarg() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+    with pytest.raises(ValueError, match="top_k"):
+        await retriever.retrieve("query", top_k=0)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_forwards_metadata_filter() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder, top_k=10)
+
+    await retriever.add_documents(
+        ["alpha doc", "alpha note", "beta doc"],
+        ids=["1", "2", "3"],
+        metadata=[
+            {"category": "doc"},
+            {"category": "note"},
+            {"category": "doc"},
+        ],
+    )
+    matches = await retriever.retrieve("alpha", filter_metadata={"category": "doc"})
+    ids = sorted(m.id for m in matches)
+    assert ids == ["1", "3"]
+
+
+# ---- close() ----
+
+
+@pytest.mark.asyncio
+async def test_close_propagates_to_store_and_embedder() -> None:
+    store = InMemoryVectorStore(dimensions=4)
+    embedder = _FakeEmbedder(dim=4)
+    retriever = Retriever(store=store, embedder=embedder)
+
+    await retriever.add_documents(["x"])
+    await retriever.close()
+    # Store cleared
+    assert await store.search(_text_to_vector("x", 4), limit=10) == []
+    # Embedder marked closed
+    assert embedder.closed is True

--- a/packages/agentforge/tests/unit/test_vector_store_properties.py
+++ b/packages/agentforge/tests/unit/test_vector_store_properties.py
@@ -1,0 +1,183 @@
+"""Property tests for `InMemoryVectorStore` invariants.
+
+These tests use Hypothesis to fuzz the locked behaviours that every
+`VectorStore` driver must respect — but exercise them on the
+in-memory reference impl so they run in CI without external services.
+The same suite (run_vector_conformance) is what third-party drivers
+must pass, so these properties hold across the contract.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import pytest
+from agentforge import InMemoryVectorStore
+from agentforge_core.values.vector import VectorItem
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# A modest dimensionality keeps the fuzzer fast while still exercising
+# real cosine math (more than two components).
+_DIM = 4
+
+
+def _floats(*, n: int) -> st.SearchStrategy[tuple[float, ...]]:
+    """Build n-component vectors, biased to non-trivial directions."""
+    return st.lists(
+        st.floats(
+            min_value=-10.0,
+            max_value=10.0,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+        min_size=n,
+        max_size=n,
+    ).map(tuple)
+
+
+def _nonzero_floats(*, n: int) -> st.SearchStrategy[tuple[float, ...]]:
+    """Vectors guaranteed to have nonzero L2 norm (avoid div-by-zero
+    on the 'all components are 0' edge case)."""
+    return _floats(n=n).filter(lambda v: math.sqrt(sum(x * x for x in v)) > 1e-3)
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(vector=_nonzero_floats(n=_DIM))
+@pytest.mark.asyncio
+async def test_self_search_is_top_hit_with_score_one(
+    vector: tuple[float, ...],
+) -> None:
+    """Searching with a vector identical to an upserted one always
+    returns that item first with score ~= 1.0 (after L2 normalisation)."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    await store.upsert([VectorItem(id="x", vector=vector, text="x")])
+    results = await store.search(vector, limit=1)
+    assert len(results) == 1
+    assert results[0].id == "x"
+    assert results[0].score == pytest.approx(1.0, abs=1e-6)
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(vector=_nonzero_floats(n=_DIM), scale=st.floats(min_value=0.1, max_value=100.0))
+@pytest.mark.asyncio
+async def test_score_is_invariant_to_query_magnitude(
+    vector: tuple[float, ...],
+    scale: float,
+) -> None:
+    """Cosine similarity is direction-only; scaling the query vector
+    doesn't change ranking. The store normalises internally."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    await store.upsert([VectorItem(id="x", vector=vector, text="x")])
+    plain = await store.search(vector, limit=1)
+    scaled = await store.search(tuple(c * scale for c in vector), limit=1)
+    assert plain[0].score == pytest.approx(scaled[0].score, abs=1e-6)
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(vector=_nonzero_floats(n=_DIM), scale=st.floats(min_value=0.1, max_value=100.0))
+@pytest.mark.asyncio
+async def test_score_is_invariant_to_indexed_magnitude(
+    vector: tuple[float, ...],
+    scale: float,
+) -> None:
+    """Same property the other direction — scaling an upserted vector
+    doesn't change its rank vs. the unchanged query."""
+    store_plain = InMemoryVectorStore(dimensions=_DIM)
+    store_scaled = InMemoryVectorStore(dimensions=_DIM)
+    await store_plain.upsert([VectorItem(id="x", vector=vector, text="x")])
+    await store_scaled.upsert(
+        [VectorItem(id="x", vector=tuple(c * scale for c in vector), text="x")]
+    )
+    plain = await store_plain.search(vector, limit=1)
+    scaled = await store_scaled.search(vector, limit=1)
+    assert plain[0].score == pytest.approx(scaled[0].score, abs=1e-6)
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    n_items=st.integers(min_value=2, max_value=8),
+    query=_nonzero_floats(n=_DIM),
+)
+@pytest.mark.asyncio
+async def test_search_results_are_sorted_descending_by_score(
+    n_items: int,
+    query: tuple[float, ...],
+) -> None:
+    """For any non-empty store, search() returns items ordered by
+    score descending. Property holds regardless of insertion order."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    items = [
+        VectorItem(
+            id=f"id-{i}",
+            vector=(float(i + 1), float((i + 2) % 3), float((i + 1) % 5), 1.0),
+            text=f"text {i}",
+        )
+        for i in range(n_items)
+    ]
+    await store.upsert(items)
+    results = await store.search(query, limit=n_items)
+    for prev, nxt in itertools.pairwise(results):
+        assert prev.score >= nxt.score
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    n_items=st.integers(min_value=1, max_value=5),
+    requested_limit=st.integers(min_value=1, max_value=20),
+    query=_nonzero_floats(n=_DIM),
+)
+@pytest.mark.asyncio
+async def test_search_returns_at_most_limit_results(
+    n_items: int,
+    requested_limit: int,
+    query: tuple[float, ...],
+) -> None:
+    """Result count is bounded by both `limit` and the actual store
+    size — never returns more than min(N, limit) items."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    items = [
+        VectorItem(id=f"id-{i}", vector=(1.0, float(i), 0.5, 0.0), text=f"t{i}")
+        for i in range(n_items)
+    ]
+    await store.upsert(items)
+    results = await store.search(query, limit=requested_limit)
+    assert len(results) <= min(requested_limit, n_items)
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    bad_dim=st.integers(min_value=1, max_value=10).filter(lambda d: d != _DIM),
+)
+@pytest.mark.asyncio
+async def test_dimension_mismatch_always_raises(bad_dim: int) -> None:
+    """Any vector whose length differs from dimensions() must raise
+    ValueError on upsert AND on search. This is the contract — the
+    store never silently truncates or pads."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    bad_vector = tuple([0.5] * bad_dim)
+    with pytest.raises(ValueError, match="dimensions"):
+        await store.upsert([VectorItem(id="x", vector=bad_vector, text="x")])
+    with pytest.raises(ValueError, match="dimensions"):
+        await store.search(bad_vector, limit=1)
+
+
+@settings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    n_items=st.integers(min_value=1, max_value=10),
+)
+@pytest.mark.asyncio
+async def test_delete_returns_count_of_removed_items(n_items: int) -> None:
+    """Round-trip property: upserting N items and deleting all their
+    ids must report exactly N removals."""
+    store = InMemoryVectorStore(dimensions=_DIM)
+    items = [
+        VectorItem(id=f"id-{i}", vector=(1.0, float(i), 0.0, 0.0), text=f"t{i}")
+        for i in range(n_items)
+    ]
+    await store.upsert(items)
+    removed = await store.delete([item.id for item in items])
+    assert removed == n_items
+    # And re-deleting the same ids reports 0 — they're already gone.
+    assert await store.delete([item.id for item in items]) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "agentforge-core",
     "agentforge",
     "agentforge-bedrock",
+    "agentforge-memory-sqlite",
 ]
 
 [tool.uv.workspace]
@@ -33,6 +34,7 @@ members = ["packages/*"]
 agentforge-core = { workspace = true }
 agentforge = { workspace = true }
 agentforge-bedrock = { workspace = true }
+agentforge-memory-sqlite = { workspace = true }
 
 [tool.uv]
 package = false   # the root is a virtual workspace; not itself published
@@ -154,6 +156,7 @@ testpaths = [
     "packages/agentforge-core/tests",
     "packages/agentforge/tests",
     "packages/agentforge-bedrock/tests",
+    "packages/agentforge-memory-sqlite/tests",
     "tests",
 ]
 markers = [
@@ -175,6 +178,7 @@ source = [
     "packages/agentforge-core/src",
     "packages/agentforge/src",
     "packages/agentforge-bedrock/src",
+    "packages/agentforge-memory-sqlite/src",
 ]
 branch = true
 parallel = true

--- a/tests/integration/test_rag_end_to_end.py
+++ b/tests/integration/test_rag_end_to_end.py
@@ -1,0 +1,196 @@
+"""Integration test — full RAG pipeline using only in-memory pieces.
+
+Wires every layer of feat-007 together to prove the contracts compose:
+
+    EmbeddingClient (fake)
+        +
+    InMemoryVectorStore
+        =
+    Retriever
+        +
+    Agent (with ReActLoop strategy)
+
+A custom strategy uses `runtime.retriever` to ground its answer in
+indexed documents. No live AWS, no Postgres, no network — just the
+locked contracts and their reference implementations.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from agentforge import Agent, InMemoryVectorStore, Retriever
+from agentforge._testing import FakeLLMClient
+from agentforge.strategies._base import get_runtime
+from agentforge_core.contracts.embedding import EmbeddingClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    EmbeddingResponse,
+    LLMResponse,
+    Message,
+    TokenUsage,
+)
+from agentforge_core.values.state import AgentState, Step
+
+
+class _FakeEmbedder(EmbeddingClient):
+    """Deterministic text → vector for reproducible RAG tests."""
+
+    def __init__(self, *, dim: int = 8) -> None:
+        self._dim = dim
+
+    async def embed(self, texts: list[str]) -> EmbeddingResponse:
+        if not texts:
+            raise ValueError("empty")
+        vectors = tuple(_to_vec(t, self._dim) for t in texts)
+        return EmbeddingResponse(
+            vectors=vectors,
+            dimensions=self._dim,
+            usage=TokenUsage(input_tokens=sum(len(t) for t in texts), output_tokens=0),
+            cost_usd=0.0,
+            model="fake-embed",
+            provider="fake",
+        )
+
+    async def close(self) -> None: ...
+
+    def dimensions(self) -> int:
+        return self._dim
+
+
+def _to_vec(text: str, dim: int) -> tuple[float, ...]:
+    """Stable text → vector via lowercased char-code accumulation."""
+    raw = [0.01] * dim
+    for i, ch in enumerate(text.lower()):
+        raw[i % dim] += ord(ch)
+    norm = math.sqrt(sum(x * x for x in raw))
+    return tuple(x / norm for x in raw)
+
+
+class _RagStrategy(ReasoningStrategy):
+    """Minimal strategy that:
+    1. Uses runtime.retriever to fetch the top match for the task.
+    2. Emits an `observe` step containing the match text.
+    3. Asks the LLM (a `FakeLLMClient`) for the final answer in one
+       call, citing the retrieved context.
+    """
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = get_runtime(state)
+        assert runtime.retriever is not None, "this test wires a retriever in"
+        matches = await runtime.retriever.retrieve(state.task, top_k=1)
+        context = matches[0].text if matches else "(no match)"
+        state.steps.append(Step(iteration=0, kind="observe", content=f"retrieved: {context}"))
+
+        # One LLM call to "synthesise" — fake it for the integration.
+        response = await runtime.llm.call(
+            system="answer using the retrieved context",
+            messages=[
+                Message(role="user", content=state.task),
+                Message(role="assistant", content=f"Context:\n{context}"),
+            ],
+        )
+        state.steps.append(
+            Step(
+                iteration=1,
+                kind="synthesize",
+                content=response.content,
+                tokens_in=response.usage.input_tokens,
+                tokens_out=response.usage.output_tokens,
+                cost_usd=response.cost_usd,
+            )
+        )
+        return state
+
+
+@pytest.mark.asyncio
+async def test_full_rag_pipeline_grounds_answer_in_retrieved_context() -> None:
+    """End-to-end: index three docs, retrieve the most relevant for a
+    user query, and pass it to a fake LLM that synthesises an answer.
+    The answer surfaces in `result.output`."""
+
+    embedder = _FakeEmbedder(dim=8)
+    store = InMemoryVectorStore(dimensions=8)
+    retriever = Retriever(store=store, embedder=embedder, top_k=2)
+    await retriever.add_documents(
+        [
+            "the louvre is in paris france",
+            "the eiffel tower is in paris france",
+            "tokyo is the capital of japan",
+        ],
+        ids=["d1", "d2", "d3"],
+    )
+
+    # FakeLLMClient mimics a single synthesis call.
+    fake_llm = FakeLLMClient(
+        responses=[
+            LLMResponse(
+                content="The Louvre is in Paris.",
+                stop_reason="end_turn",
+                usage=TokenUsage(input_tokens=20, output_tokens=8),
+                cost_usd=0.0001,
+                model="fake",
+                provider="fake",
+            ),
+        ]
+    )
+
+    async with Agent(
+        model=fake_llm,
+        strategy=_RagStrategy(),
+        retriever=retriever,
+        budget_usd=1.0,
+        install_log_filter=False,
+    ) as agent:
+        result = await agent.run("Where is the Louvre?")
+
+    assert result.output == "The Louvre is in Paris."
+    assert result.finish_reason == "completed"
+
+    # The trace shows both an observe (retrieved context) and a
+    # synthesize step (the LLM's answer). The fake embedder isn't
+    # semantic, so we don't assert *which* doc was retrieved — just
+    # that the retrieval phase produced something and the synthesis
+    # phase consumed it.
+    kinds = [s.kind for s in result.steps]
+    assert "observe" in kinds
+    assert "synthesize" in kinds
+    observe_step = next(s for s in result.steps if s.kind == "observe")
+    assert str(observe_step.content).startswith("retrieved: ")
+    # The fake LLM was called exactly once for the synthesis step.
+    assert fake_llm.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rag_pipeline_with_metadata_filter() -> None:
+    """Same pipeline but the retriever filters by metadata so only
+    `category=doc` items are eligible matches."""
+
+    embedder = _FakeEmbedder(dim=8)
+    store = InMemoryVectorStore(dimensions=8)
+    retriever = Retriever(store=store, embedder=embedder, top_k=1)
+    await retriever.add_documents(
+        [
+            "the louvre is in paris france",
+            "internal note about paris",
+        ],
+        ids=["doc1", "note1"],
+        metadata=[{"category": "doc"}, {"category": "note"}],
+    )
+
+    matches = await retriever.retrieve("where is the louvre", filter_metadata={"category": "doc"})
+    assert len(matches) == 1
+    assert matches[0].id == "doc1"
+    assert matches[0].metadata["category"] == "doc"
+
+
+@pytest.mark.asyncio
+async def test_rag_with_in_memory_store_pieces_share_dimensions() -> None:
+    """Constructor-time validation: store and embedder must agree on
+    dimensions before the first call. Mismatch fails fast."""
+
+    embedder = _FakeEmbedder(dim=8)
+    store = InMemoryVectorStore(dimensions=4)  # deliberate mismatch
+    with pytest.raises(ValueError, match="dimensions"):
+        Retriever(store=store, embedder=embedder)

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ members = [
     "agentforge",
     "agentforge-bedrock",
     "agentforge-core",
+    "agentforge-memory-sqlite",
     "agentforge-workspace",
 ]
 
@@ -66,6 +67,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "agentforge-memory-sqlite"
+version = "0.0.0"
+source = { editable = "packages/agentforge-memory-sqlite" }
+dependencies = [
+    { name = "agentforge-core" },
+    { name = "aiosqlite" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "aiosqlite", specifier = ">=0.20" },
+]
+
+[[package]]
 name = "agentforge-workspace"
 version = "0.0.0"
 source = { virtual = "." }
@@ -73,6 +89,7 @@ dependencies = [
     { name = "agentforge" },
     { name = "agentforge-bedrock" },
     { name = "agentforge-core" },
+    { name = "agentforge-memory-sqlite" },
 ]
 
 [package.dev-dependencies]
@@ -94,6 +111,7 @@ requires-dist = [
     { name = "agentforge", editable = "packages/agentforge" },
     { name = "agentforge-bedrock", editable = "packages/agentforge-bedrock" },
     { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "agentforge-memory-sqlite", editable = "packages/agentforge-memory-sqlite" },
 ]
 
 [package.metadata.requires-dev]
@@ -251,6 +269,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lifts AgentForge from "process-local memory only" to "persistent state across runs" + adds semantic retrieval. Validates the three-tier package model end-to-end: Tier 1 contract (`VectorStore` ABC) + Tier 3 module (`agentforge-memory-sqlite`).

**Core contracts** (`agentforge-core`):
- `VectorStore` ABC + `VectorItem` / `VectorMatch` value types.
- `run_vector_conformance` shared suite — every driver must pass.
- Cosine scores normalised to `[0, 1]` (1 = identical direction; 0 = orthogonal).

**Runtime helpers** (`agentforge`):
- `InMemoryVectorStore` reference impl (brute-force cosine).
- `Retriever` adapter wrapping `VectorStore` + `EmbeddingClient` for text-in / text-out RAG. Auto-ULID generation, batched embedding, metadata filter forwarding.
- `Agent(retriever=...)` kwarg threads a retriever through `RuntimeContext.retriever` for strategies to consume.

**Persistence** (`agentforge-memory-sqlite`):
- `SqliteMemoryStore` (claims via `aiosqlite`) + `SqliteVectorStore` (BLOB-stored vectors, brute-force scan). Both pass conformance.
- Dimensions pinned per database to prevent silent corruption.
- Zero external services — `:memory:` for tests, file-backed for production.

**Postgres deferred to feat-008.** SQLite covers v0.1 use cases.

## Test plan

- [x] 557 tests pass (89 new unit + 7 Hypothesis property tests + 3 integration)
- [x] Conformance suites pass for both `InMemoryVectorStore` and `SqliteVectorStore`
- [x] mypy --strict clean across all four src trees
- [x] ruff format --check + ruff check clean
- [x] bandit clean
- [x] Pre-commit gate passes end-to-end
- [x] Cross-package RAG integration test wires `Embedder → VectorStore → Retriever → Agent` with no external services

🤖 Generated with [Claude Code](https://claude.com/claude-code)