### PR TITLE
feat-007: Production rails — FallbackChain (closes feat-007)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,48 +1,129 @@
 ---
-feature: feat-004-tools-system
-state: pr-raised
-branch: feat/004-tools-system
-started_at: 2026-05-10T14:00
-last_milestone_at: 2026-05-10T17:15
-last_shipped: feat-005 (Persistence) shipped via PRs #5 (sqlite + RAG), #7 (graph + neo4j + surrealdb), #8 (postgres); chore PR #9 (self-contained project layout) merged at 74ea4ed
+feature: feat-007-production-rails
+state: analysing
+branch: feat/007-production-rails
+started_at: 2026-05-10T17:30
+last_milestone_at: 2026-05-10T17:30
+last_shipped: feat-004 (Tools system) shipped via PR #10 @ 2b1a37c
 blocker: null
-flags_for_user: []
+flags_for_user: ["design-awaiting-approval"]
 ---
 
 ## Active feature
 
-[`feat-004 — Tools system`](../../docs/features/feat-004-tools-system.md)
+[`feat-007 — Production rails`](../../docs/features/feat-007-production-rails.md)
 
-PR #10 raised. Awaiting review + merge.
+Per pipeline §1: lowest-numbered proposed feature with deps shipped.
+feat-007 deps: feat-001 ✓, feat-003 ✓.
 
-## Chunks shipped
+## Scope (from canonical spec §4)
 
-| Chunk | Commit | What |
-|---|---|---|
-| 1 | `6ec7c13` | `@tool` decorator |
-| 2 | `97e2acc` | `calculator` + `file_read` |
-| 3 | `c5be0f5` | `shell` + `web_search` |
-| 4 | `20c9dc6` | `_dispatch_tool` helper + ReAct/PlanExecute refactor |
-| 5 | `4ac290a` | `FakeTool` test helper |
-| 6 | (this) | CHANGELOG + Implementation section + PR + ruff hook id migrate |
+Most of feat-007's surface **already shipped under feat-001**. The
+only remaining piece is `FallbackChain`. The user clarified they
+saw "production rails" as covering all modern guardrails — that's
+feat-018 (Safety), separate. feat-007 is narrower:
+
+| Piece | Status |
+|---|---|
+| `BudgetPolicy` (cost / token / iteration / error-streak caps) | ✓ shipped feat-001 |
+| `RunContext` + `current_run()` (ContextVar-bound run state) | ✓ shipped feat-001 |
+| `RunContext.idempotency_key_for(*parts)` | ✓ shipped feat-001 |
+| `RunIdFilter` (auto-tags log records with run_id) | ✓ shipped feat-001 |
+| `BudgetPolicy.reserve` / `commit` / `record_error` / `record_success` | ✓ shipped feat-001 / consumed feat-002 |
+| **`FallbackChain`** — cross-provider failover wrapping multiple `LLMClient`s | ❌ **this PR** |
+
+## FallbackChain design
+
+Per spec §4.2:
+
+```python
+class FallbackChain(LLMClient):
+    def __init__(
+        self,
+        providers: list[str | LLMClient],
+        *,
+        retry_on: tuple[type[Exception], ...] = (RateLimitError, ProviderError),
+        attempts_per_provider: int = 1,
+    ) -> None: ...
+```
+
+Key invariants:
+
+1. **Implements `LLMClient` ABC** — strategies that accept any
+   `LLMClient` accept a chain transparently.
+2. **String providers resolve via the resolver**, same path
+   `Agent(model="bedrock:...")` uses today.
+3. On `retry_on` exception → try next provider (after retries on
+   the current one if `attempts_per_provider > 1`).
+4. **Last provider's exception bubbles up** if every provider
+   exhausts retries.
+5. **Tracks which provider answered** so `RunResult` can include
+   `retry_provider_used` (post-merge follow-up may add the field
+   to `RunResult` — out of scope for this PR; chain just records).
+6. `capabilities()` returns the **intersection** of every wrapped
+   provider's capabilities — a chain can only honestly claim a
+   capability every fallback supports. Conservative.
+7. `close()` calls `close()` on every wrapped provider (in
+   reverse-construction order so partial failures don't leak).
+
+## Open design questions
+
+- **Where does `FallbackChain` live?** Spec §4.2 puts it at
+  `agentforge_core/production/fallback.py`. That keeps it in the
+  contract layer alongside `BudgetPolicy` and `RunContext`. ✓
+  agreed.
+- **Should it accept arbitrary callables (`call_with_cache`,
+  `call_with_thinking`, `stream`)?** Spec only mentions `call`.
+  Plan: forward `call` as the canonical path; `call_with_cache`
+  and `call_with_thinking` raise `CapabilityNotSupported` from
+  the chain unless every wrapped provider supports them
+  (capability-intersection rule). `stream` is harder — defer to
+  a follow-up if needed.
+- **How are exceptions retried within a single provider?** Spec
+  says `attempts_per_provider`. Each attempt is a separate `await
+  provider.call(...)` call; no exponential backoff at the chain
+  level (providers can do their own).
+
+## Proposed chunks (3 total — small feature)
+
+1. **`FallbackChain` class** in
+   `agentforge_core/production/fallback.py`. Implements `LLMClient`
+   surface (`call`, `close`, `capabilities`, `supports`). Resolves
+   string providers via the resolver. Tracks `last_used_provider`
+   for diagnostic purposes. Unit tests cover: success on first
+   provider, retry-on-RateLimitError → second provider succeeds,
+   all providers fail → last exception bubbles, capabilities
+   intersection, attempts_per_provider, close() cascades, raises
+   CapabilityNotSupported for `call_with_cache` /
+   `call_with_thinking` unless every provider supports them.
+
+2. **Re-export from `agentforge` top-level** so
+   `from agentforge import FallbackChain` works. Update
+   `Agent.__init__` to accept `model=FallbackChain([...])` (it
+   already accepts `LLMClient`; verify the path).
+
+3. **CHANGELOG + Implementation status + Runbook section + PR.**
+   Update `docs/features/feat-007-production-rails.md` with:
+   - **Implementation status** section with chunk-by-chunk mapping.
+   - **`## Runbook` section** (new policy locked in 2026-05-10):
+     task-oriented "how do I…" content for agent developers using
+     `FallbackChain` — config example, picking providers, retry
+     tuning, debugging which provider answered. Future feat-011 +
+     feat-019 will consume this section into scaffolded agent
+     projects.
+   - CHANGELOG entry under [Unreleased]/Added.
+   - Mark feat-007 shipped; raise PR.
+
+## TODO before next milestone
+
+- [ ] User approves this analysis + chunk plan.
+- [ ] On approval: state → `designing` → `implementing`; begin
+      chunk 1.
 
 ## Reading order on session resume
 
 1. `AGENTS.md`
 2. `.claude/CLAUDE.md`
 3. `.claude/state/current.md` (this file)
-4. `docs/features/README.md`
-5. `docs/features/feat-NNN-*.md` (active feature)
-6. `docs/roadmap.md`
-
-## After merge
-
-- Pull main, delete `feat/004-tools-system` local + remote.
-- Pick the next feature per pipeline §1: lowest-numbered proposed
-  with deps shipped. Eligible after feat-004:
-  - **feat-007** (Production rails) — deps feat-001 ✓ feat-003 ✓
-  - **feat-008** (Findings) — deps feat-001 ✓
-  - feat-006 (Evaluators) — blocked by feat-008
-  - feat-009 (Observability) — blocked by feat-007
-  - feat-010 (Module discovery) — blocked by feat-012
-- Lowest-numbered eligible is **feat-007** by default.
+4. `docs/features/feat-007-production-rails.md`
+5. `docs/roadmap.md`

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,12 +1,12 @@
 ---
 feature: feat-007-production-rails
-state: analysing
+state: pr-raised
 branch: feat/007-production-rails
 started_at: 2026-05-10T17:30
-last_milestone_at: 2026-05-10T17:30
+last_milestone_at: 2026-05-10T18:30
 last_shipped: feat-004 (Tools system) shipped via PR #10 @ 2b1a37c
 blocker: null
-flags_for_user: ["design-awaiting-approval"]
+flags_for_user: []
 ---
 
 ## Active feature

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -406,3 +406,51 @@ scripted-response Tool for unit tests. 10 unit tests.
 Updated docs/features/feat-004 Implementation status, CHANGELOG,
 roadmap (moved feat-004 from backlog to shipped). Pre-commit hook
 ID migrated from `ruff` (legacy alias) to `ruff-check`.
+
+## 2026-05-10T17:25 — feat-004 shipped
+PR #10 merged at `2b1a37c`. Branch deleted local + remote.
+Six chunks landed cleanly: @tool decorator, calculator + file_read,
+shell + web_search, _dispatch_tool helper + ReAct/PlanExecute
+refactor, FakeTool test helper, docs + ruff hook id migrate.
+
+## 2026-05-10T17:30 — feat-007 started
+Branch: `feat/007-production-rails`. State: `analysing`.
+
+User question on scope: "production rails covers all modern
+guardrails, cost, budget, security etc". Clarified canonical
+split: feat-007 is narrower (cost budget + run_id +
+idempotency + FallbackChain). Modern security guardrails are
+feat-018 (Safety). Observability is feat-009.
+
+Most of feat-007 already shipped under feat-001 (BudgetPolicy,
+RunContext, current_run, idempotency_key_for, RunIdFilter). Only
+remaining piece: FallbackChain. User picked "Ship feat-007
+(FallbackChain only) — small (Recommended)".
+
+Chunk plan (3 total) in state/current.md awaiting approval.
+
+## 2026-05-10T17:50 — Runbook policy locked in
+User asked why runbooks aren't part of each feature PR. Reviewed
+canonical model: per docs/README.md, runbooks live in the (yet-to-
+exist) agentforge-templates repo and are owned by feat-019. Bootstrap
+problem: features ship today without their developer-facing runbook
+content; feat-019 would need to author 16 retroactively.
+
+User's choice (locked):
+1. **Inline `## Runbook` section in each feat-NNN spec.** When
+   feat-011 + feat-019 ship, the templating engine consumes these
+   sections into scaffolded agent projects. Single source of truth.
+2. **Backfill** runbook sections for feat-001/002/003/004/005 in
+   a separate `chore/backfill-runbooks` PR AFTER feat-007 ships
+   (don't disrupt in-flight work).
+
+Updates landed:
+- AGENTS.md Workflow §: new rule "Every feature PR adds a
+  `## Runbook` section in the matching canonical spec".
+- memory feedback_workflow.md rule #8 added (audience: agent
+  developers, not framework maintainers).
+- state/current.md feat-007 chunk 3 expanded to include the
+  Runbook section as part of the docs-update commit.
+
+feat-007 chunk plan unchanged in count (still 3 chunks); chunk 3
+just gains the Runbook authoring sub-task.

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -454,3 +454,14 @@ Updates landed:
 
 feat-007 chunk plan unchanged in count (still 3 chunks); chunk 3
 just gains the Runbook authoring sub-task.
+
+## 2026-05-10T18:30 — feat-007 chunks 1-3 done
+- chunk 1 `6bdd066`: FallbackChain class + 23 unit tests
+- chunk 2 `2e7d2d3`: top-level re-export + 4 Agent-integration tests
+- chunk 3 (this): CHANGELOG, Implementation status, **first-ever
+  Runbook section** (configure fallback / tune retries / combine
+  with budget / read run_id from a tool / debug "every provider
+  failed" / when not to use FallbackChain), roadmap moved feat-007
+  from backlog to shipped.
+
+PR #11 to be raised next.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,16 @@ Don't reference anything outside this repo.
   deviations from the original design, link to the PR. The spec is
   the durable record; CHANGELOG is the user-facing summary. Both
   ship in the same PR.
+- **Every feature PR adds (or updates) a `## Runbook` section in
+  the matching canonical spec.** This section is task-oriented
+  (audience: agent developers using the framework, not framework
+  maintainers): "How do I do X with this feature?", "How do I
+  configure / swap / extend it?", "What goes wrong and how do I
+  debug it?". When feat-011 (Copier scaffolding) and feat-019
+  (runbook system) ship, the templating engine consumes these
+  sections and renders proper runbook files into scaffolded agent
+  projects. Authoring inline avoids the bootstrap problem of
+  retroactive runbook debt.
 - **Every feature PR updates `.claude/state/current.md` and appends
   to `.claude/state/log.md`** at every milestone (analysis,
   design-approved, chunk-complete, PR-raised, shipped). The state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,57 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-007 — Production rails (`FallbackChain` only).** Closes
+  out canonical feat-007. Cost budget (`BudgetPolicy`), run-id
+  propagation (`RunContext`, `current_run`, `idempotency_key_for`),
+  and structured-log run-id tagging (`RunIdFilter`) all shipped
+  under feat-001 already; this PR adds the last remaining piece
+  — cross-provider failover.
+
+  *New in `agentforge-core`:*
+  - **`FallbackChain`** (`agentforge_core.production.fallback`)
+    wraps multiple `LLMClient`s. On `retry_on` exception, falls
+    through to the next provider (after retrying the current one
+    `attempts_per_provider` times). Implements `LLMClient` so any
+    strategy that accepts an `LLMClient` accepts a chain
+    transparently.
+  - String providers resolve via the global `Resolver` (same path
+    as `Agent(model="bedrock:…")`).
+  - `capabilities()` returns the **intersection** of every wrapped
+    provider's capabilities; a chain can only honestly claim what
+    every fallback delivers.
+  - Optional methods (`call_with_cache`, `call_with_thinking`)
+    raise `CapabilityNotSupported` unless every wrapped provider
+    declares the capability (capability-intersection rule).
+  - `stream` raises `CapabilityNotSupported` unconditionally;
+    streaming with cross-provider fallback semantics is harder
+    than the unary call and deferred to a follow-up.
+  - `last_used_provider` (int | None) tracks the index of the
+    provider that answered the most recent call (diagnostic).
+  - `close()` cascades in reverse-construction order; individual
+    close failures are logged and swallowed (best-effort cleanup).
+
+  *Public surface:*
+  - `from agentforge import FallbackChain` (also
+    `from agentforge_core import FallbackChain`).
+
+  *Coverage:* 23 unit tests for the chain itself + 4 Agent-
+  integration tests covering constructor wiring, ReActLoop
+  dispatch, fallback on RateLimitError, top-level import.
+
+  *New workflow rule (locked in 2026-05-10):* every feature PR
+  now adds a **`## Runbook` section** to the matching canonical
+  spec. Audience: agent developers using AgentForge to build
+  production agents. Task-oriented "how do I configure / tune /
+  debug" content. When feat-011 (Copier scaffolding) and feat-019
+  (runbook system) ship, the templating engine consumes these
+  sections into scaffolded agent projects. feat-007's spec is the
+  first to carry one (configure cross-provider fallback, tune
+  retries, combine with budget, read run_id from a tool, debug
+  "every provider failed", etc.). Already-shipped features
+  (feat-001/002/003/004/005) get backfilled in a separate
+  `chore/backfill-runbooks` PR.
+
 - **feat-004 — Tools system.** Adds the decorator + default tools +
   dispatch enhancements that turn a typed Python function into a
   ready-to-use `Tool`, and the four default tools every agent gets

--- a/docs/features/feat-007-production-rails.md
+++ b/docs/features/feat-007-production-rails.md
@@ -269,3 +269,248 @@ and `FallbackChain` shape identical.
 - Archived: `docs/archive/cr/CR-008-cross-provider-fallback.md`,
   `CR-010-run-id-context-propagation.md`, `CR-013-idempotency-keys.md`,
   `docs/archive/subsystem-production-rails.md`
+
+---
+
+## Implementation status
+
+**Status: shipped (Python). TypeScript port pending.**
+
+feat-007's surface largely shipped under feat-001:
+
+| Piece | Status |
+|---|---|
+| `BudgetPolicy` (USD / token / iteration / error-streak caps) | shipped feat-001 |
+| `RunContext` + `current_run()` (ContextVar-bound run state) | shipped feat-001 |
+| `RunContext.idempotency_key_for(*parts)` | shipped feat-001 |
+| `RunIdFilter` (auto-tags log records with run_id) | shipped feat-001 |
+| `BudgetPolicy.reserve` / `commit` / `record_error` / `record_success` | shipped feat-001; consumed feat-002 |
+| **`FallbackChain`** | **shipped this PR** |
+
+`FallbackChain` landed via PR #11 on `feat/007-production-rails`
+across three chunks:
+
+| Chunk | Commit | Scope |
+|---|---|---|
+| 1 | `6bdd066` | `FallbackChain` class (`agentforge_core/production/fallback.py`); 23 unit tests |
+| 2 | `2e7d2d3` | Top-level re-export (`from agentforge import FallbackChain`); 4 Agent-integration tests |
+| 3 | (this) | CHANGELOG, Implementation status, Runbook section, PR |
+
+### Public surface delivered
+
+```python
+from agentforge import Agent, FallbackChain
+
+chain = FallbackChain(
+    [
+        "anthropic:claude-sonnet-4.7",
+        "bedrock:anthropic.claude-sonnet-4.7",
+        "openai:gpt-4o",
+    ],
+    retry_on=(RateLimitError, ProviderError),  # default
+    attempts_per_provider=1,                   # default
+)
+agent = Agent(model=chain, tools=[...])
+```
+
+### Deviations from this spec
+
+- **`FallbackChain` is NOT re-exported from
+  `agentforge_core.production`.** The natural location creates a
+  circular import (`production/__init__.py` → `fallback` →
+  `contracts.llm` → `production.exceptions.CapabilityNotSupported`
+  → back into `production/__init__.py` while still loading). The
+  workaround documented inline in `production/__init__.py`:
+  `FallbackChain` is imported from the submodule directly inside
+  `agentforge_core/__init__.py`, which runs *after* `production`
+  finishes. Users reach it via
+  `from agentforge_core import FallbackChain` or
+  `from agentforge import FallbackChain`.
+- **`stream` is not supported** in v0.1. Streaming with
+  cross-provider fallback semantics is harder than the unary call
+  (events from provider N might partially arrive before fallback
+  N+1 kicks in). `chain.stream(...)` raises
+  `CapabilityNotSupported` unconditionally. Callers needing
+  streaming pick a single provider.
+- **Capability-intersection rule** for optional methods
+  (`call_with_cache`, `call_with_thinking`) — locked in by user
+  decision before chunk 1. The chain's `capabilities()` returns
+  the intersection of every wrapped provider's capabilities, and
+  optional methods raise `CapabilityNotSupported` unless every
+  wrapped provider declares the capability.
+- **Default `retry_on` includes `AuthenticationError`** via
+  inheritance (`AuthenticationError` extends `ProviderError`).
+  Intentional: one provider's auth being misconfigured is a
+  legitimate reason to try the next provider with its own auth.
+  Callers wanting tighter behaviour pass
+  `retry_on=(RateLimitError,)`.
+
+### What's *not* yet implemented
+
+- **`RunResult.retry_provider_used`**: spec mentions tracking
+  which provider answered. `FallbackChain.last_used_provider`
+  exposes the index for diagnostics, but `RunResult` does not yet
+  carry the field. Adding it is a minor bump on the locked
+  `RunResult` shape; lands in a follow-up or alongside feat-009
+  (Observability) where the field becomes most useful.
+- **Provider-level retry backoff** at the chain level. Today the
+  chain just retries `attempts_per_provider` times in immediate
+  succession. Backoff sits per-provider (the bedrock driver
+  already implements bounded exponential backoff with jitter
+  internally).
+- **TypeScript port** of the entire feat-007 surface.
+
+---
+
+## Runbook
+
+Audience: agent developers using AgentForge to build production
+agents. Task-oriented. When feat-011 (Copier scaffolding) and
+feat-019 (runbook system) ship, this section is consumed by the
+templating engine and rendered into scaffolded agent projects.
+
+### How do I configure cross-provider fallback?
+
+Wrap your providers in `FallbackChain` and pass it as `model`:
+
+```python
+from agentforge import Agent, FallbackChain
+
+chain = FallbackChain([
+    "anthropic:claude-sonnet-4.7",          # primary
+    "bedrock:anthropic.claude-sonnet-4.7",  # fallback 1
+    "openai:gpt-4o",                        # fallback 2
+])
+agent = Agent(model=chain, tools=[...])
+```
+
+Order matters — the chain tries the **first** provider first and
+only falls back on a `retry_on` exception. Put the cheapest /
+fastest / most-trusted provider first.
+
+### How do I tune retries?
+
+Two levers:
+
+```python
+chain = FallbackChain(
+    providers=["anthropic:claude-sonnet-4.7", "bedrock:..."],
+    retry_on=(RateLimitError, ServiceError),  # narrow the set
+    attempts_per_provider=3,                  # try each provider 3x
+)
+```
+
+- `retry_on` is the **set of exception types** that trigger
+  fallback. Default `(RateLimitError, ProviderError)` covers
+  every transient provider error, including auth/model-not-found
+  (since they're `ProviderError` subclasses). Pass a narrower
+  tuple to keep falling back only on rate limits or service
+  errors.
+- `attempts_per_provider` is how many times each provider is
+  retried **before** moving to the next one. Default 1 (no
+  retry; first failure → next provider).
+
+### How do I set a budget cap on top of fallback?
+
+`BudgetPolicy` and `FallbackChain` are independent. Combine:
+
+```python
+from agentforge import Agent, BudgetPolicy, FallbackChain
+
+agent = Agent(
+    model=FallbackChain([...]),
+    budget=BudgetPolicy(usd=5.0, max_tokens=200_000, max_iterations=50),
+)
+```
+
+Failover cost counts against the same budget — falling over to a
+more expensive provider exhausts the budget sooner, tripping
+`BudgetExceeded` per the existing semantics.
+
+### How do I read the run_id from inside a tool?
+
+```python
+from agentforge import current_run
+
+@tool
+def charge_customer(amount_cents: int, customer_id: str) -> dict:
+    """Charge a customer (uses the run's idempotency key)."""
+    ctx = current_run()
+    return stripe.charge(
+        amount=amount_cents,
+        customer=customer_id,
+        idempotency_key=ctx.idempotency_key_for("charge", customer_id),
+    )
+```
+
+`current_run()` reads the per-run `RunContext` from the ContextVar
+`Agent.run()` binds. Safe to call from any tool body or any code
+running inside `Agent.run()`'s scope.
+
+`ctx.idempotency_key_for(*parts)` is **stable for the lifetime of
+one run** — retries within the run reuse the same key, so
+external services (Stripe, SQS, etc.) dedupe them. Different runs
+get different keys.
+
+### How do I tag my logs with run_id automatically?
+
+Already on by default:
+
+```python
+import logging
+log = logging.getLogger(__name__)
+log.info("Looking up user %s", user_id)
+# stdout: 2026-05-10 14:23:01 [run_id=01HX...ZYZ] INFO Looking up user U-42
+```
+
+`Agent.__init__` installs `RunIdFilter` on the root logger
+(idempotent — installing again is a no-op). To opt out:
+`Agent(install_log_filter=False)`.
+
+### How do I debug "which provider answered my call"?
+
+Read `chain.last_used_provider` after a call:
+
+```python
+chain = FallbackChain(["anthropic:...", "bedrock:..."])
+agent = Agent(model=chain)
+result = await agent.run("hello")
+print(f"answered by provider index {chain.last_used_provider}")
+# 0 = anthropic, 1 = bedrock
+```
+
+`None` until the first successful call; the index is 0-based and
+reflects the chain's construction order.
+
+### How do I debug "every provider failed"?
+
+The **last** provider's exception bubbles up. The chain logs a
+WARNING for each fallback transition:
+
+```
+WARNING agentforge_core.production.fallback: provider 1/3 (BedrockClient)
+        raised RateLimitError (attempt 1/1); trying next provider
+WARNING agentforge_core.production.fallback: provider 2/3 (BedrockClient)
+        raised RateLimitError (attempt 1/1); trying next provider
+```
+
+Set `agentforge_core.production.fallback` to DEBUG or INFO during
+development to see the full transition log. WARNINGS are usually
+sufficient in production.
+
+### When should I NOT use FallbackChain?
+
+- **Streaming**: `FallbackChain.stream` raises
+  `CapabilityNotSupported`. Pick a single provider for streaming.
+- **Providers with very different capabilities**: the chain's
+  `capabilities()` is the intersection. Wrapping a
+  caching-supporting Anthropic with a non-caching OpenAI means
+  `chain.supports("caching")` is `False`. Either use
+  `FallbackChain` only over capability-equivalent providers, or
+  avoid declaring the capability.
+- **When `AuthenticationError` is config drift, not transient**:
+  the default `retry_on` falls back on auth errors too. If your
+  auth-error means "credentials rotated and need updating",
+  failing over hides that signal. Pass
+  `retry_on=(RateLimitError, ServiceError, TimeoutError)` for
+  stricter behaviour.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,7 @@ onward every feature uses the canonical feat-NNN number.
 | [feat-003](./features/feat-003-llm-provider-abstraction.md) | LLM provider abstraction (Bedrock) | [#4](https://github.com/Scaffoldic/agentforge-py/pull/4) |
 | [feat-004](./features/feat-004-tools-system.md) | Tools system — `@tool` decorator + 4 default tools + dispatch enhancements + `FakeTool` | [#10](https://github.com/Scaffoldic/agentforge-py/pull/10) |
 | [feat-005](./features/feat-005-persistence-and-memory.md) | Persistence — MemoryStore + sqlite + postgres + neo4j + surrealdb + VectorStore + GraphStore + RAG | [#5](https://github.com/Scaffoldic/agentforge-py/pull/5) (sqlite + RAG, mis-labelled feat-007), [#7](https://github.com/Scaffoldic/agentforge-py/pull/7) (graph + neo4j + surrealdb, mis-labelled feat-009), [#8](https://github.com/Scaffoldic/agentforge-py/pull/8) (postgres, mis-labelled feat-008) |
+| [feat-007](./features/feat-007-production-rails.md) | Production rails — `BudgetPolicy` + `RunContext` + `idempotency_key_for` + `RunIdFilter` (shipped under feat-001) + `FallbackChain` cross-provider failover | [#11](https://github.com/Scaffoldic/agentforge-py/pull/11) |
 
 For details on what each shipped feature delivered vs. what was
 deferred, read the **Implementation status** section at the bottom
@@ -49,11 +50,6 @@ move into "In flight" when starting.
   Evaluators & benchmarks.** `Evaluator` ABC was shipped under
   feat-001; the full eval framework (closes `scorer="judge"`
   placeholder in feat-002's `TreeOfThoughts`) is feat-006.
-- **[feat-007](./features/feat-007-production-rails.md) — Production
-  rails.** Cost budget (partially shipped via `BudgetPolicy`),
-  fallback chain (NOT shipped), `run_id` propagation (partially
-  shipped), idempotency (NOT shipped). The full feat-007 scope
-  remains.
 - **[feat-008](./features/feat-008-findings-and-output-shapes.md) —
   Findings & output shapes.** `Finding` Protocol + variants
   (Simple, Patch, Narrative, MultiSpan) + renderers. Spec exists;

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -45,6 +45,12 @@ from agentforge_core.production import (
     reset_run,
     uninstall_run_id_filter,
 )
+
+# Imported from the submodule directly (not via production/__init__)
+# to avoid a circular import — see the comment in production/__init__.py
+# for the chain. This import runs *after* production finishes, so
+# LLMClient is already available.
+from agentforge_core.production.fallback import FallbackChain
 from agentforge_core.resolver import (
     Resolver,
     parse_model_string,
@@ -92,6 +98,7 @@ __all__ = [
     "EmbeddingResponse",
     "EvalResult",
     "Evaluator",
+    "FallbackChain",
     "Finding",
     "FinishReason",
     "GraphEdge",

--- a/packages/agentforge-core/src/agentforge_core/production/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/production/__init__.py
@@ -3,11 +3,21 @@
 Owned by the framework (per ADR-0010): every agent has these wired by
 default. Includes per-run cost guarding (`BudgetPolicy`), correlation
 context (`RunContext`, `current_run`), structured logging filter
-(`RunIdFilter`), and the framework's exception hierarchy.
+(`RunIdFilter`), cross-provider failover (`FallbackChain`), and the
+framework's exception hierarchy.
 """
 
 from __future__ import annotations
 
+# `FallbackChain` is intentionally NOT re-exported here because it
+# imports `LLMClient`, which would create a circular import:
+# `agentforge_core/__init__.py` → contracts.llm (imports
+# `CapabilityNotSupported` from `production.exceptions`) →
+# triggers `production/__init__.py` → fallback (imports
+# LLMClient still being loaded). Users reach FallbackChain via the
+# top-level `from agentforge_core import FallbackChain` (loaded
+# after `production` finishes), or directly via
+# `agentforge_core.production.fallback`.
 from agentforge_core.production.budget import BudgetPolicy
 from agentforge_core.production.exceptions import (
     AgentForgeError,

--- a/packages/agentforge-core/src/agentforge_core/production/fallback.py
+++ b/packages/agentforge-core/src/agentforge_core/production/fallback.py
@@ -1,0 +1,321 @@
+"""`FallbackChain` — cross-provider failover wrapping multiple
+`LLMClient`s (feat-007).
+
+Implements the `LLMClient` ABC, so any strategy that accepts an
+`LLMClient` accepts a chain transparently.
+
+Usage:
+
+    from agentforge import Agent, FallbackChain
+
+    chain = FallbackChain(
+        [
+            "anthropic:claude-sonnet-4.7",
+            "bedrock:anthropic.claude-sonnet-4.7",
+            "openai:gpt-4o",
+        ],
+        retry_on=(RateLimitError, ProviderError),
+        attempts_per_provider=1,
+    )
+    agent = Agent(model=chain, tools=[...])
+
+Behaviour:
+  - On `retry_on` exception → try next provider (after retrying the
+    current provider `attempts_per_provider` times).
+  - Last provider's exception bubbles up if every provider exhausts.
+  - `last_used_provider` tracks the index of the provider that
+    answered the most recent call (diagnostic only).
+  - `capabilities()` returns the **intersection** of every wrapped
+    provider's capabilities — a chain can only honestly claim what
+    every fallback can deliver.
+  - `call_with_cache` / `call_with_thinking` raise
+    `CapabilityNotSupported` unless every wrapped provider declares
+    the capability.
+  - `close()` cascades in reverse-construction order.
+
+Out of scope (v0.1):
+  - Streaming (`stream`) — not yet supported by `FallbackChain`;
+    callers using streaming should pick a single provider.
+  - Provider-level retry backoff — providers handle their own
+    retries internally.
+  - Per-call `retry_on` override — chain-level configuration only.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.production.exceptions import (
+    CapabilityNotSupported,
+    ModuleError,
+    ProviderError,
+    RateLimitError,
+)
+from agentforge_core.resolver import Resolver, parse_model_string
+from agentforge_core.values.messages import LLMResponse, Message, ToolSpec
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_RETRY_ON: tuple[type[Exception], ...] = (RateLimitError, ProviderError)
+_DEFAULT_ATTEMPTS_PER_PROVIDER = 1
+
+
+class FallbackChain(LLMClient):
+    """Wrap multiple `LLMClient`s with cross-provider failover.
+
+    Args:
+        providers: A non-empty list of providers. Each entry is
+            either a model string (`"<provider>:<model_id>"`,
+            resolved via the global `Resolver`) or a typed
+            `LLMClient` instance.
+        retry_on: Exception types that trigger a fallback to the
+            next provider. Default: `(RateLimitError, ProviderError)`.
+            Other exceptions (e.g. `AuthenticationError`) bubble
+            immediately — falling back on those is usually wrong.
+        attempts_per_provider: How many times to retry the *current*
+            provider before moving to the next. Default 1 (no
+            retry; first failure → next provider).
+
+    Raises:
+        ValueError: empty providers list, non-positive
+            `attempts_per_provider`, or an unrecognised provider
+            string.
+    """
+
+    def __init__(
+        self,
+        providers: list[str | LLMClient],
+        *,
+        retry_on: tuple[type[Exception], ...] = _DEFAULT_RETRY_ON,
+        attempts_per_provider: int = _DEFAULT_ATTEMPTS_PER_PROVIDER,
+    ) -> None:
+        if not providers:
+            msg = "FallbackChain requires at least one provider"
+            raise ValueError(msg)
+        if attempts_per_provider < 1:
+            msg = f"attempts_per_provider must be >= 1, got {attempts_per_provider}"
+            raise ValueError(msg)
+        self._clients: list[LLMClient] = [_resolve_provider(p) for p in providers]
+        self._retry_on = retry_on
+        self._attempts_per_provider = attempts_per_provider
+        self._last_used_provider: int | None = None
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    @property
+    def last_used_provider(self) -> int | None:
+        """Index (0-based) of the provider that answered the most
+        recent call. `None` until the first call succeeds."""
+        return self._last_used_provider
+
+    @property
+    def providers(self) -> tuple[LLMClient, ...]:
+        """Resolved providers in chain order. Useful for tests."""
+        return tuple(self._clients)
+
+    # ------------------------------------------------------------------
+    # LLMClient surface
+    # ------------------------------------------------------------------
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        return await self._dispatch_with_fallback("call", system, messages, tools=tools)
+
+    async def close(self) -> None:
+        """Close every wrapped provider in reverse-construction order.
+
+        Reverse order so a partial-construction failure during
+        `__init__` doesn't leak resources held by earlier providers.
+        Exceptions during close are logged and swallowed; the goal
+        is best-effort cleanup, not failure.
+        """
+        for client in reversed(self._clients):
+            try:
+                await client.close()
+            except Exception:
+                log.exception(
+                    "FallbackChain: error closing %s; continuing",
+                    type(client).__name__,
+                )
+
+    def capabilities(self) -> set[str]:
+        """Intersection of every wrapped provider's capabilities.
+
+        A chain can only honestly claim a capability that every
+        fallback can deliver — otherwise a fallback might fail to
+        honour a feature the caller relied on declaring.
+        """
+        if not self._clients:
+            return set()
+        common = set(self._clients[0].capabilities())
+        for client in self._clients[1:]:
+            common &= client.capabilities()
+        return common
+
+    # ------------------------------------------------------------------
+    # Optional capabilities — capability-intersection rule
+    # ------------------------------------------------------------------
+
+    async def call_with_cache(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+        *,
+        cache_breakpoints: list[int],
+    ) -> LLMResponse:
+        if "caching" not in self.capabilities():
+            msg = (
+                "FallbackChain does not support 'caching'. Every "
+                "wrapped provider must declare the capability for the "
+                "chain to honour it; check chain.supports('caching') "
+                "before calling."
+            )
+            raise CapabilityNotSupported(msg)
+        return await self._dispatch_with_fallback(
+            "call_with_cache",
+            system,
+            messages,
+            tools=tools,
+            cache_breakpoints=cache_breakpoints,
+        )
+
+    async def call_with_thinking(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+        *,
+        thinking_budget_tokens: int,
+    ) -> LLMResponse:
+        if "thinking" not in self.capabilities():
+            msg = (
+                "FallbackChain does not support 'thinking'. Every "
+                "wrapped provider must declare the capability for the "
+                "chain to honour it; check chain.supports('thinking') "
+                "before calling."
+            )
+            raise CapabilityNotSupported(msg)
+        return await self._dispatch_with_fallback(
+            "call_with_thinking",
+            system,
+            messages,
+            tools=tools,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+
+    def stream(
+        self,
+        system: str,  # noqa: ARG002 — interface compatibility; we raise unconditionally
+        messages: list[Message],  # noqa: ARG002
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002
+    ) -> AsyncIterator[Any]:
+        """Streaming is not supported on `FallbackChain` in v0.1.
+
+        Streaming with cross-provider fallback semantics is genuinely
+        harder than the unary call: events from provider N might
+        partially arrive before a fallback to N+1 kicks in, leaving
+        the caller with incoherent partial output. Callers needing
+        streaming should pick a single provider.
+        """
+        msg = (
+            "FallbackChain does not support 'streaming' in v0.1. "
+            "Pick a single provider for streaming use cases."
+        )
+        raise CapabilityNotSupported(msg)
+
+    # ------------------------------------------------------------------
+    # Internal — fallback dispatch
+    # ------------------------------------------------------------------
+
+    async def _dispatch_with_fallback(
+        self,
+        method_name: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Iterate providers; for each, try `attempts_per_provider`
+        times; on `retry_on` exception move to the next provider.
+
+        The last provider's exception bubbles up if every provider
+        is exhausted.
+        """
+        last_exc: Exception | None = None
+        for index, client in enumerate(self._clients):
+            method = getattr(client, method_name)
+            for attempt in range(self._attempts_per_provider):
+                try:
+                    response: LLMResponse = await method(*args, **kwargs)
+                except self._retry_on as exc:
+                    last_exc = exc
+                    log.warning(
+                        "FallbackChain: provider %d/%d (%s) raised %s (attempt %d/%d); %s",
+                        index + 1,
+                        len(self._clients),
+                        type(client).__name__,
+                        type(exc).__name__,
+                        attempt + 1,
+                        self._attempts_per_provider,
+                        "trying next provider"
+                        if attempt + 1 == self._attempts_per_provider
+                        else "retrying",
+                    )
+                    continue
+                else:
+                    self._last_used_provider = index
+                    return response
+        # Every provider exhausted.
+        assert last_exc is not None
+        raise last_exc
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _resolve_provider(provider: Any) -> LLMClient:
+    """Turn a `str` model spec or `LLMClient` instance into an
+    `LLMClient` instance via the global resolver.
+
+    Accepts `Any` (not `str | LLMClient`) so the runtime
+    `isinstance` guards remain reachable for type-checkers — the
+    public `FallbackChain.__init__` signature is the typed gate;
+    this internal helper hardens against accidental mistypes.
+    """
+    if isinstance(provider, LLMClient):
+        return provider
+    if not isinstance(provider, str):
+        msg = f"FallbackChain providers must be str or LLMClient, got {type(provider).__name__}"
+        raise TypeError(msg)
+    name, model_id = parse_model_string(provider)
+    try:
+        cls = Resolver.global_().resolve("providers", name)
+    except ModuleError as exc:
+        msg = (
+            f"FallbackChain: no LLM provider registered for {name!r}. "
+            f"Install agentforge-{name} (e.g. "
+            f"`uv add agentforge-{name}`) or pass a typed LLMClient "
+            f"instance instead of the {provider!r} string."
+        )
+        raise ValueError(msg) from exc
+    instance = cls(model_id=model_id)
+    if not isinstance(instance, LLMClient):
+        msg = (
+            f"FallbackChain: resolved provider {name!r} ({cls.__name__}) "
+            f"does not implement LLMClient."
+        )
+        raise TypeError(msg)
+    return instance
+
+
+__all__ = ["FallbackChain"]

--- a/packages/agentforge-core/tests/unit/test_fallback_chain.py
+++ b/packages/agentforge-core/tests/unit/test_fallback_chain.py
@@ -1,0 +1,343 @@
+"""Unit tests for `FallbackChain` (feat-007 chunk 1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agentforge_core import FallbackChain
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.production import (
+    AuthenticationError,
+    CapabilityNotSupported,
+    ProviderError,
+    RateLimitError,
+)
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+
+# ----------------------------------------------------------------------
+# Test doubles
+# ----------------------------------------------------------------------
+
+
+def _response(text: str = "ok") -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=(),
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=0.0,
+        model="fake",
+        provider="fake",
+    )
+
+
+class _ScriptedClient(LLMClient):
+    """LLMClient that yields a script of (response | exception) per call.
+
+    Each `call` pops the next item: if a callable, it's invoked; if
+    an exception class, it's raised; otherwise returned as-is.
+    """
+
+    def __init__(
+        self,
+        script: list[Any],
+        *,
+        capabilities_set: set[str] | None = None,
+    ) -> None:
+        self._script = list(script)
+        self._caps = capabilities_set or set()
+        self.calls: list[tuple[Any, ...]] = []
+        self.closed = False
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        self.calls.append((system, messages, tools))
+        if not self._script:
+            raise ProviderError("script exhausted")
+        item = self._script.pop(0)
+        if isinstance(item, type) and issubclass(item, BaseException):
+            raise item("scripted")
+        if callable(item):
+            return item()  # type: ignore[no-any-return]
+        return item  # type: ignore[no-any-return]
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def capabilities(self) -> set[str]:
+        return set(self._caps)
+
+
+# ----------------------------------------------------------------------
+# Constructor
+# ----------------------------------------------------------------------
+
+
+def test_constructor_rejects_empty_providers() -> None:
+    with pytest.raises(ValueError, match="at least one provider"):
+        FallbackChain([])
+
+
+def test_constructor_rejects_zero_attempts_per_provider() -> None:
+    client = _ScriptedClient([])
+    with pytest.raises(ValueError, match="attempts_per_provider"):
+        FallbackChain([client], attempts_per_provider=0)
+
+
+def test_constructor_rejects_non_str_non_client() -> None:
+    with pytest.raises(TypeError, match="must be str or LLMClient"):
+        FallbackChain([42])  # type: ignore[list-item]
+
+
+def test_constructor_rejects_unknown_provider_string() -> None:
+    with pytest.raises(ValueError, match="no LLM provider registered"):
+        FallbackChain(["never-registered:model-x"])
+
+
+def test_constructor_accepts_typed_clients() -> None:
+    a = _ScriptedClient([])
+    b = _ScriptedClient([])
+    chain = FallbackChain([a, b])
+    assert chain.providers == (a, b)
+
+
+# ----------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_provider_success_short_circuits() -> None:
+    a = _ScriptedClient([_response("from-a")])
+    b = _ScriptedClient([_response("from-b")])
+    chain = FallbackChain([a, b])
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "from-a"
+    assert b.calls == []  # b never invoked
+    assert chain.last_used_provider == 0
+
+
+# ----------------------------------------------------------------------
+# Fallback on retry_on
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_rate_limit_error() -> None:
+    a = _ScriptedClient([RateLimitError])
+    b = _ScriptedClient([_response("from-b")])
+    chain = FallbackChain([a, b])
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "from-b"
+    assert chain.last_used_provider == 1
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_provider_error() -> None:
+    a = _ScriptedClient([ProviderError])
+    b = _ScriptedClient([_response("ok")])
+    chain = FallbackChain([a, b])
+    await chain.call(system="s", messages=[])
+    assert chain.last_used_provider == 1
+
+
+@pytest.mark.asyncio
+async def test_default_retry_on_includes_authentication_error() -> None:
+    """The spec's default `retry_on=(RateLimitError, ProviderError)`
+    catches every `ProviderError` subclass via inheritance — including
+    `AuthenticationError`. The intent is "fall back on anything
+    provider-related": one provider's auth being misconfigured is a
+    legitimate reason to try the next one (which has its own auth).
+    Callers who want stricter behaviour can pass a tighter
+    `retry_on=(RateLimitError,)` etc."""
+    a = _ScriptedClient([AuthenticationError])
+    b = _ScriptedClient([_response("from-b")])
+    chain = FallbackChain([a, b])
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "from-b"
+
+
+@pytest.mark.asyncio
+async def test_tight_retry_on_excludes_authentication() -> None:
+    """With `retry_on=(RateLimitError,)`, auth errors bubble
+    immediately because they're outside the explicit allowlist."""
+    a = _ScriptedClient([AuthenticationError])
+    b = _ScriptedClient([_response("from-b")])
+    chain = FallbackChain([a, b], retry_on=(RateLimitError,))
+    with pytest.raises(AuthenticationError):
+        await chain.call(system="s", messages=[])
+    assert b.calls == []
+
+
+@pytest.mark.asyncio
+async def test_custom_retry_on_with_unrelated_exception() -> None:
+    """The user can opt into falling back on any exception type."""
+
+    class _CustomError(Exception):
+        pass
+
+    a = _ScriptedClient([_CustomError])
+    b = _ScriptedClient([_response("recovered")])
+    chain = FallbackChain([a, b], retry_on=(_CustomError,))
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "recovered"
+
+
+# ----------------------------------------------------------------------
+# attempts_per_provider
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attempts_per_provider_retries_before_falling_through() -> None:
+    a = _ScriptedClient([RateLimitError, RateLimitError, _response("third try")])
+    chain = FallbackChain([a], attempts_per_provider=3)
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "third try"
+    assert len(a.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_attempts_per_provider_then_fallback() -> None:
+    """Each provider gets `attempts_per_provider` chances; on
+    exhaustion, the chain moves to the next provider."""
+    a = _ScriptedClient([RateLimitError, RateLimitError])
+    b = _ScriptedClient([_response("from-b")])
+    chain = FallbackChain([a, b], attempts_per_provider=2)
+    result = await chain.call(system="s", messages=[])
+    assert result.content == "from-b"
+    assert len(a.calls) == 2  # a tried twice
+    assert len(b.calls) == 1  # b answered first try
+
+
+# ----------------------------------------------------------------------
+# All providers exhausted
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_exception_bubbles_when_all_exhausted() -> None:
+    a = _ScriptedClient([RateLimitError])
+    b = _ScriptedClient([ProviderError])
+    chain = FallbackChain([a, b])
+    with pytest.raises(ProviderError):
+        await chain.call(system="s", messages=[])
+
+
+# ----------------------------------------------------------------------
+# Capabilities — intersection rule
+# ----------------------------------------------------------------------
+
+
+def test_capabilities_intersection() -> None:
+    a = _ScriptedClient([], capabilities_set={"tools", "caching", "thinking"})
+    b = _ScriptedClient([], capabilities_set={"tools", "caching"})
+    chain = FallbackChain([a, b])
+    assert chain.capabilities() == {"tools", "caching"}
+
+
+def test_capabilities_empty_intersection() -> None:
+    a = _ScriptedClient([], capabilities_set={"tools"})
+    b = _ScriptedClient([], capabilities_set={"caching"})
+    chain = FallbackChain([a, b])
+    assert chain.capabilities() == set()
+
+
+def test_supports_reflects_intersection() -> None:
+    a = _ScriptedClient([], capabilities_set={"tools", "caching"})
+    b = _ScriptedClient([], capabilities_set={"tools"})
+    chain = FallbackChain([a, b])
+    assert chain.supports("tools") is True
+    assert chain.supports("caching") is False  # b doesn't support
+
+
+# ----------------------------------------------------------------------
+# Optional methods — capability-intersection rule
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_with_cache_raises_if_not_all_support() -> None:
+    a = _ScriptedClient([], capabilities_set={"caching"})
+    b = _ScriptedClient([], capabilities_set=set())
+    chain = FallbackChain([a, b])
+    with pytest.raises(CapabilityNotSupported, match="caching"):
+        await chain.call_with_cache(system="s", messages=[], cache_breakpoints=[0])
+
+
+@pytest.mark.asyncio
+async def test_call_with_thinking_raises_if_not_all_support() -> None:
+    a = _ScriptedClient([], capabilities_set={"thinking"})
+    b = _ScriptedClient([], capabilities_set=set())
+    chain = FallbackChain([a, b])
+    with pytest.raises(CapabilityNotSupported, match="thinking"):
+        await chain.call_with_thinking(system="s", messages=[], thinking_budget_tokens=100)
+
+
+def test_stream_raises_unsupported() -> None:
+    a = _ScriptedClient([])
+    chain = FallbackChain([a])
+    with pytest.raises(CapabilityNotSupported, match="streaming"):
+        chain.stream(system="s", messages=[])
+
+
+# ----------------------------------------------------------------------
+# close() cascades
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_cascades_to_every_provider() -> None:
+    a = _ScriptedClient([])
+    b = _ScriptedClient([])
+    c = _ScriptedClient([])
+    chain = FallbackChain([a, b, c])
+    await chain.close()
+    assert a.closed is True
+    assert b.closed is True
+    assert c.closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_swallows_individual_errors() -> None:
+    """A failing close on one provider must not block close of the
+    others — best-effort cleanup."""
+
+    class _BrokenCloser(_ScriptedClient):
+        async def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    a = _BrokenCloser([])
+    b = _ScriptedClient([])
+    chain = FallbackChain([a, b])
+    await chain.close()  # must not raise
+    assert b.closed is True
+
+
+# ----------------------------------------------------------------------
+# Diagnostics
+# ----------------------------------------------------------------------
+
+
+def test_last_used_provider_starts_none() -> None:
+    chain = FallbackChain([_ScriptedClient([])])
+    assert chain.last_used_provider is None
+
+
+@pytest.mark.asyncio
+async def test_last_used_provider_tracks_index() -> None:
+    a = _ScriptedClient([RateLimitError])
+    b = _ScriptedClient([_response()])
+    chain = FallbackChain([a, b])
+    await chain.call(system="s", messages=[])
+    assert chain.last_used_provider == 1

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -19,6 +19,8 @@ the per-feature specs under `docs/features/`.
 
 from __future__ import annotations
 
+from agentforge_core import FallbackChain
+
 from agentforge._tools import tool
 from agentforge.agent import Agent
 from agentforge.config import AgentForgeConfig, load_config
@@ -42,6 +44,7 @@ __all__ = [
     "RUNTIME_KEY",
     "Agent",
     "AgentForgeConfig",
+    "FallbackChain",
     "InMemoryGraphStore",
     "InMemoryStore",
     "InMemoryVectorStore",

--- a/packages/agentforge/tests/unit/test_agent_fallback_chain.py
+++ b/packages/agentforge/tests/unit/test_agent_fallback_chain.py
@@ -1,0 +1,101 @@
+"""Verify `Agent(model=FallbackChain([...]))` works end-to-end
+(feat-007 chunk 2)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import agentforge as af
+import pytest
+from agentforge import Agent, FallbackChain, ReActLoop
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.production import RateLimitError
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+
+
+class _ScriptedClient(LLMClient):
+    """Minimal LLMClient that yields a script of (response | exception)."""
+
+    def __init__(self, script: list[Any]) -> None:
+        self._script = list(script)
+        self.calls = 0
+
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        self.calls += 1
+        if not self._script:
+            raise RateLimitError("script exhausted")
+        item = self._script.pop(0)
+        if isinstance(item, type) and issubclass(item, BaseException):
+            raise item("scripted")
+        return item  # type: ignore[no-any-return]
+
+    async def close(self) -> None:
+        pass
+
+
+def _ok_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=(),
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=1, output_tokens=1),
+        cost_usd=0.0,
+        model="fake",
+        provider="fake",
+    )
+
+
+# ---- Agent accepts a FallbackChain transparently ----
+
+
+def test_agent_constructor_accepts_chain() -> None:
+    """`Agent(model=FallbackChain([...]))` sets `_llm` to the chain
+    instance directly — no string parsing, no resolver lookup."""
+    chain = FallbackChain([_ScriptedClient([])])
+    agent = Agent(model=chain, strategy=ReActLoop())
+    assert agent._llm is chain  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_agent_run_uses_first_provider_when_healthy() -> None:
+    a = _ScriptedClient([_ok_response("from-a")])
+    b = _ScriptedClient([_ok_response("from-b")])
+    chain = FallbackChain([a, b])
+    agent = Agent(model=chain, strategy=ReActLoop(max_iterations=2))
+    result = await agent.run("hi")
+    assert "from-a" in result.output
+    assert b.calls == 0
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_run_falls_back_on_rate_limit() -> None:
+    a = _ScriptedClient([RateLimitError])
+    b = _ScriptedClient([_ok_response("from-b")])
+    chain = FallbackChain([a, b])
+    agent = Agent(model=chain, strategy=ReActLoop(max_iterations=2))
+    result = await agent.run("hi")
+    assert "from-b" in result.output
+    assert chain.last_used_provider == 1
+    await agent.close()
+
+
+# ---- Top-level re-export ----
+
+
+def test_fallback_chain_importable_from_agentforge() -> None:
+    """`from agentforge import FallbackChain` is the documented
+    public surface for agent authors. The top-level imports of
+    this test file already establish that; this assertion confirms
+    the bound name is the same class as the canonical core export."""
+    assert af.FallbackChain is FallbackChain


### PR DESCRIPTION
## Summary

Closes out canonical feat-007. Most of feat-007's surface shipped
under feat-001 already (`BudgetPolicy`, `RunContext`,
`current_run`, `idempotency_key_for`, `RunIdFilter`). This PR adds
the only un-shipped piece: **`FallbackChain`** — cross-provider
failover wrapping multiple `LLMClient`s.

\`\`\`python
from agentforge import Agent, FallbackChain

chain = FallbackChain([
    "anthropic:claude-sonnet-4.7",
    "bedrock:anthropic.claude-sonnet-4.7",
    "openai:gpt-4o",
])
agent = Agent(model=chain, tools=[...])
\`\`\`

**3 chunks:**

| # | Commit | Scope |
|---|---|---|
| 1 | \`6bdd066\` | \`FallbackChain\` class + 23 unit tests (constructor, retry, exhaustion, capability intersection, optional-method gating, close cascade) |
| 2 | \`2e7d2d3\` | Top-level re-export + 4 Agent-integration tests (\`Agent(model=FallbackChain([...]))\` works end-to-end) |
| 3 | \`940e3c0\` | CHANGELOG + Implementation status + **first Runbook section** + roadmap |

**Capability-intersection rule** for optional methods (locked in
by user before chunk 1): \`call_with_cache\` / \`call_with_thinking\`
work only if EVERY wrapped provider declares the capability;
otherwise raise \`CapabilityNotSupported\`. \`stream\` raises
unconditionally — streaming with cross-provider fallback semantics
is harder than the unary call and deferred.

**New runbook policy** (locked in 2026-05-10): every feature PR
adds a \`## Runbook\` section to its canonical spec. Audience: agent
developers using the framework. When feat-011 + feat-019 land, the
templating engine consumes these sections into scaffolded agent
projects. feat-007's spec is the first to carry one. Already-
shipped features (feat-001 through 005) get backfilled in a
separate \`chore/backfill-runbooks\` PR after this merges.

## Test plan

- [x] \`uv run pre-commit run --all-files\` green at every commit
  (ruff format, ruff check, mypy --strict, bandit, pytest unit +
  integration excluding live, coverage ≥ 90%)
- [x] 23 \`FallbackChain\` unit tests + 4 Agent-integration tests
- [x] No regression on feat-001 / -002 / -003 / -004 / -005 tests
- [x] Implementation status section appended to canonical spec
- [x] First Runbook section authored on canonical spec under the
  new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)