### PR TITLE
feat(chat): ChatSession + history drivers + chat-http server (feat-020 v0.2)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,111 +1,78 @@
 ---
-feature: feat-020
-state: in_progress
+feature: none
+state: idle
 branch: feat/020-chat-agents-v02
-started_at: 2026-05-12
+started_at: null
 last_milestone_at: 2026-05-12
-last_shipped: feat-015 shipped via PR #25 (merged 2026-05-12)
+last_shipped: feat-020 v0.2 scope shipped via PR #26 (open for review)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-[`feat-020 — Chat agents`](../../docs/features/feat-020-chat-agents.md)
-
-**v0.2 scope only**: contracts in `agentforge-core`,
-`agentforge-chat` package (`ChatSession` + in-memory +
-sqlite + 4 truncation strategies), `agentforge-chat-http`
-package (FastAPI REST + WS + SSE + bearer auth).
-
-**Deferred to v0.3 follow-ups** (per
-`feedback_scope_preferences.md` "one half clearly riskier"
-exception): `agentforge-chat-history-postgres`,
-`agentforge-chat-history-redis`, `agentforge-chat-slack`,
-real per-token streaming, cross-process locking.
-
-6 chunks:
-
-1. Chat contracts + value models + conformance harness.
-2. `agentforge-chat` package: drivers + truncation strategies.
-3. `ChatSession` (send + stream + idempotency + budgets).
-4. `agentforge-chat-http`: FastAPI REST + WS + SSE + bearer auth.
-5. `modules.chat:` config schema + `build_chat_session_from_config`.
-6. Docs (spec §10/§11) + roadmap + CHANGELOG + state + PR.
+*None — awaiting next pick.*
 
 ## Last shipped
 
-[`feat-015 — Pipeline & deterministic tasks`](../../docs/features/feat-015-pipeline-and-tasks.md)
-opened as PR #25 (framework-only feature inside `agentforge`):
+[`feat-020 — Chat agents (v0.2 scope)`](../../docs/features/feat-020-chat-agents.md)
+opened as PR #26 across three packages:
 
-- `agentforge_core.contracts.task.Task` ABC +
-  `agentforge_core.values.pipeline.PipelineResult` frozen value.
-- `agentforge.pipeline.Pipeline` engine with DAG validation
-  (cycles / duplicates / missing deps at construction),
-  `asyncio.Semaphore`-bounded parallelism, per-task
-  `asyncio.wait_for(timeout_s)`, `on_task_error` continue/fail
-  modes, `PipelineFailure` exception.
-- `PipelineFindingsTool` built-in tool with category/severity
-  filters; `Agent(pipeline=...)` kwarg; `Agent.run(task, *,
-  context, replay_pipeline)` API; per-run system-prompt
-  addendum.
-- `modules.pipeline:` config block + `build_pipeline_from_config`
-  wired into `build_agent_from_config`.
-- `__pipeline` recording category + `load_pipeline_result`
-  replay so side-effect-bearing tasks don't double-run on
-  `agentforge run --replay`.
-- `FinishReason` literal extended with `"pipeline"`.
-- Public re-exports + renderer-compat sanity test.
+- **`agentforge-core` extensions**: `ChatHistoryStore` and
+  `HistoryTruncationStrategy` ABCs; `ChatTurn`, `SessionInfo`,
+  `ChatChunk`, `ChatResponse` frozen value models;
+  `run_chat_history_conformance` / `run_truncation_conformance`
+  harnesses; `modules.chat:` schema (`ChatConfig` /
+  `ChatHistoryDriverConfig` / `ChatTruncationConfig` /
+  `ChatSessionConfig`) + `_validate_driver` helper.
+- **`agentforge-chat` (new)**: `ChatSession` (send + stream +
+  history + reset + idempotency + per-turn/per-session budgets +
+  input/output guardrails); `InMemoryChatHistory` +
+  `SqliteChatHistory` drivers; four truncation strategies
+  (sliding-window / token-budget / summarise-oldest / hybrid);
+  per-session lock registry + LRU+TTL idempotency cache;
+  `build_chat_session_from_config(config, agent)`.
+- **`agentforge-chat-http` (new)**: FastAPI `ChatServer` with
+  REST + WebSocket + SSE + bearer-auth + token-bucket rate
+  limiting + cross-owner 403; `BearerAuthPolicy` ABC +
+  `EnvBearerAuth` placeholder pending feat-014.
 
-Deviations recorded in spec §10:
+Deviations recorded in spec §11:
 
-- `Agent.run` gained both `context=` and `replay_pipeline=`
-  kwargs (spec showed `context=` only).
-- `finish_reason = "pipeline"` is new; the CLI maps it to
-  generic exit 1 to keep the exit-code surface stable.
-- Mid-run pipeline streaming, end-to-end LLM-using task
-  example, and TS port are deferred.
+- Streaming is buffer-then-stream only (strategy ABC has no
+  `stream()` method yet; sentence-segmented chunks ship the
+  correct wire format today).
+- Cancellation is pre-LLM only (WS disconnect propagates).
+- Single-process locking only (cross-process Redis lock is
+  v0.3).
+- `BearerAuthPolicy` is a v0.2 stub; becomes a thin adapter
+  on top of feat-014's `AuthPolicy` when that lands.
+- Approximate token counting in `TokenBudget`.
+
+Deferred to v0.3 follow-up PRs:
+
+- `agentforge-chat-history-postgres` driver.
+- `agentforge-chat-history-redis` driver.
+- `agentforge-chat-slack` reference channel adapter.
+- Real per-token streaming through the strategy loop.
+- Cross-process per-session locking.
+- Provider-aware tokenisation.
+- TS port.
 
 ### Previously
 
-[`feat-013 — MCP integration`](../../docs/features/feat-013-mcp-integration.md)
-shipped in PR #24 as the new Tier-3 `agentforge-mcp` module:
-
-- `MCPClientRunner` / `MCPServerRunner` protocols +
-  `MCPToolDescriptor` value.
-- `MCPToolAdapter` (`build_adapter(runner, descriptor,
-  server_name)`) — synthesises a `Tool` subclass per MCP tool
-  with a server-prefixed name + Pydantic input schema.
-- `MCPServerClient.{from_stdio, from_http, from_sse}` —
-  consumes external MCP servers; `discover_tools` + `tool_filter`.
-- `MCPServer.{from_stdio, from_http}` — exposes local tools as
-  MCP with `allowed` whitelist semantics.
-- `MCPBridge.from_config(config)` — orchestrates clients +
-  optional server; `start` / `close` lifecycle.
-- `manifest.yaml` so `agentforge add module mcp` registers
-  the protocol entry.
-
-Deviations recorded in spec §10:
-
-- Production runner classes (`_SDKClientRunner`,
-  `_SDKServerRunner`) scaffolded but scoped to
-  `# pragma: no cover` — they raise
-  `Production MCP runner not implemented yet` until the
-  framework's first integration test against a real MCP server.
-- `Agent.tools` auto-merge via `build_agent_from_config` is
-  follow-up (today the bridge is opt-in; tests use it via the
-  bare constructor).
-- TS port deferred.
+[`feat-015 — Pipeline & deterministic tasks`](../../docs/features/feat-015-pipeline-and-tasks.md)
+shipped in PR #25 (merged 2026-05-12).
 
 ## Next pick candidates (canonical numbering)
 
-- **feat-015** — Pipelines & deterministic tasks. v0.2-target.
-  Runbook 03 cross-references it.
 - **feat-014** — A2A (agent-to-agent) protocol. v0.4-target.
-- **feat-020** — Chat agents (ChatSession + history stores +
-  HTTP/WebSocket/SSE server). v0.2-target. Largest remaining.
+- **feat-020 v0.3 follow-ups** — postgres / redis / slack
+  drivers, real streaming, cross-process lock, provider-aware
+  tokeniser.
 - Vendor observability sub-feats (langfuse/phoenix/evidently/
   statsd).
+- Backfill chore PRs (Runbooks for feat-001–005).
 
 User selects on session resume.
 

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,17 +1,37 @@
 ---
-feature: none
-state: idle
-branch: feat/015-pipeline-and-tasks
-started_at: null
+feature: feat-020
+state: in_progress
+branch: feat/020-chat-agents-v02
+started_at: 2026-05-12
 last_milestone_at: 2026-05-12
-last_shipped: feat-015 shipped via PR #25 (open for review)
+last_shipped: feat-015 shipped via PR #25 (merged 2026-05-12)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-*None — awaiting next pick.*
+[`feat-020 — Chat agents`](../../docs/features/feat-020-chat-agents.md)
+
+**v0.2 scope only**: contracts in `agentforge-core`,
+`agentforge-chat` package (`ChatSession` + in-memory +
+sqlite + 4 truncation strategies), `agentforge-chat-http`
+package (FastAPI REST + WS + SSE + bearer auth).
+
+**Deferred to v0.3 follow-ups** (per
+`feedback_scope_preferences.md` "one half clearly riskier"
+exception): `agentforge-chat-history-postgres`,
+`agentforge-chat-history-redis`, `agentforge-chat-slack`,
+real per-token streaming, cross-process locking.
+
+6 chunks:
+
+1. Chat contracts + value models + conformance harness.
+2. `agentforge-chat` package: drivers + truncation strategies.
+3. `ChatSession` (send + stream + idempotency + budgets).
+4. `agentforge-chat-http`: FastAPI REST + WS + SSE + bearer auth.
+5. `modules.chat:` config schema + `build_chat_session_from_config`.
+6. Docs (spec §10/§11) + roadmap + CHANGELOG + state + PR.
 
 ## Last shipped
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1211,3 +1211,68 @@ Tooling notes:
   keeping `Pipeline.run` under PLR0915.
 
 Ready to push and raise PR #25.
+
+
+## 2026-05-12T14:00 — feat-020 (Chat agents v0.2 scope) shipped
+
+Branch `feat/020-chat-agents-v02` opens PR #26. v0.2 scope only
+per the scope-preference exception (one half clearly riskier):
+v0.3 postgres / redis / slack drivers + real streaming +
+cross-process locking deferred to follow-up PRs.
+
+Chunks landed:
+
+- chunk 1 (`2bd8f38`): `agentforge_core.contracts.chat.{ChatHistoryStore,
+  HistoryTruncationStrategy}` ABCs +
+  `agentforge_core.values.chat.{ChatTurn, SessionInfo, ChatChunk,
+  ChatResponse}` + conformance harnesses.
+- chunk 2 (`d6d0a73`): new `agentforge-chat` workspace member with
+  `InMemoryChatHistory` + `SqliteChatHistory` drivers + four
+  truncation strategies + entry-points + manifest.yaml; root
+  pyproject + pre-commit + CI updated.
+- chunk 3 (`e4ff78d`): `ChatSession` (send + stream + history +
+  reset + close + idempotency + per-turn/per-session budgets +
+  guardrails wired); per-session asyncio.Lock registry via
+  WeakValueDictionary; LRU+TTL idempotency cache;
+  sentence-segmenting `stream()` using buffer-then-stream
+  semantics.
+- chunk 4 (`200b38e`): new `agentforge-chat-http` workspace
+  member with FastAPI REST + WS + SSE + `BearerAuthPolicy` +
+  `EnvBearerAuth` + in-process rate limiting + cross-owner 403.
+- chunk 5 (`1369c95`): `modules.chat:` config schema +
+  `_validate_driver` helper +
+  `build_chat_session_from_config` +
+  `register_chat_history` / `register_chat_truncation`
+  resolver helpers.
+- chunk 6 (about-to-commit): spec status → shipped + §11
+  Implementation Status + §12 Runbook + features README +
+  roadmap + CHANGELOG + state refreshed.
+
+Deviations captured in spec §11:
+
+- Streaming is buffer-then-stream only (strategy ABC has no
+  `stream()` method yet).
+- Cancellation is pre-LLM only.
+- Single-process locking; cross-process Redis lock deferred.
+- `BearerAuthPolicy` is a v0.2 placeholder; refactors to
+  feat-014's `AuthPolicy` when it lands.
+- Approximate token counting in `TokenBudget`.
+
+Tooling notes:
+
+- New filename collision avoided: chat-http's test file is
+  `test_chat_server.py` (the workspace already has
+  `test_server.py` in agentforge-mcp; pytest collection fails
+  on duplicate basenames).
+- B008 (`Depends` in defaults) noqa'd on every FastAPI route
+  function; standard FastAPI idiom.
+- B107 (hardcoded password default) noqa'd on
+  `EnvBearerAuth(token_env_var="API_TOKENS")` — the value
+  is the env-var NAME, not a token.
+- WebSocket consumer extracted to a method (`_consume_stream`)
+  so B023 (loop-variable capture in closure) is cleanly
+  avoided.
+- `uv sync` after adding each package pulls fastapi /
+  uvicorn / httpx into the shared venv.
+
+Ready to push and raise PR #26.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
       - name: Mypy strict
-        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
+        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
       - name: Bandit
         # -c pyproject.toml so [tool.bandit] (skips B101) is honoured;
         # without it, the conformance suite's asserts in
         # agentforge_core.testing.conformance trip B101.
-        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
+        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -61,7 +61,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
       - name: Pytest unit
-        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit tests/unit
+        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit tests/unit
       - name: Pytest integration
         run: uv run pytest -q -m "not live" packages/agentforge-bedrock/tests/integration tests/integration
       - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
       - name: Mypy strict
-        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src
+        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
       - name: Bandit
         # -c pyproject.toml so [tool.bandit] (skips B101) is honoured;
         # without it, the conformance suite's asserts in
         # agentforge_core.testing.conformance trip B101.
-        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src
+        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -61,7 +61,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
       - name: Pytest unit
-        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit tests/unit
+        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit tests/unit
       - name: Pytest integration
         run: uv run pytest -q -m "not live" packages/agentforge-bedrock/tests/integration tests/integration
       - name: Coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       # errors that file-scope mypy misses.
       - id: mypy-strict
         name: mypy --strict
-        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src
+        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
         language: system
         types: [python]
         pass_filenames: false
@@ -82,7 +82,7 @@ repos:
       - id: bandit
         name: bandit security lint
         # -c pyproject.toml so bandit reads [tool.bandit] (skips B101 etc.)
-        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src
+        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
         language: system
         types: [python]
         pass_filenames: false
@@ -92,7 +92,7 @@ repos:
       # are still empty. Real failures (1, 2, 3, 4) still block.
       - id: pytest-unit
         name: pytest unit
-        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
+        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
         language: system
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       # errors that file-scope mypy misses.
       - id: mypy-strict
         name: mypy --strict
-        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
+        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
         language: system
         types: [python]
         pass_filenames: false
@@ -82,7 +82,7 @@ repos:
       - id: bandit
         name: bandit security lint
         # -c pyproject.toml so bandit reads [tool.bandit] (skips B101 etc.)
-        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src
+        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
         language: system
         types: [python]
         pass_filenames: false
@@ -92,7 +92,7 @@ repos:
       # are still empty. Real failures (1, 2, 3, 4) still block.
       - id: pytest-unit
         name: pytest unit
-        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
+        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
         language: system
         always_run: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,75 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-020 — Chat agents (Python v0.2 scope).** Three new
+  workspace members + locked contracts in core. Wraps the
+  one-shot `Agent` into a multi-turn, stateful conversation
+  with multi-tenant isolation, per-turn / per-session budgets,
+  per-turn input/output guardrails, idempotency, and a FastAPI
+  HTTP + WS + SSE server.
+
+  *Contracts (`agentforge-core`):*
+  - `agentforge_core.contracts.chat.{ChatHistoryStore,
+    HistoryTruncationStrategy}` ABCs.
+  - `agentforge_core.values.chat.{ChatTurn, SessionInfo,
+    ChatChunk, ChatResponse}` frozen Pydantic value models.
+  - `run_chat_history_conformance(store)` +
+    `run_truncation_conformance(strategy)` harnesses.
+
+  *Chat runtime (`agentforge-chat`):*
+  - `ChatSession(agent, *, session_id, history_store,
+    system_prompt, truncation, owner, per_turn_budget_usd,
+    per_session_budget_usd, idempotency_window_s, on_turn)`.
+  - `send(message, *, idempotency_key, cancellation)` and
+    `stream(...)` (buffer-then-stream; sentence-segmented text
+    chunks + done/error sentinels).
+  - `history(...)`, `reset()`, `close()`.
+  - `InMemoryChatHistory` (asyncio-lock protected, in-memory
+    TTL sweep) + `SqliteChatHistory` (aiosqlite-backed, mirrors
+    `SqliteMemoryStore`).
+  - Four truncation strategies: `SlidingWindow`, `TokenBudget`,
+    `SummariseOldest`, `Hybrid`. Pair-atomicity invariant
+    enforced.
+  - Per-session `asyncio.Lock` registry +
+    `IdempotencyCache` LRU+TTL.
+  - Entry-points under `agentforge.chat.history` /
+    `agentforge.chat.truncation`; `manifest.yaml` for
+    `agentforge add module chat`.
+
+  *HTTP server (`agentforge-chat-http`):*
+  - `ChatServer(agent_factory, history_store, auth, host, port,
+    cors_origins, rate_limit_per_session_per_minute,
+    truncation)` — FastAPI app with REST + WebSocket + SSE.
+  - `BearerAuthPolicy` ABC + `EnvBearerAuth(token_env_var)`
+    placeholder (refactors to feat-014's `AuthPolicy` when
+    shipped).
+  - Multi-tenant: cross-owner access returns 403; missing /
+    invalid bearer returns 401; rate-limit overflow returns
+    429.
+  - WebSocket cancellation: disconnect aborts the in-flight
+    consume coroutine.
+
+  *Config + wiring:*
+  - `modules.chat:` config block (`ChatHistoryDriverConfig`,
+    `ChatTruncationConfig`, `ChatSessionConfig`, `ChatConfig`).
+  - `validate_module_configs` extension via new
+    `_validate_driver` helper.
+  - `agentforge_chat.build_chat_session_from_config(config,
+    agent)` resolves drivers via the global resolver.
+  - `agentforge.register_chat_history` /
+    `register_chat_truncation` resolver helpers.
+
+  *v0.3 follow-ups (deferred):*
+  - `agentforge-chat-history-postgres`,
+    `agentforge-chat-history-redis`,
+    `agentforge-chat-slack` reference adapter.
+  - Real per-token streaming through the strategy loop.
+  - Cross-process per-session locking (Redis-backed).
+  - Provider-aware tokenisation in `TokenBudget`.
+
+  Shipped via PR #26. See spec
+  `docs/features/feat-020-chat-agents.md` §11–§12.
+
 - **feat-015 — Pipeline & deterministic tasks (full spec).** New
   framework-level subsystem inside `agentforge` for deterministic,
   pre-LLM analysis steps. Findings flow back into the LLM loop two

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -67,7 +67,7 @@
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-020** | Chat agents — `ChatSession` wrapper, `ChatHistoryStore` (memory/sqlite/postgres/redis drivers), streaming, HTTP/WebSocket/SSE server, multi-tenant isolation, per-turn cost/guardrails, idempotency, cancellation | proposed | 0.2 (contracts + memory + sqlite + chat-http), 0.3 (postgres + redis + reference channel adapter) | both | `agentforge-chat`, `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-http`, optional `agentforge-chat-slack` |
+| **feat-020** | Chat agents — `ChatSession` wrapper, `ChatHistoryStore` (memory/sqlite/postgres/redis drivers), streaming, HTTP/WebSocket/SSE server, multi-tenant isolation, per-turn cost/guardrails, idempotency, cancellation | shipped (Python v0.2 scope) | 0.2 (contracts + memory + sqlite + chat-http — shipped), 0.3 (postgres + redis + reference channel adapter + real per-token streaming) | both | `agentforge-chat`, `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-http`, optional `agentforge-chat-slack` |
 
 ### Pipeline
 

--- a/docs/features/feat-020-chat-agents.md
+++ b/docs/features/feat-020-chat-agents.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-020 |
 | **Title** | Chat agents — stateful conversation wrapper over `Agent` + history store + HTTP/WebSocket server |
-| **Status** | proposed |
+| **Status** | shipped (Python v0.2 scope) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.2 (contracts + memory + sqlite drivers + chat-http server), 0.3 (postgres + redis drivers + Slack reference adapter) |
@@ -584,3 +584,174 @@ landings:
 - Prior art: Letta (server-resident chat agents); Pydantic AI
   conversation (similar wrapper pattern); Vercel AI SDK chunk shape;
   OpenAI Assistants threads; Slack Bolt SDK
+
+## 11. Implementation status (Python — v0.2 scope)
+
+Shipped in PR #26. Three workspace members went up together:
+`agentforge-core` extensions, the new `agentforge-chat`, and
+the new `agentforge-chat-http`.
+
+| Chunk | Commit | What landed |
+|---|---|---|
+| 1 | `2bd8f38` | `agentforge_core.contracts.chat.{ChatHistoryStore, HistoryTruncationStrategy}` ABCs + `agentforge_core.values.chat.{ChatTurn, SessionInfo, ChatChunk, ChatResponse}` frozen value models + `run_chat_history_conformance` / `run_truncation_conformance` harnesses. |
+| 2 | `d6d0a73` | `agentforge-chat` workspace member: `InMemoryChatHistory` + `SqliteChatHistory` (mirrors `SqliteMemoryStore`) + four truncation strategies (sliding-window, token-budget, summarise-oldest, hybrid). Entry-points under `agentforge.chat.history` / `agentforge.chat.truncation`. Pair-atomicity helper enforces tool-call/tool-result invariants. |
+| 3 | `e4ff78d` | `ChatSession` (send + stream + history + reset + close + idempotency + budgets) wired through the agent's input/output guardrails. Per-session lock registry (`WeakValueDictionary`); LRU+TTL idempotency cache; sentence-segmenting `stream()` using the spec's `buffer-then-stream` default. |
+| 4 | `200b38e` | `agentforge-chat-http` workspace member: FastAPI `ChatServer` with REST + WS + SSE + bearer-auth + in-process rate limiting + cross-owner 403 enforcement. `BearerAuthPolicy` ABC + `EnvBearerAuth` placeholder (refactors to feat-014's `AuthPolicy` when shipped). |
+| 5 | `1369c95` | `modules.chat:` config block (`ChatHistoryDriverConfig`, `ChatTruncationConfig`, `ChatSessionConfig`, `ChatConfig`) + module-schema validation hook + `build_chat_session_from_config(config, agent)` + `register_chat_history` / `register_chat_truncation` resolver helpers. |
+| 6 | (this PR) | Docs + Runbook + roadmap + CHANGELOG + state. |
+
+### Deviations from the design
+
+- **Streaming is buffer-then-stream only.** The strategy ABC
+  has no `stream()` method yet; v0.2 runs the agent to
+  completion and emits the assistant turn as sentence-segmented
+  `ChatChunk(kind="text")` chunks followed by a `done`
+  chunk. The wire format is correct; real per-token streaming
+  becomes a no-API-break enhancement when the strategy
+  contract grows streaming.
+- **Cancellation is pre-LLM only.** The cancellation event is
+  honoured between `history.load()` and `agent.run()`;
+  mid-LLM cancellation requires the same strategy-streaming
+  work. WS disconnect propagates a `set()` to the in-flight
+  consume coroutine.
+- **Single-process locking only.** Per-session
+  `asyncio.Lock` lives in a `WeakValueDictionary` keyed by
+  `session_id`. Cross-process locking (Redis) is deferred to
+  v0.3 alongside the Redis driver.
+- **`BearerAuthPolicy` is a v0.2-local stub.** feat-014's real
+  `AuthPolicy` contract hasn't shipped yet; the chat-http
+  policy becomes a thin adapter when it does.
+- **Approximate token counting in `TokenBudget`.** Uses a
+  4-chars-per-token heuristic. Provider-aware tokenisation is
+  a v0.3 follow-up.
+- **Postgres / Redis history drivers + Slack reference
+  adapter** — all deferred to separate v0.3 PRs once each
+  driver has a live-service test path.
+- **TypeScript port** deferred (contract is locked).
+
+### Open items
+
+- `agentforge-chat-history-postgres` driver (v0.3).
+- `agentforge-chat-history-redis` driver (v0.3).
+- `agentforge-chat-slack` reference channel adapter (v0.3).
+- Real per-token streaming through the strategy loop.
+- Cross-process per-session locking (Redis-backed).
+- Provider-aware tokenisation in `TokenBudget`.
+
+## 12. Runbook
+
+### How do I wire a chat session in code?
+
+```python
+import asyncio
+from agentforge import Agent
+from agentforge_chat import ChatSession, SqliteChatHistory, SlidingWindow
+
+async def main() -> None:
+    agent = Agent(model="anthropic:claude-sonnet-4-6", strategy="react")
+    history = await SqliteChatHistory.from_path("./chat.db")
+    session = ChatSession(
+        agent=agent,
+        session_id="user-42-thread-1",
+        history_store=history,
+        truncation=SlidingWindow(max_turns=50),
+        system_prompt="You are a careful research assistant.",
+        per_turn_budget_usd=0.50,
+        per_session_budget_usd=10.0,
+        owner="user-42",
+    )
+    print((await session.send("Hi")).content)
+    print((await session.send("What did I just say?")).content)
+    await session.close()
+
+asyncio.run(main())
+```
+
+### How do I serve over HTTP?
+
+```python
+from agentforge import Agent
+from agentforge_chat import SqliteChatHistory
+from agentforge_chat_http import ChatServer, EnvBearerAuth
+
+server = ChatServer(
+    agent_factory=lambda: Agent(model="...", strategy="react"),
+    history_store=await SqliteChatHistory.from_path("./chat.db"),
+    auth=EnvBearerAuth("API_TOKENS"),
+    host="0.0.0.0",
+    port=8080,
+    cors_origins=["https://chat.example.com"],
+)
+await server.serve()
+```
+
+Then call it: `POST /sessions` → `{id}`, `POST
+/sessions/{id}/messages` with `Authorization: Bearer <token>`.
+Set `Accept: text/event-stream` for SSE streaming, or open a
+WebSocket at `/sessions/{id}/ws`.
+
+### How do I wire a chat session from config?
+
+```yaml
+modules:
+  chat:
+    history:
+      driver: sqlite
+      config:
+        path: ./chat.db
+    truncation:
+      strategy: sliding_window
+      config:
+        max_turns: 50
+    session:
+      per_turn_budget_usd: 0.50
+      per_session_budget_usd: 10.0
+```
+
+```python
+from agentforge_core.config import load_config
+from agentforge_chat import build_chat_session_from_config
+from agentforge import Agent
+
+config = load_config()
+agent = Agent(config_path=None)
+session = await build_chat_session_from_config(
+    config, agent, session_id="user-42", owner="user-42"
+)
+```
+
+### How do I swap the history backend?
+
+Change `modules.chat.history.driver` from `sqlite` to one of
+the future v0.3 drivers (`postgres`, `redis`) and adjust the
+`config:` block to the driver's accepted schema. The
+`ChatHistoryStore` ABC is locked, so no application code
+changes are required.
+
+### How do I handle budget exhaustion?
+
+`ChatSession.send()` raises
+`agentforge_core.production.exceptions.BudgetExceeded` when
+either `per_turn_budget_usd` or `per_session_budget_usd` would
+be exceeded. The HTTP layer surfaces this as 200 + the error
+captured in the response body (current behaviour); future v0.3
+work will map to a clean 402-equivalent. In streaming mode,
+the final chunk is `ChatChunk(kind="error",
+content={"reason": "BudgetExceeded", ...})`.
+
+### How do I test against a fake history store?
+
+```python
+from agentforge_chat import ChatSession, InMemoryChatHistory
+from agentforge.testing import agent_factory, MockLLMClient
+
+session = ChatSession(
+    agent=agent_factory(model=MockLLMClient.deterministic("hi back")),
+    history_store=InMemoryChatHistory(),
+)
+assert (await session.send("hi")).content == "hi back"
+```
+
+`run_chat_history_conformance(store)` from
+`agentforge_core.testing` validates any custom store against
+the locked contract.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,7 @@ onward every feature uses the canonical feat-NNN number.
 | [feat-019](./features/feat-019-developer-experience-and-ai-rules.md) | Developer experience + AI rules — three-section managed/custom markdown format (`<!-- agentforge:end-managed -->`); `inject_shared_scaffold` post-render hook copies `_shared/` into every new scaffold; 16 runbooks + `AGENTS.md` + `CLAUDE.md` + `.cursorrules` ship Day-1; `agentforge docs` CLI (list / open by stem/number/alias / `--check` drift / `--serve` local HTTP). | [#23](https://github.com/Scaffoldic/agentforge-py/pull/23) |
 | [feat-013](./features/feat-013-mcp-integration.md) | MCP integration — `agentforge-mcp` module: `MCPServerClient` (stdio + HTTP/SSE) consumes upstream MCP tool servers via `MCPToolAdapter`s (server-name prefixed); `MCPServer` exposes local tools as MCP; `MCPBridge.from_config` orchestrates from `modules.protocols.mcp`. Production runners scaffolded behind `MCPClientRunner` / `MCPServerRunner` protocols pending live integration tests. | [#24](https://github.com/Scaffoldic/agentforge-py/pull/24) |
 | [feat-015](./features/feat-015-pipeline-and-tasks.md) | Pipeline & deterministic tasks — `Task` ABC + `PipelineResult` value in `agentforge-core`; `Pipeline` engine (DAG validation, `asyncio.Semaphore`-bounded parallelism, per-task timeouts, continue/fail error mode) + `PipelineFailure` + `PipelineFindingsTool` built-in; `Agent(pipeline=...)` kwarg + `Agent.run(task, *, context, replay_pipeline)` API; system-prompt addendum; `modules.pipeline:` config block + `build_pipeline_from_config`; `__pipeline` recording category + `load_pipeline_result` replay; `FinishReason` literal extended with `"pipeline"`. | [#25](https://github.com/Scaffoldic/agentforge-py/pull/25) |
+| [feat-020 (v0.2 scope)](./features/feat-020-chat-agents.md) | Chat agents v0.2 — `ChatHistoryStore` / `HistoryTruncationStrategy` ABCs + `ChatTurn` / `SessionInfo` / `ChatChunk` / `ChatResponse` value models in `agentforge-core`; `agentforge-chat` package with `ChatSession` (send + stream + idempotency + per-turn/per-session budgets + input/output guardrails + sentence-segmenting buffer-then-stream) and `InMemoryChatHistory` / `SqliteChatHistory` drivers + four truncation strategies (sliding-window, token-budget, summarise-oldest, hybrid); `agentforge-chat-http` package with FastAPI REST + WS + SSE + bearer auth + cross-owner 403 + token-bucket rate limiting; `modules.chat:` config block + `build_chat_session_from_config`. Postgres / Redis drivers, Slack adapter, and real per-token streaming deferred to v0.3 follow-up PRs. | [#26](https://github.com/Scaffoldic/agentforge-py/pull/26) |
 
 For details on what each shipped feature delivered vs. what was
 deferred, read the **Implementation status** section at the bottom
@@ -58,8 +59,14 @@ These are tracked here so they don't get lost. Full design specs
 already exist under [`docs/features/`](./features/); pick one to
 move into "In flight" when starting.
 
-- **feat-014, feat-020** — see specs under
+- **feat-014** — A2A protocol. See spec under
   [`docs/features/`](./features/).
+- **feat-020 v0.3 follow-ups** —
+  `agentforge-chat-history-postgres`,
+  `agentforge-chat-history-redis`, `agentforge-chat-slack`
+  reference adapter, real per-token streaming through the
+  strategy loop, cross-process per-session locking
+  (Redis-backed), provider-aware tokeniser in `TokenBudget`.
 
 ### feat-009 vendor-package sub-feats (deferred)
 

--- a/packages/agentforge-chat-http/LICENSE
+++ b/packages/agentforge-chat-http/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agentforge-chat-http/README.md
+++ b/packages/agentforge-chat-http/README.md
@@ -1,0 +1,35 @@
+# agentforge-chat-http
+
+FastAPI server for `agentforge-chat`: REST + WebSocket + SSE,
+bearer auth, in-process rate limiting, multi-tenant session
+isolation.
+
+See [`docs/features/feat-020-chat-agents.md`](https://github.com/Scaffoldic/agentforge-py/blob/main/docs/features/feat-020-chat-agents.md)
+§4.1 for the HTTP wire format.
+
+## Install
+
+```bash
+pip install agentforge-chat-http
+```
+
+## Run a chat server
+
+```python
+import asyncio
+from agentforge import Agent
+from agentforge_chat import InMemoryChatHistory
+from agentforge_chat_http import ChatServer, EnvBearerAuth
+
+async def main() -> None:
+    server = ChatServer(
+        agent_factory=lambda: Agent(model="anthropic:claude-sonnet-4-6", strategy="react"),
+        history_store=InMemoryChatHistory(),
+        auth=EnvBearerAuth("API_TOKENS"),
+        host="0.0.0.0",
+        port=8080,
+    )
+    await server.serve()
+
+asyncio.run(main())
+```

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -1,0 +1,56 @@
+# agentforge-chat-http — FastAPI server for agentforge-chat.
+
+[project]
+name = "agentforge-chat-http"
+version = "0.0.0"
+description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "The AgentForge Authors"},
+]
+keywords = ["ai", "agent", "chat", "fastapi", "websocket", "sse"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: FastAPI",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "agentforge-core",
+    "agentforge",
+    "agentforge-chat",
+    "fastapi>=0.115",
+    "uvicorn>=0.32",
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+
+[project.entry-points."agentforge.protocols"]
+chat_http = "agentforge_chat_http.server:ChatServer"
+
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentforge_chat_http"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/agentforge_chat_http",
+    "tests",
+    "README.md",
+    "LICENSE",
+]

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/__init__.py
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/__init__.py
@@ -1,0 +1,19 @@
+"""`agentforge-chat-http` — FastAPI server for AgentForge chat (feat-020)."""
+
+from __future__ import annotations
+
+from agentforge_chat_http.auth import BearerAuthPolicy, EnvBearerAuth, Principal
+from agentforge_chat_http.server import (
+    ChatServer,
+    CreateSessionRequest,
+    SendMessageRequest,
+)
+
+__all__ = [
+    "BearerAuthPolicy",
+    "ChatServer",
+    "CreateSessionRequest",
+    "EnvBearerAuth",
+    "Principal",
+    "SendMessageRequest",
+]

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/auth.py
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/auth.py
@@ -1,0 +1,63 @@
+"""Bearer auth for `agentforge-chat-http` (feat-020 v0.2 scope).
+
+`BearerAuthPolicy` is a minimal placeholder ABC; when feat-014's
+real `AuthPolicy` contract lands in `agentforge-core`, this becomes
+a thin adapter and is documented as such.
+
+`EnvBearerAuth(token_env_var="API_TOKENS")` reads a
+comma-separated list of valid bearer tokens from an environment
+variable; each token maps to an opaque principal id (the token
+itself by default).
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Identity returned by a successful `authenticate(...)` call."""
+
+    id: str
+    metadata: dict[str, str] | None = None
+
+
+class BearerAuthPolicy(ABC):
+    """Per-feat-020 v0.2 placeholder. Refactor to feat-014's
+    `AuthPolicy` when that ships."""
+
+    @abstractmethod
+    async def authenticate(self, bearer_token: str | None) -> Principal | None:
+        """Return a `Principal` if the token is valid, else None."""
+
+
+class EnvBearerAuth(BearerAuthPolicy):
+    """Bearer-token policy backed by a comma-separated env var.
+
+    Format of ``$<token_env_var>``: ``"token1,token2,token3"``.
+    Each token is its own principal id (no token → identity map).
+    """
+
+    def __init__(self, token_env_var: str = "API_TOKENS") -> None:  # noqa: S107  # nosec B107 — env-var NAME, not a token
+        self._var = token_env_var
+
+    async def authenticate(self, bearer_token: str | None) -> Principal | None:
+        if bearer_token is None or not bearer_token:
+            return None
+        raw = os.environ.get(self._var, "")
+        if not raw:
+            return None
+        valid = {t.strip() for t in raw.split(",") if t.strip()}
+        if bearer_token in valid:
+            return Principal(id=bearer_token)
+        return None
+
+
+__all__ = [
+    "BearerAuthPolicy",
+    "EnvBearerAuth",
+    "Principal",
+]

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/manifest.yaml
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/manifest.yaml
@@ -1,0 +1,23 @@
+# Module manifest for `agentforge add module chat-http` (feat-010).
+name: chat-http
+description: |
+  FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions
+  (feat-020 v0.2). Wraps `agentforge_chat.ChatSession`.
+
+distribution:
+  pip_name: agentforge-chat-http
+
+config_block:
+  modules.chat_http:
+    host: "0.0.0.0"
+    port: 8080
+    cors_origins: []
+    auth:
+      type: bearer
+      tokens_env: API_TOKENS
+    rate_limit:
+      per_session_per_minute: 60
+
+entry_points:
+  agentforge.protocols:
+    chat_http: agentforge_chat_http.server:ChatServer

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/server.py
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/server.py
@@ -1,0 +1,325 @@
+"""`ChatServer` — FastAPI app exposing `ChatSession` over HTTP.
+
+REST API (per feat-020 §4.1):
+
+    POST   /sessions                    -> 200 + {id}
+    GET    /sessions                    -> 200 + [SessionInfo]
+    DELETE /sessions/{id}               -> 204
+    POST   /sessions/{id}/messages      -> 200 + ChatResponse (JSON)
+                                           or SSE when Accept matches
+    GET    /sessions/{id}/messages      -> 200 + [ChatTurn]
+    WS     /sessions/{id}/ws            -> bidirectional streaming
+    GET    /healthz                     -> 200
+
+v0.2 ships an in-process bearer-auth policy + token-bucket
+rate limiting. Postgres / Redis history drivers are deferred to
+v0.3 follow-up PRs; today the server runs against any
+`ChatHistoryStore` instance (in-memory or sqlite).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import uvicorn
+from agentforge.agent import Agent
+from agentforge_chat import ChatSession
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
+from agentforge_core.values.chat import ChatChunk, ChatResponse, ChatTurn
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict
+
+from agentforge_chat_http.auth import BearerAuthPolicy, Principal
+
+
+class SendMessageRequest(BaseModel):
+    """Body of POST /sessions/{id}/messages."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    content: str
+    idempotency_key: str | None = None
+
+
+class CreateSessionRequest(BaseModel):
+    """Body of POST /sessions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str | None = None
+    system_prompt: str | None = None
+
+
+class _RateLimiter:
+    """Naive in-process token bucket per (owner, session)."""
+
+    def __init__(self, *, per_minute: int) -> None:
+        self._per_minute = max(1, per_minute)
+        self._counts: dict[tuple[str, str], list[float]] = {}
+
+    def check(self, owner: str, session_id: str) -> bool:
+        key = (owner, session_id)
+        now = time.monotonic()
+        window = self._counts.setdefault(key, [])
+        # purge entries older than 60s
+        cutoff = now - 60.0
+        while window and window[0] < cutoff:
+            window.pop(0)
+        if len(window) >= self._per_minute:
+            return False
+        window.append(now)
+        return True
+
+
+class ChatServer:
+    """FastAPI app wrapper holding session state."""
+
+    def __init__(
+        self,
+        *,
+        agent_factory: Callable[[], Agent],
+        history_store: ChatHistoryStore,
+        auth: BearerAuthPolicy,
+        host: str = "0.0.0.0",  # noqa: S104  # nosec B104 — server defaults to all interfaces; caller binds explicitly in prod
+        port: int = 8080,
+        cors_origins: list[str] | None = None,
+        rate_limit_per_session_per_minute: int = 60,
+        truncation: HistoryTruncationStrategy | None = None,
+    ) -> None:
+        self._agent_factory = agent_factory
+        self._history = history_store
+        self._auth = auth
+        self._host = host
+        self._port = port
+        self._cors_origins = list(cors_origins or [])
+        self._truncation = truncation
+        self._sessions: dict[str, ChatSession] = {}
+        self._session_owners: dict[str, str] = {}
+        self._sessions_lock = asyncio.Lock()
+        self._rate_limit = _RateLimiter(per_minute=rate_limit_per_session_per_minute)
+        self.app = self._build_app()
+
+    @property
+    def http_app(self) -> FastAPI:
+        return self.app
+
+    def _build_app(self) -> FastAPI:
+        app = FastAPI(title="agentforge-chat-http")
+        if self._cors_origins:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=self._cors_origins,
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+        bearer = HTTPBearer(auto_error=False)
+
+        async def require_principal(
+            credentials: HTTPAuthorizationCredentials | None = Depends(bearer),  # noqa: B008 — FastAPI Depends idiom
+        ) -> Principal:
+            token = credentials.credentials if credentials is not None else None
+            principal = await self._auth.authenticate(token)
+            if principal is None:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+            return principal
+
+        @app.get("/healthz")
+        async def healthz() -> dict[str, str]:
+            return {"status": "ok"}
+
+        @app.post("/sessions")
+        async def create_session(
+            body: CreateSessionRequest,
+            principal: Principal = Depends(require_principal),  # noqa: B008
+        ) -> dict[str, str]:
+            session = await self._create_session(body, principal)
+            return {"id": session.session_id}
+
+        @app.get("/sessions")
+        async def list_sessions(
+            principal: Principal = Depends(require_principal),  # noqa: B008
+        ) -> list[dict[str, Any]]:
+            infos = await self._history.list_sessions(owner=principal.id)
+            return [json.loads(i.model_dump_json()) for i in infos]
+
+        @app.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+        async def delete_session(
+            session_id: str,
+            principal: Principal = Depends(require_principal),  # noqa: B008
+        ) -> None:
+            self._assert_owner(session_id, principal)
+            async with self._sessions_lock:
+                session = self._sessions.pop(session_id, None)
+                self._session_owners.pop(session_id, None)
+            if session is not None:
+                await session.close()
+            await self._history.delete_session(session_id)
+
+        @app.post("/sessions/{session_id}/messages")
+        async def post_message(
+            session_id: str,
+            body: SendMessageRequest,
+            request: Request,
+            principal: Principal = Depends(require_principal),  # noqa: B008
+        ) -> Any:
+            self._assert_owner(session_id, principal)
+            if not self._rate_limit.check(principal.id, session_id):
+                raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
+            session = await self._get_session(session_id, principal)
+            accept = request.headers.get("accept", "")
+            if "text/event-stream" in accept:
+                return StreamingResponse(
+                    self._sse_stream(session, body),
+                    media_type="text/event-stream",
+                )
+            response = await session.send(body.content, idempotency_key=body.idempotency_key)
+            return json.loads(response.model_dump_json())
+
+        @app.get("/sessions/{session_id}/messages")
+        async def get_history(
+            session_id: str,
+            principal: Principal = Depends(require_principal),  # noqa: B008
+            limit: int | None = None,
+        ) -> list[dict[str, Any]]:
+            self._assert_owner(session_id, principal)
+            turns = await self._history.load(session_id, limit=limit)
+            return [json.loads(t.model_dump_json()) for t in turns]
+
+        @app.websocket("/sessions/{session_id}/ws")
+        async def ws_endpoint(ws: WebSocket, session_id: str) -> None:
+            await self._ws_endpoint(ws, session_id)
+
+        return app
+
+    async def _ws_endpoint(self, ws: WebSocket, session_id: str) -> None:
+        await ws.accept()
+        token = ws.headers.get("authorization", "").removeprefix("Bearer ").strip()
+        principal = await self._auth.authenticate(token or None)
+        if principal is None:
+            await ws.close(code=4401)
+            return
+        try:
+            self._assert_owner(session_id, principal)
+        except HTTPException:
+            await ws.close(code=4403)
+            return
+        session = await self._get_session(session_id, principal)
+        try:
+            while True:
+                raw = await ws.receive_text()
+                payload = json.loads(raw)
+                message = str(payload["content"])
+                cancellation = asyncio.Event()
+                consumer = asyncio.create_task(
+                    self._consume_stream(ws, session, message, cancellation)
+                )
+                receiver = asyncio.create_task(ws.receive_text())
+                _, pending = await asyncio.wait(
+                    {consumer, receiver},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not consumer.done():
+                    cancellation.set()
+                for task in pending:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+        except WebSocketDisconnect:
+            return
+
+    async def _consume_stream(
+        self,
+        ws: WebSocket,
+        session: ChatSession,
+        message: str,
+        cancellation: asyncio.Event,
+    ) -> None:
+        async for chunk in await session.stream(message, cancellation=cancellation):
+            await ws.send_text(chunk.model_dump_json())
+
+    async def _sse_stream(
+        self,
+        session: ChatSession,
+        body: SendMessageRequest,
+    ) -> Any:
+        async for chunk in await session.stream(body.content, idempotency_key=body.idempotency_key):
+            yield self._sse_format(chunk)
+
+    def _sse_format(self, chunk: ChatChunk) -> bytes:
+        return f"data: {chunk.model_dump_json()}\n\n".encode()
+
+    async def _create_session(
+        self, body: CreateSessionRequest, principal: Principal
+    ) -> ChatSession:
+        agent = self._agent_factory()
+        session = ChatSession(
+            agent=agent,
+            session_id=body.session_id or uuid.uuid4().hex,
+            history_store=self._history,
+            system_prompt=body.system_prompt,
+            owner=principal.id,
+            truncation=self._truncation,
+        )
+        async with self._sessions_lock:
+            self._sessions[session.session_id] = session
+            self._session_owners[session.session_id] = principal.id
+        # Persist an initial owner record on the store so list_sessions
+        # filtering works before the first turn.
+        await self._history.update_session_metadata(session.session_id, {"owner": principal.id})
+        return session
+
+    async def _get_session(self, session_id: str, principal: Principal) -> ChatSession:
+        async with self._sessions_lock:
+            cached = self._sessions.get(session_id)
+        if cached is not None:
+            return cached
+        # Cold path: rehydrate a session object from existing history.
+        agent = self._agent_factory()
+        session = ChatSession(
+            agent=agent,
+            session_id=session_id,
+            history_store=self._history,
+            owner=principal.id,
+            truncation=self._truncation,
+        )
+        async with self._sessions_lock:
+            self._sessions[session_id] = session
+            self._session_owners[session_id] = principal.id
+        return session
+
+    def _assert_owner(self, session_id: str, principal: Principal) -> None:
+        recorded = self._session_owners.get(session_id)
+        if recorded is not None and recorded != principal.id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+    async def serve(self) -> None:
+        config = uvicorn.Config(self.app, host=self._host, port=self._port, log_level="info")
+        server = uvicorn.Server(config)
+        await server.serve()
+
+
+__all__ = [
+    "ChatResponse",
+    "ChatServer",
+    "ChatTurn",
+    "CreateSessionRequest",
+    "SendMessageRequest",
+]

--- a/packages/agentforge-chat-http/tests/unit/test_chat_server.py
+++ b/packages/agentforge-chat-http/tests/unit/test_chat_server.py
@@ -1,0 +1,223 @@
+"""Unit tests for `ChatServer` (feat-020 chunk 4)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_chat import InMemoryChatHistory
+from agentforge_chat_http import ChatServer, EnvBearerAuth
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+from fastapi.testclient import TestClient
+
+
+class _EchoStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content=f"echo:{state.task[-100:]}"))
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent_factory() -> Agent:
+    return Agent(model=_FakeLLM(), strategy=_EchoStrategy())
+
+
+@pytest.fixture
+def server(monkeypatch: pytest.MonkeyPatch) -> ChatServer:
+    monkeypatch.setenv("API_TOKENS", "good-token,other-token")
+    return ChatServer(
+        agent_factory=_agent_factory,
+        history_store=InMemoryChatHistory(),
+        auth=EnvBearerAuth("API_TOKENS"),
+        host="127.0.0.1",
+        port=8080,
+    )
+
+
+@pytest.fixture
+def client(server: ChatServer) -> TestClient:
+    return TestClient(server.app)
+
+
+def _auth(token: str = "good-token") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_healthz_is_unauthenticated(client: TestClient) -> None:
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_create_session_returns_id(client: TestClient) -> None:
+    r = client.post("/sessions", json={}, headers=_auth())
+    assert r.status_code == 200
+    assert "id" in r.json()
+
+
+def test_missing_bearer_returns_401(client: TestClient) -> None:
+    r = client.post("/sessions", json={})
+    assert r.status_code == 401
+
+
+def test_invalid_bearer_returns_401(client: TestClient) -> None:
+    r = client.post("/sessions", json={}, headers=_auth("nope"))
+    assert r.status_code == 401
+
+
+def test_post_message_returns_response(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth()).json()["id"]
+    r = client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "hi"},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "content" in body
+    assert "echo:" in body["content"]
+
+
+def test_cross_owner_access_returns_403(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth("good-token")).json()["id"]
+    r = client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "hi"},
+        headers=_auth("other-token"),
+    )
+    assert r.status_code == 403
+
+
+def test_get_history_returns_turns(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth()).json()["id"]
+    client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "hi"},
+        headers=_auth(),
+    )
+    r = client.get(f"/sessions/{sid}/messages", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert any(t["role"] == "user" for t in body)
+    assert any(t["role"] == "assistant" for t in body)
+
+
+def test_delete_session_cascades(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth()).json()["id"]
+    client.post(
+        f"/sessions/{sid}/messages",
+        json={"content": "hi"},
+        headers=_auth(),
+    )
+    r = client.delete(f"/sessions/{sid}", headers=_auth())
+    assert r.status_code == 204
+    after = client.get(f"/sessions/{sid}/messages", headers=_auth())
+    assert after.status_code == 200
+    assert after.json() == []
+
+
+def test_list_sessions_filters_by_owner(client: TestClient) -> None:
+    client.post("/sessions", json={}, headers=_auth("good-token"))
+    client.post("/sessions", json={}, headers=_auth("other-token"))
+    mine = client.get("/sessions", headers=_auth("good-token")).json()
+    assert all(s["owner"] == "good-token" for s in mine)
+
+
+def test_sse_streaming_returns_chunks(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth()).json()["id"]
+    headers = {**_auth(), "Accept": "text/event-stream"}
+    with client.stream(
+        "POST",
+        f"/sessions/{sid}/messages",
+        json={"content": "hi there. how are you?"},
+        headers=headers,
+    ) as r:
+        assert r.status_code == 200
+        payload = "".join(r.iter_text())
+    # SSE frames start with `data: `; at least one text + one done chunk.
+    assert '"kind":"text"' in payload
+    assert '"kind":"done"' in payload
+
+
+def test_rate_limit_returns_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_TOKENS", "k")
+    server = ChatServer(
+        agent_factory=_agent_factory,
+        history_store=InMemoryChatHistory(),
+        auth=EnvBearerAuth("API_TOKENS"),
+        rate_limit_per_session_per_minute=1,
+    )
+    client = TestClient(server.app)
+    sid = client.post("/sessions", json={}, headers={"Authorization": "Bearer k"}).json()["id"]
+    headers = {"Authorization": "Bearer k"}
+    r1 = client.post(f"/sessions/{sid}/messages", json={"content": "a"}, headers=headers)
+    assert r1.status_code == 200
+    r2 = client.post(f"/sessions/{sid}/messages", json={"content": "b"}, headers=headers)
+    assert r2.status_code == 429
+
+
+def test_websocket_round_trip(client: TestClient) -> None:
+    sid = client.post("/sessions", json={}, headers=_auth()).json()["id"]
+    with client.websocket_connect(
+        f"/sessions/{sid}/ws",
+        headers=_auth(),
+    ) as ws:
+        ws.send_text('{"content": "hi"}')
+        seen_done = False
+        for _ in range(10):
+            data = ws.receive_text()
+            if '"kind":"done"' in data:
+                seen_done = True
+                break
+        assert seen_done
+
+
+@pytest.mark.parametrize("missing_var", ["MISSING_TOKENS_VAR_FOR_TEST"])
+def test_empty_env_var_rejects_all_tokens(
+    missing_var: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(missing_var, raising=False)
+    assert os.environ.get(missing_var) is None
+    auth = EnvBearerAuth(missing_var)
+    server = ChatServer(
+        agent_factory=_agent_factory,
+        history_store=InMemoryChatHistory(),
+        auth=auth,
+    )
+    client = TestClient(server.app)
+    r = client.post("/sessions", json={}, headers={"Authorization": "Bearer anything"})
+    assert r.status_code == 401

--- a/packages/agentforge-chat/LICENSE
+++ b/packages/agentforge-chat/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agentforge-chat/README.md
+++ b/packages/agentforge-chat/README.md
@@ -1,0 +1,32 @@
+# agentforge-chat
+
+Chat-agent runtime for AgentForge: `ChatSession`,
+`InMemoryChatHistory` / `SqliteChatHistory` drivers, and four
+truncation strategies (sliding-window, token-budget,
+summarise-oldest, hybrid).
+
+See [`docs/features/feat-020-chat-agents.md`](https://github.com/Scaffoldic/agentforge-py/blob/main/docs/features/feat-020-chat-agents.md)
+for the design and runbook.
+
+## Install
+
+```bash
+pip install agentforge-chat
+# or, with the SQLite driver pre-pulled:
+pip install "agentforge-chat[sqlite]"
+```
+
+## Three-line chat from a one-shot agent
+
+```python
+from agentforge import Agent
+from agentforge_chat import ChatSession, SqliteChatHistory
+
+agent = Agent(model="anthropic:claude-sonnet-4-6", strategy="react")
+session = ChatSession(
+    agent=agent,
+    history_store=await SqliteChatHistory.from_path("./chat.db"),
+)
+print((await session.send("Hi")).content)
+print((await session.send("What did I just say?")).content)
+```

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -1,0 +1,70 @@
+# agentforge-chat — Chat-agent runtime for AgentForge.
+#
+# `ChatSession` wraps a one-shot `Agent` into a multi-turn,
+# stateful conversation; ships in-memory + sqlite history
+# drivers + four truncation strategies.
+#
+# Per ADR-0003 (three-tier package model — this is Tier 2, a
+# framework runtime extension).
+
+[project]
+name = "agentforge-chat"
+version = "0.0.0"
+description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "The AgentForge Authors"},
+]
+keywords = ["ai", "agent", "chat", "conversation", "chatbot"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "agentforge-core",
+    "agentforge",
+]
+
+[project.optional-dependencies]
+sqlite = ["aiosqlite>=0.20"]
+
+[project.urls]
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Documentation = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Scaffoldic/agentforge-py/issues"
+
+[project.entry-points."agentforge.chat.history"]
+memory = "agentforge_chat.history:InMemoryChatHistory"
+sqlite = "agentforge_chat.sqlite:SqliteChatHistory"
+
+[project.entry-points."agentforge.chat.truncation"]
+sliding_window = "agentforge_chat.truncation:SlidingWindow"
+token_budget = "agentforge_chat.truncation:TokenBudget"
+summarise_oldest = "agentforge_chat.truncation:SummariseOldest"
+hybrid = "agentforge_chat.truncation:Hybrid"
+
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentforge_chat"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/agentforge_chat",
+    "tests",
+    "README.md",
+    "LICENSE",
+]

--- a/packages/agentforge-chat/src/agentforge_chat/__init__.py
+++ b/packages/agentforge-chat/src/agentforge_chat/__init__.py
@@ -1,0 +1,27 @@
+"""`agentforge-chat` — Chat-agent runtime for AgentForge (feat-020).
+
+Public surface: `ChatSession` (chunk 3) + history drivers
+(`InMemoryChatHistory`, `SqliteChatHistory`) + four truncation
+strategies (`SlidingWindow`, `TokenBudget`, `SummariseOldest`,
+`Hybrid`).
+"""
+
+from __future__ import annotations
+
+from agentforge_chat.history import InMemoryChatHistory
+from agentforge_chat.sqlite import SqliteChatHistory
+from agentforge_chat.truncation import (
+    Hybrid,
+    SlidingWindow,
+    SummariseOldest,
+    TokenBudget,
+)
+
+__all__ = [
+    "Hybrid",
+    "InMemoryChatHistory",
+    "SlidingWindow",
+    "SqliteChatHistory",
+    "SummariseOldest",
+    "TokenBudget",
+]

--- a/packages/agentforge-chat/src/agentforge_chat/__init__.py
+++ b/packages/agentforge-chat/src/agentforge_chat/__init__.py
@@ -8,6 +8,7 @@ strategies (`SlidingWindow`, `TokenBudget`, `SummariseOldest`,
 
 from __future__ import annotations
 
+from agentforge_chat.build import build_chat_session_from_config
 from agentforge_chat.history import InMemoryChatHistory
 from agentforge_chat.session import ChatSession
 from agentforge_chat.sqlite import SqliteChatHistory
@@ -26,4 +27,5 @@ __all__ = [
     "SqliteChatHistory",
     "SummariseOldest",
     "TokenBudget",
+    "build_chat_session_from_config",
 ]

--- a/packages/agentforge-chat/src/agentforge_chat/__init__.py
+++ b/packages/agentforge-chat/src/agentforge_chat/__init__.py
@@ -9,6 +9,7 @@ strategies (`SlidingWindow`, `TokenBudget`, `SummariseOldest`,
 from __future__ import annotations
 
 from agentforge_chat.history import InMemoryChatHistory
+from agentforge_chat.session import ChatSession
 from agentforge_chat.sqlite import SqliteChatHistory
 from agentforge_chat.truncation import (
     Hybrid,
@@ -18,6 +19,7 @@ from agentforge_chat.truncation import (
 )
 
 __all__ = [
+    "ChatSession",
     "Hybrid",
     "InMemoryChatHistory",
     "SlidingWindow",

--- a/packages/agentforge-chat/src/agentforge_chat/_idempotency.py
+++ b/packages/agentforge-chat/src/agentforge_chat/_idempotency.py
@@ -1,0 +1,38 @@
+"""Tiny LRU+TTL cache for per-session idempotency keys (feat-020).
+
+Keyed by ``(session_id, key)``; values are the previous
+`ChatResponse`. Entries past TTL are evicted on lookup; entries
+past `max_entries` are evicted oldest-first.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+
+
+class IdempotencyCache[V]:
+    def __init__(self, *, ttl_s: float, max_entries: int = 256) -> None:
+        self._ttl = ttl_s
+        self._max = max_entries
+        self._store: OrderedDict[tuple[str, str], tuple[float, V]] = OrderedDict()
+
+    def get(self, session_id: str, key: str) -> V | None:
+        k = (session_id, key)
+        entry = self._store.get(k)
+        if entry is None:
+            return None
+        ts, value = entry
+        if (time.monotonic() - ts) > self._ttl:
+            self._store.pop(k, None)
+            return None
+        # Mark as recently used.
+        self._store.move_to_end(k)
+        return value
+
+    def put(self, session_id: str, key: str, value: V) -> None:
+        k = (session_id, key)
+        self._store[k] = (time.monotonic(), value)
+        self._store.move_to_end(k)
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)

--- a/packages/agentforge-chat/src/agentforge_chat/_locks.py
+++ b/packages/agentforge-chat/src/agentforge_chat/_locks.py
@@ -1,0 +1,35 @@
+"""Per-session lock registry (feat-020).
+
+`ChatSession.send`/`stream` acquires a session-scoped
+`asyncio.Lock` so concurrent calls against the same `session_id`
+queue. Locks live in a `WeakValueDictionary`; once no session
+references a key the lock GCs automatically.
+
+v0.2 is single-process. Cross-process locking (Redis-backed) is
+v0.3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+
+class _LockRegistry:
+    def __init__(self) -> None:
+        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+
+    def get(self, session_id: str) -> asyncio.Lock:
+        lock = self._locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[session_id] = lock
+        return lock
+
+
+_REGISTRY = _LockRegistry()
+
+
+def lock_for(session_id: str) -> asyncio.Lock:
+    """Return the (shared, weak-referenced) lock for ``session_id``."""
+    return _REGISTRY.get(session_id)

--- a/packages/agentforge-chat/src/agentforge_chat/_segment.py
+++ b/packages/agentforge-chat/src/agentforge_chat/_segment.py
@@ -1,0 +1,45 @@
+"""Sentence segmenter for the buffer-then-stream path (feat-020).
+
+v0.2 ships `ChatSession.stream()` in the spec's
+`safety_mode: "buffer-then-stream"` semantics: the agent runs to
+completion, then the assistant turn is sliced into sentence-ish
+chunks for the wire format. Real per-token streaming follows in a
+later release without changing this surface.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+_MAX_CHUNK_CHARS = 200
+"""Soft cap so a single uninterrupted paragraph still emits as
+multiple chunks."""
+
+
+def segment_for_stream(text: str) -> list[str]:
+    """Split ``text`` into wire-format-friendly chunks.
+
+    Prefers sentence boundaries (``.!?`` followed by whitespace);
+    falls back to paragraph boundaries; falls back to a hard
+    `_MAX_CHUNK_CHARS` cap.
+    """
+    if not text:
+        return []
+    parts = [p for p in _SENTENCE_BOUNDARY.split(text) if p]
+    out: list[str] = []
+    for part in parts:
+        out.extend(_split_long(part))
+    return out
+
+
+def _split_long(text: str) -> list[str]:
+    if len(text) <= _MAX_CHUNK_CHARS:
+        return [text]
+    pieces: list[str] = []
+    cursor = 0
+    while cursor < len(text):
+        end = min(cursor + _MAX_CHUNK_CHARS, len(text))
+        pieces.append(text[cursor:end])
+        cursor = end
+    return pieces

--- a/packages/agentforge-chat/src/agentforge_chat/build.py
+++ b/packages/agentforge-chat/src/agentforge_chat/build.py
@@ -1,0 +1,109 @@
+"""Config-driven `ChatSession` construction (feat-020).
+
+`build_chat_session_from_config(config, agent)` reads
+`modules.chat:` and assembles:
+
+  - the history-store driver (resolver category `chat.history`),
+  - the truncation strategy (resolver category `chat.truncation`),
+  - per-turn / per-session budget + idempotency knobs.
+
+Drivers that expose `from_config(cfg)` are preferred; otherwise
+the class is constructed with `**cfg`. Async-factory drivers
+(e.g. `SqliteChatHistory.from_path`) are recognised by the
+`from_path` classmethod returning an awaitable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentforge.agent import Agent
+from agentforge_core.config.schema import AgentForgeConfig
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.resolver import Resolver
+
+from agentforge_chat.history import InMemoryChatHistory
+from agentforge_chat.session import ChatSession
+from agentforge_chat.truncation import SlidingWindow
+
+
+async def build_chat_session_from_config(
+    config: AgentForgeConfig,
+    agent: Agent,
+    *,
+    session_id: str | None = None,
+    owner: str | None = None,
+    system_prompt: str | None = None,
+) -> ChatSession:
+    """Instantiate a `ChatSession` driven by `modules.chat:`.
+
+    Caller still owns the `Agent`; the chat session merely wraps it.
+    `session_id` defaults to a fresh ULID-ish hex when omitted.
+    """
+    chat_cfg = config.modules.chat
+    history: ChatHistoryStore = InMemoryChatHistory()
+    truncation: HistoryTruncationStrategy = SlidingWindow(50)
+    per_turn = None
+    per_session = None
+    idem_window = 60.0
+    if chat_cfg is not None:
+        if chat_cfg.history is not None:
+            history = await _build_history(chat_cfg.history.driver, chat_cfg.history.config)
+        if chat_cfg.truncation is not None:
+            truncation = _build_truncation(chat_cfg.truncation.strategy, chat_cfg.truncation.config)
+        per_turn = chat_cfg.session.per_turn_budget_usd
+        per_session = chat_cfg.session.per_session_budget_usd
+        idem_window = chat_cfg.session.idempotency_window_s
+    return ChatSession(
+        agent=agent,
+        session_id=session_id,
+        history_store=history,
+        system_prompt=system_prompt,
+        truncation=truncation,
+        owner=owner,
+        per_turn_budget_usd=per_turn,
+        per_session_budget_usd=per_session,
+        idempotency_window_s=idem_window,
+    )
+
+
+async def _build_history(driver: str, cfg: dict[str, Any]) -> ChatHistoryStore:
+    cls = Resolver.global_().resolve("chat.history", driver)
+    instance = await _maybe_async(_instantiate(cls, cfg))
+    if not isinstance(instance, ChatHistoryStore):
+        raise ModuleError(
+            f"Resolved chat.history driver {driver!r} ({cls.__name__}) does not "
+            f"implement ChatHistoryStore."
+        )
+    return instance
+
+
+def _build_truncation(name: str, cfg: dict[str, Any]) -> HistoryTruncationStrategy:
+    cls = Resolver.global_().resolve("chat.truncation", name)
+    instance = _instantiate(cls, cfg)
+    if not isinstance(instance, HistoryTruncationStrategy):
+        raise ModuleError(
+            f"Resolved chat.truncation {name!r} ({cls.__name__}) does not "
+            f"implement HistoryTruncationStrategy."
+        )
+    return instance
+
+
+def _instantiate(cls: type, cfg: dict[str, Any]) -> Any:
+    from_config = getattr(cls, "from_config", None)
+    if callable(from_config):
+        return from_config(cfg)
+    from_path = getattr(cls, "from_path", None)
+    if callable(from_path) and "path" in cfg:
+        return from_path(cfg["path"])
+    return cls(**cfg)
+
+
+async def _maybe_async(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+__all__ = ["build_chat_session_from_config"]

--- a/packages/agentforge-chat/src/agentforge_chat/history.py
+++ b/packages/agentforge-chat/src/agentforge_chat/history.py
@@ -1,0 +1,126 @@
+"""`InMemoryChatHistory` — process-local default `ChatHistoryStore`.
+
+Backs `ChatSession` when no driver is configured. Useful for tests
+and tiny demos; not persistent across process restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from agentforge_core.contracts.chat import ChatHistoryStore
+from agentforge_core.values.chat import ChatTurn, SessionInfo
+
+
+class InMemoryChatHistory(ChatHistoryStore):
+    """Thread-safe in-memory implementation of `ChatHistoryStore`."""
+
+    def __init__(self) -> None:
+        self._turns: dict[str, list[ChatTurn]] = {}
+        self._meta: dict[str, dict[str, Any]] = {}
+        self._owners: dict[str, str | None] = {}
+        self._created_at: dict[str, datetime] = {}
+        self._last_active: dict[str, datetime] = {}
+        self._lock = asyncio.Lock()
+
+    async def append(self, turn: ChatTurn) -> None:
+        async with self._lock:
+            self._turns.setdefault(turn.session_id, []).append(turn)
+            now = datetime.now(UTC)
+            self._created_at.setdefault(turn.session_id, now)
+            self._last_active[turn.session_id] = now
+
+    async def load(
+        self,
+        session_id: str,
+        *,
+        limit: int | None = None,
+        before: datetime | None = None,
+        after: datetime | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        async with self._lock:
+            turns = list(self._turns.get(session_id, []))
+        if before is not None:
+            turns = [t for t in turns if t.timestamp < before]
+        if after is not None:
+            turns = [t for t in turns if t.timestamp > after]
+        if roles is not None:
+            allowed = set(roles)
+            turns = [t for t in turns if t.role in allowed]
+        turns.sort(key=lambda t: t.timestamp)
+        if limit is not None:
+            turns = turns[:limit]
+        return turns
+
+    async def count(self, session_id: str) -> int:
+        async with self._lock:
+            return len(self._turns.get(session_id, []))
+
+    async def delete_session(self, session_id: str) -> int:
+        async with self._lock:
+            removed = len(self._turns.pop(session_id, []))
+            self._meta.pop(session_id, None)
+            self._owners.pop(session_id, None)
+            self._created_at.pop(session_id, None)
+            self._last_active.pop(session_id, None)
+            return removed
+
+    async def list_sessions(
+        self,
+        *,
+        owner: str | None = None,
+        limit: int = 100,
+        before: datetime | None = None,
+    ) -> list[SessionInfo]:
+        async with self._lock:
+            out = [self._build_info(sid) for sid in self._turns]
+        if owner is not None:
+            out = [s for s in out if s.owner == owner]
+        if before is not None:
+            out = [s for s in out if s.last_active_at < before]
+        out.sort(key=lambda s: s.last_active_at, reverse=True)
+        return out[:limit]
+
+    async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        async with self._lock:
+            bag = self._meta.setdefault(session_id, {})
+            for k, v in metadata.items():
+                bag[k] = v
+            if "owner" in metadata:
+                self._owners[session_id] = metadata["owner"]
+
+    async def expire_before(self, cutoff: datetime) -> int:
+        async with self._lock:
+            doomed = [sid for sid, last in self._last_active.items() if last < cutoff]
+            for sid in doomed:
+                self._turns.pop(sid, None)
+                self._meta.pop(sid, None)
+                self._owners.pop(sid, None)
+                self._created_at.pop(sid, None)
+                self._last_active.pop(sid, None)
+            return len(doomed)
+
+    async def close(self) -> None:
+        return None
+
+    def capabilities(self) -> set[str]:
+        return {"ttl"}
+
+    def _build_info(self, sid: str) -> SessionInfo:
+        turns = self._turns.get(sid, [])
+        return SessionInfo(
+            id=sid,
+            owner=self._owners.get(sid),
+            created_at=self._created_at.get(sid, datetime.now(UTC)),
+            last_active_at=self._last_active.get(sid, datetime.now(UTC)),
+            turn_count=len(turns),
+            total_cost_usd=sum(t.cost_usd for t in turns),
+            metadata=dict(self._meta.get(sid, {})),
+        )
+
+
+__all__ = ["InMemoryChatHistory"]

--- a/packages/agentforge-chat/src/agentforge_chat/manifest.yaml
+++ b/packages/agentforge-chat/src/agentforge_chat/manifest.yaml
@@ -1,0 +1,32 @@
+# Module manifest for `agentforge add module chat` (feat-010).
+name: chat
+description: |
+  Chat-agent runtime (feat-020). Adds the `agentforge_chat` package
+  with `ChatSession`, in-memory + SQLite history drivers, and four
+  truncation strategies.
+
+distribution:
+  pip_name: agentforge-chat
+
+config_block:
+  modules.chat:
+    history:
+      driver: memory   # memory | sqlite (sqlite needs `agentforge-chat[sqlite]`)
+      config: {}
+    truncation:
+      strategy: sliding_window
+      max_turns: 50
+    session:
+      per_turn_budget_usd: null
+      per_session_budget_usd: null
+      idempotency_window_s: 60
+
+entry_points:
+  agentforge.chat.history:
+    memory: agentforge_chat.history:InMemoryChatHistory
+    sqlite: agentforge_chat.sqlite:SqliteChatHistory
+  agentforge.chat.truncation:
+    sliding_window: agentforge_chat.truncation:SlidingWindow
+    token_budget: agentforge_chat.truncation:TokenBudget
+    summarise_oldest: agentforge_chat.truncation:SummariseOldest
+    hybrid: agentforge_chat.truncation:Hybrid

--- a/packages/agentforge-chat/src/agentforge_chat/session.py
+++ b/packages/agentforge-chat/src/agentforge_chat/session.py
@@ -1,0 +1,329 @@
+"""`ChatSession` — stateful conversation wrapper around `Agent`
+(feat-020).
+
+Lifecycle per turn (`send` / `stream`):
+
+  1. Acquire per-session lock.
+  2. Check idempotency cache.
+  3. Build user `ChatTurn` and run input guardrails.
+  4. Append user turn.
+  5. Load + truncate prior history.
+  6. Build the agent task as a serialised transcript.
+  7. `agent.run(task)`.
+  8. Run output guardrails.
+  9. Append assistant + tool turns.
+ 10. Aggregate per-turn / per-session cost.
+ 11. Release lock; return `ChatResponse`.
+
+Cancellation in v0.2 is pre-LLM only (between history-load and
+agent.run). Mid-LLM cancellation needs the same strategy-level
+streaming work documented in feat-020 §10 deferrals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+from uuid import uuid4
+
+from agentforge.agent import Agent
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
+from agentforge_core.production.exceptions import (
+    BudgetExceeded,
+    GuardrailViolation,
+)
+from agentforge_core.values.chat import ChatChunk, ChatResponse, ChatTurn
+
+from agentforge_chat._idempotency import IdempotencyCache
+from agentforge_chat._locks import lock_for
+from agentforge_chat._segment import segment_for_stream
+from agentforge_chat.history import InMemoryChatHistory
+from agentforge_chat.truncation import SlidingWindow
+
+OnTurnHook = Callable[[ChatTurn], None]
+
+
+class ChatSession:
+    """Wrap a one-shot `Agent` into a multi-turn chat session."""
+
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        session_id: str | None = None,
+        history_store: ChatHistoryStore | None = None,
+        system_prompt: str | None = None,
+        truncation: HistoryTruncationStrategy | None = None,
+        owner: str | None = None,
+        per_turn_budget_usd: float | None = None,
+        per_session_budget_usd: float | None = None,
+        idempotency_window_s: float = 60.0,
+        on_turn: OnTurnHook | None = None,
+    ) -> None:
+        self._agent = agent
+        self._session_id = session_id if session_id is not None else uuid4().hex
+        self._history: ChatHistoryStore = (
+            history_store if history_store is not None else InMemoryChatHistory()
+        )
+        self._system_prompt = system_prompt
+        self._truncation: HistoryTruncationStrategy = (
+            truncation if truncation is not None else SlidingWindow(50)
+        )
+        self._owner = owner
+        self._per_turn_budget = per_turn_budget_usd
+        self._per_session_budget = per_session_budget_usd
+        self._on_turn = on_turn
+        self._lock = lock_for(self._session_id)
+        self._idempotency: IdempotencyCache[ChatResponse] = IdempotencyCache(
+            ttl_s=idempotency_window_s
+        )
+        self._total_cost = 0.0
+        self._turn_count = 0
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def total_cost_usd(self) -> float:
+        return self._total_cost
+
+    @property
+    def turn_count(self) -> int:
+        return self._turn_count
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        message: str,
+        *,
+        idempotency_key: str | None = None,
+        cancellation: asyncio.Event | None = None,
+    ) -> ChatResponse:
+        """Send one user message and await a buffered response."""
+        async with self._lock:
+            cached = self._check_cache(idempotency_key)
+            if cached is not None:
+                return cached
+            response, _ = await self._run_turn(message, cancellation=cancellation)
+            self._stash_cache(idempotency_key, response)
+            return response
+
+    async def stream(
+        self,
+        message: str,
+        *,
+        idempotency_key: str | None = None,
+        cancellation: asyncio.Event | None = None,
+    ) -> AsyncIterator[ChatChunk]:
+        """Send one user message and stream the response back as chunks.
+
+        v0.2 uses buffer-then-stream: the agent runs to completion,
+        then the assistant turn is emitted as a sequence of text
+        chunks (sentence-segmented) followed by a `done` chunk. Real
+        per-token streaming becomes a no-API-break enhancement when
+        the strategy ABC grows a `stream()` method.
+        """
+        return self._stream_impl(message, idempotency_key, cancellation)
+
+    async def history(
+        self,
+        *,
+        limit: int | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        return await self._history.load(self._session_id, limit=limit, roles=roles)
+
+    async def reset(self) -> None:
+        await self._history.delete_session(self._session_id)
+        self._total_cost = 0.0
+        self._turn_count = 0
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        await self._history.close()
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Implementation helpers
+    # ------------------------------------------------------------------
+
+    def _check_cache(self, key: str | None) -> ChatResponse | None:
+        if key is None:
+            return None
+        return self._idempotency.get(self._session_id, key)
+
+    def _stash_cache(self, key: str | None, response: ChatResponse) -> None:
+        if key is None:
+            return
+        self._idempotency.put(self._session_id, key, response)
+
+    async def _run_turn(
+        self,
+        message: str,
+        *,
+        cancellation: asyncio.Event | None,
+    ) -> tuple[ChatResponse, ChatTurn]:
+        ctx = self._guard_context()
+        validated_msg = await self._agent._guardrails.check_input(message, ctx)
+        user_turn = await self._build_user_turn(validated_msg)
+        if cancellation is not None and cancellation.is_set():
+            raise asyncio.CancelledError("chat turn cancelled before agent.run")
+        task = await self._compose_task(user_turn)
+        start = time.monotonic()
+        result = await self._agent.run(task)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        validated_out = await self._agent._guardrails.check_output(self._extract_text(result), ctx)
+        assistant_turn = await self._persist_assistant(validated_out, result, duration_ms)
+        self._enforce_budgets(result.cost_usd)
+        response = ChatResponse(
+            content=validated_out,
+            turn_id=assistant_turn.id,
+            run_id=result.run_id,
+            tool_calls=(),
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
+            cost_usd=result.cost_usd,
+            duration_ms=duration_ms,
+            finish_reason=str(result.finish_reason),
+        )
+        return response, assistant_turn
+
+    def _guard_context(self) -> dict[str, Any]:
+        return {
+            "session_id": self._session_id,
+            "owner": self._owner or "anonymous",
+            "project": "chat",
+        }
+
+    async def _build_user_turn(self, content: str) -> ChatTurn:
+        turn = ChatTurn(
+            id=uuid4().hex,
+            session_id=self._session_id,
+            role="user",
+            content=content,
+        )
+        await self._history.append(turn)
+        if self._on_turn is not None:
+            self._on_turn(turn)
+        return turn
+
+    async def _compose_task(self, user_turn: ChatTurn) -> str:
+        prior = await self._history.load(self._session_id, limit=None)
+        # Drop the just-appended user turn — it's added as the final
+        # line below.
+        prior_without_current = [t for t in prior if t.id != user_turn.id]
+        kept = await self._truncation.select(prior_without_current, user_turn.content, {})
+        lines: list[str] = []
+        prompt = self._system_prompt or ""
+        if prompt:
+            lines.append(prompt)
+        lines.extend(f"{t.role}: {t.content}" for t in kept)
+        lines.append(f"user: {user_turn.content}")
+        return "\n\n".join(lines)
+
+    def _extract_text(self, result: Any) -> str:
+        output = result.output
+        if isinstance(output, str):
+            return output
+        return str(output)
+
+    async def _persist_assistant(
+        self,
+        text: str,
+        result: Any,
+        duration_ms: int,
+    ) -> ChatTurn:
+        del duration_ms
+        turn = ChatTurn(
+            id=uuid4().hex,
+            session_id=self._session_id,
+            role="assistant",
+            content=text,
+            run_id=result.run_id,
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
+            cost_usd=result.cost_usd,
+        )
+        await self._history.append(turn)
+        if self._on_turn is not None:
+            self._on_turn(turn)
+        self._total_cost += result.cost_usd
+        self._turn_count += 1
+        await self._history.update_session_metadata(
+            self._session_id,
+            {"owner": self._owner, "total_cost_usd": self._total_cost},
+        )
+        return turn
+
+    def _enforce_budgets(self, turn_cost: float) -> None:
+        if self._per_turn_budget is not None and turn_cost > self._per_turn_budget:
+            raise BudgetExceeded(
+                f"chat turn cost ${turn_cost:.4f} exceeds per-turn budget "
+                f"${self._per_turn_budget:.4f}"
+            )
+        if self._per_session_budget is not None and self._total_cost > self._per_session_budget:
+            raise BudgetExceeded(
+                f"chat session total ${self._total_cost:.4f} exceeds per-session "
+                f"budget ${self._per_session_budget:.4f}"
+            )
+
+    async def _stream_impl(
+        self,
+        message: str,
+        idempotency_key: str | None,
+        cancellation: asyncio.Event | None,
+    ) -> AsyncIterator[ChatChunk]:
+        async with self._lock:
+            cached = self._check_cache(idempotency_key)
+            if cached is not None:
+                async for chunk in self._chunks_for(cached):
+                    yield chunk
+                return
+            try:
+                response, _ = await self._run_turn(message, cancellation=cancellation)
+            except (BudgetExceeded, GuardrailViolation, asyncio.CancelledError) as exc:
+                yield ChatChunk(
+                    kind="error",
+                    turn_id=uuid4().hex,
+                    content={"reason": type(exc).__name__, "message": str(exc)},
+                )
+                return
+            self._stash_cache(idempotency_key, response)
+            async for chunk in self._chunks_for(response):
+                yield chunk
+
+    async def _chunks_for(self, response: ChatResponse) -> AsyncIterator[ChatChunk]:
+        cumulative = ""
+        for piece in segment_for_stream(response.content):
+            cumulative += piece
+            yield ChatChunk(
+                kind="text",
+                content=piece,
+                cumulative_text=cumulative,
+                turn_id=response.turn_id,
+            )
+        yield ChatChunk(
+            kind="done",
+            turn_id=response.turn_id,
+            content={
+                "run_id": response.run_id,
+                "cost_usd": response.cost_usd,
+                "tokens_in": response.tokens_in,
+                "tokens_out": response.tokens_out,
+            },
+        )
+
+
+__all__ = ["ChatSession"]

--- a/packages/agentforge-chat/src/agentforge_chat/sqlite.py
+++ b/packages/agentforge-chat/src/agentforge_chat/sqlite.py
@@ -1,0 +1,276 @@
+"""`SqliteChatHistory` — `ChatHistoryStore` over SQLite via aiosqlite.
+
+Two tables: ``chat_turns`` (one row per turn) and ``chat_sessions``
+(one row per session). Indexed on ``(session_id, created_at)`` so
+``load()`` is sub-linear w.r.t. total turn count.
+
+Schema is created via ``init_schema()`` / ``from_path()``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+import aiosqlite
+from agentforge_core.contracts.chat import ChatHistoryStore
+from agentforge_core.production.exceptions import ModuleError
+from agentforge_core.values.chat import ChatTurn, SessionInfo
+from agentforge_core.values.messages import ToolCall
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    id              TEXT PRIMARY KEY,
+    owner           TEXT,
+    created_at      TEXT NOT NULL,
+    last_active_at  TEXT NOT NULL,
+    metadata        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_owner
+    ON chat_sessions(owner);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active
+    ON chat_sessions(last_active_at);
+CREATE TABLE IF NOT EXISTS chat_turns (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    role            TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    timestamp       TEXT NOT NULL,
+    run_id          TEXT,
+    tool_calls      TEXT NOT NULL,
+    tool_call_id    TEXT,
+    tokens_in       INTEGER NOT NULL,
+    tokens_out      INTEGER NOT NULL,
+    cost_usd        REAL NOT NULL,
+    metadata        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turns_session_ts
+    ON chat_turns(session_id, timestamp);
+"""
+
+
+class SqliteChatHistory(ChatHistoryStore):
+    """`ChatHistoryStore` backed by a single SQLite file."""
+
+    def __init__(self, *, connection: aiosqlite.Connection) -> None:
+        self._db = connection
+
+    @classmethod
+    async def from_path(cls, path: str | Path) -> SqliteChatHistory:
+        """Open or create a SQLite database at ``path``.
+
+        ``":memory:"`` is allowed for tests; on disk the parent
+        directory must already exist.
+        """
+        connection = await aiosqlite.connect(str(path))
+        connection.row_factory = aiosqlite.Row
+        await connection.executescript(_SCHEMA_SQL)
+        await connection.commit()
+        return cls(connection=connection)
+
+    async def __aenter__(self) -> SqliteChatHistory:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        await self._db.close()
+
+    async def append(self, turn: ChatTurn) -> None:
+        ts_iso = turn.timestamp.isoformat()
+        await self._db.execute(
+            """INSERT OR REPLACE INTO chat_turns
+               (id, session_id, role, content, timestamp, run_id,
+                tool_calls, tool_call_id, tokens_in, tokens_out,
+                cost_usd, metadata)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                turn.id,
+                turn.session_id,
+                turn.role,
+                turn.content,
+                ts_iso,
+                turn.run_id,
+                json.dumps([tc.model_dump(mode="json") for tc in turn.tool_calls]),
+                turn.tool_call_id,
+                turn.tokens_in,
+                turn.tokens_out,
+                turn.cost_usd,
+                json.dumps(turn.metadata),
+            ),
+        )
+        await self._upsert_session(turn.session_id, ts_iso)
+        await self._db.commit()
+
+    async def _upsert_session(self, session_id: str, now_iso: str) -> None:
+        await self._db.execute(
+            """INSERT INTO chat_sessions
+               (id, owner, created_at, last_active_at, metadata)
+               VALUES (?, NULL, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET last_active_at=excluded.last_active_at""",
+            (session_id, now_iso, now_iso, "{}"),
+        )
+
+    async def load(
+        self,
+        session_id: str,
+        *,
+        limit: int | None = None,
+        before: datetime | None = None,
+        after: datetime | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        where = ["session_id = ?"]
+        params: list[Any] = [session_id]
+        if before is not None:
+            where.append("timestamp < ?")
+            params.append(before.isoformat())
+        if after is not None:
+            where.append("timestamp > ?")
+            params.append(after.isoformat())
+        if roles is not None:
+            placeholders = ", ".join("?" * len(roles))
+            where.append(f"role IN ({placeholders})")  # nosec B608 — `?` placeholders only
+            params.extend(roles)
+        sql = (
+            "SELECT * FROM chat_turns WHERE "  # noqa: S608  # nosec B608
+            + " AND ".join(where)
+            + " ORDER BY timestamp"
+        )
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        return [_row_to_turn(row) for row in rows]
+
+    async def count(self, session_id: str) -> int:
+        async with self._db.execute(
+            "SELECT COUNT(*) FROM chat_turns WHERE session_id = ?",
+            (session_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return int(row[0]) if row else 0
+
+    async def delete_session(self, session_id: str) -> int:
+        cur = await self._db.execute(
+            "DELETE FROM chat_turns WHERE session_id = ?",
+            (session_id,),
+        )
+        removed = cur.rowcount or 0
+        await self._db.execute(
+            "DELETE FROM chat_sessions WHERE id = ?",
+            (session_id,),
+        )
+        await self._db.commit()
+        return removed
+
+    async def list_sessions(
+        self,
+        *,
+        owner: str | None = None,
+        limit: int = 100,
+        before: datetime | None = None,
+    ) -> list[SessionInfo]:
+        where: list[str] = []
+        params: list[Any] = []
+        if owner is not None:
+            where.append("owner = ?")
+            params.append(owner)
+        if before is not None:
+            where.append("last_active_at < ?")
+            params.append(before.isoformat())
+        sql = "SELECT * FROM chat_sessions"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY last_active_at DESC LIMIT ?"  # nosec B608
+        params.append(limit)
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        return [await self._row_to_info(row) for row in rows]
+
+    async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        async with self._db.execute(
+            "SELECT metadata, owner FROM chat_sessions WHERE id = ?",
+            (session_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise ModuleError(f"Cannot update metadata for unknown session {session_id!r}")
+        existing = json.loads(row["metadata"])
+        existing.update(dict(metadata))
+        owner = metadata.get("owner", row["owner"])
+        await self._db.execute(
+            "UPDATE chat_sessions SET metadata = ?, owner = ? WHERE id = ?",
+            (json.dumps(existing), owner, session_id),
+        )
+        await self._db.commit()
+
+    async def expire_before(self, cutoff: datetime) -> int:
+        cutoff_iso = cutoff.isoformat()
+        await self._db.execute(
+            """DELETE FROM chat_turns WHERE session_id IN (
+                 SELECT id FROM chat_sessions WHERE last_active_at < ?
+               )""",
+            (cutoff_iso,),
+        )
+        cur = await self._db.execute(
+            "DELETE FROM chat_sessions WHERE last_active_at < ?",
+            (cutoff_iso,),
+        )
+        removed = cur.rowcount or 0
+        await self._db.commit()
+        return removed
+
+    def capabilities(self) -> set[str]:
+        return {"ttl"}
+
+    async def _row_to_info(self, row: Any) -> SessionInfo:
+        async with self._db.execute(
+            "SELECT COUNT(*), COALESCE(SUM(cost_usd), 0.0) FROM chat_turns WHERE session_id = ?",
+            (row["id"],),
+        ) as cur:
+            agg = await cur.fetchone()
+        count = int(agg[0]) if agg else 0
+        cost = float(agg[1]) if agg else 0.0
+        return SessionInfo(
+            id=row["id"],
+            owner=row["owner"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            last_active_at=datetime.fromisoformat(row["last_active_at"]),
+            turn_count=count,
+            total_cost_usd=cost,
+            metadata=json.loads(row["metadata"]),
+        )
+
+
+def _row_to_turn(row: Any) -> ChatTurn:
+    raw_calls = json.loads(row["tool_calls"])
+    tool_calls = tuple(ToolCall.model_validate(tc) for tc in raw_calls)
+    return ChatTurn(
+        id=row["id"],
+        session_id=row["session_id"],
+        role=row["role"],
+        content=row["content"],
+        timestamp=datetime.fromisoformat(row["timestamp"]),
+        run_id=row["run_id"],
+        tool_calls=tool_calls,
+        tool_call_id=row["tool_call_id"],
+        tokens_in=int(row["tokens_in"]),
+        tokens_out=int(row["tokens_out"]),
+        cost_usd=float(row["cost_usd"]),
+        metadata=json.loads(row["metadata"]),
+    )
+
+
+__all__ = ["SqliteChatHistory"]

--- a/packages/agentforge-chat/src/agentforge_chat/truncation.py
+++ b/packages/agentforge-chat/src/agentforge_chat/truncation.py
@@ -1,0 +1,185 @@
+"""Truncation strategies (feat-020).
+
+Four built-ins ship in v0.2:
+
+- `SlidingWindow(max_turns=N)` — keep the last N turns.
+- `TokenBudget(max_tokens=N)` — keep as many recent turns as fit
+  under N tokens (approximate, using a 4-chars-per-token heuristic
+  in v0.2; provider-aware tokenisation is a follow-up).
+- `SummariseOldest(threshold_turns=N, summariser=cb)` — keep the
+  last N turns verbatim; everything older condenses to a single
+  ``system`` turn via the supplied summariser callback.
+- `Hybrid(*strategies)` — pipe input through each strategy in
+  order; later strategies see the previous strategy's output.
+
+Each respects the conformance invariants documented in
+`agentforge_core.contracts.chat.HistoryTruncationStrategy`:
+order-preserving + tool-call/tool-result pair atomicity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from agentforge_core.contracts.chat import HistoryTruncationStrategy
+from agentforge_core.values.chat import ChatTurn
+
+SummariserCallback = Callable[[list[ChatTurn]], Awaitable[str]]
+"""Async callback that turns a batch of turns into a single
+summary string. The default implementation in `SummariseOldest`
+concatenates contents — production users supply an LLM-backed
+summariser."""
+
+_CHARS_PER_TOKEN = 4
+"""Approximate chars-per-token heuristic for `TokenBudget`."""
+
+
+def _approx_tokens(turn: ChatTurn) -> int:
+    return max(1, len(turn.content) // _CHARS_PER_TOKEN)
+
+
+def _keep_pair_atomic(turns: list[ChatTurn]) -> list[ChatTurn]:
+    """Drop a leading orphan tool turn that lost its act partner.
+
+    The truncation contract says tool-call/tool-result pairs must
+    not be split. We enforce by dropping any tool turn whose
+    preceding assistant turn isn't in the selection.
+    """
+    if not turns:
+        return turns
+    out: list[ChatTurn] = []
+    last_role: str | None = None
+    for t in turns:
+        if t.role == "tool" and last_role != "assistant":
+            continue
+        out.append(t)
+        last_role = t.role
+    return out
+
+
+class SlidingWindow(HistoryTruncationStrategy):
+    """Keep the most recent ``max_turns`` turns."""
+
+    def __init__(self, max_turns: int = 50) -> None:
+        if max_turns < 1:
+            raise ValueError(f"max_turns must be >= 1, got {max_turns}")
+        self.max_turns = max_turns
+
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del next_user_message, context
+        kept = all_turns[-self.max_turns :]
+        return _keep_pair_atomic(kept)
+
+
+class TokenBudget(HistoryTruncationStrategy):
+    """Keep recent turns until ``max_tokens`` is exhausted.
+
+    Token counting is approximate in v0.2 (4 chars ≈ 1 token).
+    Replace with a provider-aware tokeniser when the next-gen
+    LLM contract lands.
+    """
+
+    def __init__(self, max_tokens: int = 64_000) -> None:
+        if max_tokens < 1:
+            raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
+        self.max_tokens = max_tokens
+
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del context
+        # Reserve budget for the next user message itself.
+        reserved = max(1, len(next_user_message) // _CHARS_PER_TOKEN)
+        remaining = self.max_tokens - reserved
+        chosen: list[ChatTurn] = []
+        for turn in reversed(all_turns):
+            cost = _approx_tokens(turn)
+            if cost > remaining:
+                break
+            chosen.append(turn)
+            remaining -= cost
+        chosen.reverse()
+        return _keep_pair_atomic(chosen)
+
+
+class SummariseOldest(HistoryTruncationStrategy):
+    """Keep the last ``threshold_turns``; condense older turns
+    into a single ``system`` summary turn."""
+
+    def __init__(
+        self,
+        *,
+        threshold_turns: int = 30,
+        summariser: SummariserCallback | None = None,
+    ) -> None:
+        if threshold_turns < 1:
+            raise ValueError(f"threshold_turns must be >= 1, got {threshold_turns}")
+        self.threshold_turns = threshold_turns
+        self.summariser: SummariserCallback = (
+            summariser if summariser is not None else _default_summariser
+        )
+
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del next_user_message, context
+        if len(all_turns) <= self.threshold_turns:
+            return _keep_pair_atomic(list(all_turns))
+        older = all_turns[: -self.threshold_turns]
+        recent = all_turns[-self.threshold_turns :]
+        summary_text = await self.summariser(older)
+        summary = ChatTurn(
+            id=f"summary-{older[0].id}-{older[-1].id}",
+            session_id=older[0].session_id,
+            role="system",
+            content=f"[Summary of {len(older)} older turns] {summary_text}",
+            timestamp=older[0].timestamp,
+            metadata={"agentforge_chat.summary": True},
+        )
+        return _keep_pair_atomic([summary, *recent])
+
+
+class Hybrid(HistoryTruncationStrategy):
+    """Compose strategies in series: each runs against the
+    previous strategy's output."""
+
+    def __init__(self, *strategies: HistoryTruncationStrategy) -> None:
+        if not strategies:
+            raise ValueError("Hybrid requires at least one strategy")
+        self.strategies = strategies
+
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        current = list(all_turns)
+        for s in self.strategies:
+            current = await s.select(current, next_user_message, context)
+        return current
+
+
+async def _default_summariser(turns: list[ChatTurn]) -> str:
+    pieces = [f"{t.role}: {t.content}" for t in turns]
+    return " | ".join(pieces)[:2000]
+
+
+__all__ = [
+    "Hybrid",
+    "SlidingWindow",
+    "SummariseOldest",
+    "TokenBudget",
+]

--- a/packages/agentforge-chat/tests/unit/test_chat_build.py
+++ b/packages/agentforge-chat/tests/unit/test_chat_build.py
@@ -1,0 +1,98 @@
+"""Tests for `build_chat_session_from_config` (feat-020 chunk 5)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge.agent import Agent
+from agentforge.resolver_register import register_chat_history, register_chat_truncation
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_chat import ChatSession, build_chat_session_from_config
+from agentforge_chat.history import InMemoryChatHistory
+from agentforge_chat.truncation import SlidingWindow
+from agentforge_core.config.schema import (
+    AgentForgeConfig,
+    ChatConfig,
+    ChatHistoryDriverConfig,
+    ChatSessionConfig,
+    ChatTruncationConfig,
+    ModulesConfig,
+)
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+
+
+class _Strat(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content="ok"))
+        return state
+
+
+class _LLM(LLMClient):
+    async def call(
+        self, system: str, messages: list[Message], tools: list[ToolSpec] | None = None
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent() -> Agent:
+    return Agent(model=_LLM(), strategy=_Strat())
+
+
+@register_chat_history("_test_inmem_chat_history")
+class _Dummy(InMemoryChatHistory):
+    pass
+
+
+@register_chat_truncation("_test_sliding")
+class _Slid(SlidingWindow):
+    def __init__(self, *, max_turns: int = 20) -> None:
+        super().__init__(max_turns=max_turns)
+
+
+@pytest.mark.asyncio
+async def test_build_chat_defaults_when_no_chat_block() -> None:
+    cfg = AgentForgeConfig()
+    session = await build_chat_session_from_config(cfg, _agent())
+    assert isinstance(session, ChatSession)
+    # Default history is InMemoryChatHistory; default truncation
+    # behaves like SlidingWindow(50).
+    await session.send("hi")
+    assert session.turn_count == 1
+
+
+@pytest.mark.asyncio
+async def test_build_chat_resolves_named_driver_and_strategy() -> None:
+    cfg = AgentForgeConfig(
+        modules=ModulesConfig(
+            chat=ChatConfig(
+                history=ChatHistoryDriverConfig(driver="_test_inmem_chat_history", config={}),
+                truncation=ChatTruncationConfig(strategy="_test_sliding", config={"max_turns": 3}),
+                session=ChatSessionConfig(per_turn_budget_usd=1.0),
+            )
+        )
+    )
+    session = await build_chat_session_from_config(cfg, _agent())
+    await session.send("hi")
+    assert session.turn_count == 1

--- a/packages/agentforge-chat/tests/unit/test_in_memory_history.py
+++ b/packages/agentforge-chat/tests/unit/test_in_memory_history.py
@@ -1,0 +1,19 @@
+"""Unit tests for `InMemoryChatHistory`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_chat import InMemoryChatHistory
+from agentforge_core.testing import run_chat_history_conformance
+
+
+@pytest.mark.asyncio
+async def test_in_memory_history_passes_conformance() -> None:
+    await run_chat_history_conformance(InMemoryChatHistory())
+
+
+@pytest.mark.asyncio
+async def test_in_memory_history_supports_ttl_capability() -> None:
+    store = InMemoryChatHistory()
+    assert store.supports("ttl") is True
+    assert store.supports("encryption_at_rest") is False

--- a/packages/agentforge-chat/tests/unit/test_session.py
+++ b/packages/agentforge-chat/tests/unit/test_session.py
@@ -1,0 +1,243 @@
+"""Unit tests for `ChatSession` (feat-020 chunk 3)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_chat import ChatSession, InMemoryChatHistory, SlidingWindow
+from agentforge_core.contracts.chat import HistoryTruncationStrategy
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.production.exceptions import BudgetExceeded
+from agentforge_core.values.chat import ChatTurn
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+
+
+class _EchoStrategy(ReasoningStrategy):
+    """Strategy that appends a single 'think' step echoing the task
+    and commits a fixed cost to the runtime budget."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.01)
+        state.steps.append(
+            Step(
+                iteration=0,
+                kind="think",
+                content=f"echo: {state.task[-200:]}",
+                cost_usd=0.01,
+            )
+        )
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent() -> Agent:
+    return Agent(model=_FakeLLM(), strategy=_EchoStrategy())
+
+
+def _session(**kwargs: Any) -> ChatSession:
+    return ChatSession(_agent(), history_store=InMemoryChatHistory(), **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_single_turn_round_trip() -> None:
+    session = _session(session_id="t1")
+    response = await session.send("hi")
+    assert "echo:" in response.content
+    assert response.run_id
+
+
+@pytest.mark.asyncio
+async def test_history_remembers_prior_turn() -> None:
+    session = _session(session_id="t2")
+    await session.send("first message")
+    await session.send("second message")
+    turns = await session.history()
+    # 2 user turns + 2 assistant turns
+    user_contents = [t.content for t in turns if t.role == "user"]
+    assert "first message" in user_contents
+    assert "second message" in user_contents
+
+
+@pytest.mark.asyncio
+async def test_truncation_applies_to_serialised_task() -> None:
+    captured: dict[str, str] = {}
+
+    class _CapturingStrategy(ReasoningStrategy):
+        async def run(self, state: AgentState) -> AgentState:
+            captured["task"] = state.task
+            state.steps.append(Step(iteration=0, kind="think", content="ok"))
+            return state
+
+    agent = Agent(model=_FakeLLM(), strategy=_CapturingStrategy())
+    session = ChatSession(
+        agent,
+        session_id="t3",
+        history_store=InMemoryChatHistory(),
+        truncation=SlidingWindow(max_turns=1),
+        system_prompt="you are helpful.",
+    )
+    await session.send("first")
+    await session.send("second")
+    # With max_turns=1, the prior history shown to the agent is the
+    # single most recent (assistant) turn before the new user line.
+    assert "user: second" in captured["task"]
+    assert "you are helpful." in captured["task"]
+
+
+@pytest.mark.asyncio
+async def test_idempotency_returns_cached_response() -> None:
+    session = _session(session_id="t4")
+    r1 = await session.send("hi", idempotency_key="abc")
+    r2 = await session.send("ignored second body", idempotency_key="abc")
+    assert r1.turn_id == r2.turn_id
+    assert r1.content == r2.content
+    # second send must NOT have appended new turns
+    turns = await session.history()
+    user_count = sum(1 for t in turns if t.role == "user")
+    assert user_count == 1
+
+
+@pytest.mark.asyncio
+async def test_per_turn_budget_enforced() -> None:
+    session = _session(session_id="t5", per_turn_budget_usd=0.001)
+    with pytest.raises(BudgetExceeded, match="per-turn"):
+        await session.send("hi")
+
+
+@pytest.mark.asyncio
+async def test_per_session_budget_enforced() -> None:
+    session = _session(session_id="t6", per_session_budget_usd=0.015)
+    await session.send("first")  # commits 0.01 cost
+    with pytest.raises(BudgetExceeded, match="per-session"):
+        await session.send("second")  # 0.01 + 0.01 > 0.015
+
+
+@pytest.mark.asyncio
+async def test_per_session_lock_serialises_concurrent_sends() -> None:
+    session = _session(session_id="t7")
+    results = await asyncio.gather(
+        session.send("a"),
+        session.send("b"),
+    )
+    assert len(results) == 2
+    turns = await session.history()
+    # Lock serialises: histories of user turns reflect both messages in
+    # some order.
+    user_contents = {t.content for t in turns if t.role == "user"}
+    assert user_contents == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_history_and_counters() -> None:
+    session = _session(session_id="t8")
+    await session.send("hi")
+    assert session.turn_count == 1
+    await session.reset()
+    assert session.turn_count == 0
+    assert session.total_cost_usd == 0.0
+    assert await session.history() == []
+
+
+@pytest.mark.asyncio
+async def test_on_turn_hook_fires_for_user_and_assistant() -> None:
+    seen: list[ChatTurn] = []
+
+    def hook(turn: ChatTurn) -> None:
+        seen.append(turn)
+
+    session = _session(session_id="t9", on_turn=hook)
+    await session.send("hi")
+    roles = [t.role for t in seen]
+    assert "user" in roles
+    assert "assistant" in roles
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_text_and_done_chunks() -> None:
+    session = _session(session_id="t10")
+    chunks = [chunk async for chunk in await session.stream("hi there.")]
+    kinds = [c.kind for c in chunks]
+    assert "text" in kinds
+    assert kinds[-1] == "done"
+    # cumulative_text on text chunks grows monotonically
+    cumulative = [c.cumulative_text for c in chunks if c.kind == "text"]
+    assert cumulative == sorted(cumulative, key=lambda s: len(s) if s else 0)
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_error_chunk_on_budget_breach() -> None:
+    session = _session(session_id="t11", per_turn_budget_usd=0.0001)
+    chunks = [chunk async for chunk in await session.stream("hi")]
+    assert chunks[-1].kind == "error"
+    assert "BudgetExceeded" in chunks[-1].content["reason"]  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_pre_llm_raises() -> None:
+    session = _session(session_id="t12")
+    event = asyncio.Event()
+    event.set()
+    with pytest.raises(asyncio.CancelledError):
+        await session.send("hi", cancellation=event)
+
+
+class _ConstantSelect(HistoryTruncationStrategy):
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del next_user_message, context
+        return list(all_turns)
+
+
+@pytest.mark.asyncio
+async def test_custom_truncation_strategy_is_invoked() -> None:
+    session = _session(session_id="t13", truncation=_ConstantSelect())
+    await session.send("first")
+    await session.send("second")
+    turns = await session.history()
+    assert len(turns) >= 4  # 2 user + 2 assistant
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    session = _session(session_id="t14")
+    await session.close()
+    await session.close()

--- a/packages/agentforge-chat/tests/unit/test_sqlite_history.py
+++ b/packages/agentforge-chat/tests/unit/test_sqlite_history.py
@@ -1,0 +1,13 @@
+"""Unit tests for `SqliteChatHistory`."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_chat import SqliteChatHistory
+from agentforge_core.testing import run_chat_history_conformance
+
+
+@pytest.mark.asyncio
+async def test_sqlite_history_passes_conformance() -> None:
+    async with await SqliteChatHistory.from_path(":memory:") as store:
+        await run_chat_history_conformance(store)

--- a/packages/agentforge-chat/tests/unit/test_truncation.py
+++ b/packages/agentforge-chat/tests/unit/test_truncation.py
@@ -1,0 +1,134 @@
+"""Unit tests for truncation strategies."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from agentforge_chat import Hybrid, SlidingWindow, SummariseOldest, TokenBudget
+from agentforge_core.testing import run_truncation_conformance
+from agentforge_core.values.chat import ChatTurn
+
+
+def _make_turns(n: int, *, role: str = "user", chars: int = 20) -> list[ChatTurn]:
+    base = datetime.now(UTC)
+    return [
+        ChatTurn(
+            id=f"t{i}",
+            session_id="s",
+            role=role,
+            content="x" * chars,
+            timestamp=base + timedelta(seconds=i),
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sliding_window_conformance() -> None:
+    await run_truncation_conformance(SlidingWindow(max_turns=3))
+
+
+@pytest.mark.asyncio
+async def test_token_budget_conformance() -> None:
+    await run_truncation_conformance(TokenBudget(max_tokens=1000))
+
+
+@pytest.mark.asyncio
+async def test_hybrid_conformance() -> None:
+    await run_truncation_conformance(Hybrid(SlidingWindow(20), TokenBudget(500)))
+
+
+@pytest.mark.asyncio
+async def test_summarise_oldest_conformance() -> None:
+    await run_truncation_conformance(SummariseOldest(threshold_turns=2))
+
+
+@pytest.mark.asyncio
+async def test_sliding_window_keeps_last_n() -> None:
+    turns = _make_turns(5)
+    out = await SlidingWindow(max_turns=2).select(turns, "next", {})
+    assert [t.id for t in out] == ["t3", "t4"]
+
+
+def test_sliding_window_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="max_turns"):
+        SlidingWindow(max_turns=0)
+
+
+def test_token_budget_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="max_tokens"):
+        TokenBudget(max_tokens=0)
+
+
+@pytest.mark.asyncio
+async def test_token_budget_drops_oldest_when_over_cap() -> None:
+    turns = _make_turns(5, chars=200)
+    # 200 chars ≈ 50 tokens per turn. cap=100 → keep ~2 turns.
+    out = await TokenBudget(max_tokens=120).select(turns, "msg", {})
+    assert len(out) <= 3
+    assert all(t in turns for t in out)
+
+
+@pytest.mark.asyncio
+async def test_summarise_oldest_compresses_older_turns() -> None:
+    turns = _make_turns(5)
+    out = await SummariseOldest(threshold_turns=2).select(turns, "msg", {})
+    # first turn is the synthesised summary
+    assert out[0].role == "system"
+    assert out[0].metadata.get("agentforge_chat.summary") is True
+    # last two are kept verbatim
+    assert out[-2].id == "t3"
+    assert out[-1].id == "t4"
+
+
+@pytest.mark.asyncio
+async def test_summarise_oldest_passthrough_below_threshold() -> None:
+    turns = _make_turns(2)
+    out = await SummariseOldest(threshold_turns=3).select(turns, "msg", {})
+    assert out == turns
+
+
+@pytest.mark.asyncio
+async def test_hybrid_pipes_through_strategies() -> None:
+    turns = _make_turns(10)
+    pipeline = Hybrid(SlidingWindow(5), SlidingWindow(2))
+    out = await pipeline.select(turns, "msg", {})
+    assert [t.id for t in out] == ["t8", "t9"]
+
+
+def test_hybrid_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        Hybrid()
+
+
+@pytest.mark.asyncio
+async def test_pair_atomicity_drops_orphan_tool_turn() -> None:
+    base = datetime.now(UTC)
+    turns = [
+        ChatTurn(
+            id="a",
+            session_id="s",
+            role="assistant",
+            content="call",
+            timestamp=base,
+        ),
+        ChatTurn(
+            id="b",
+            session_id="s",
+            role="tool",
+            content="result",
+            timestamp=base + timedelta(seconds=1),
+        ),
+        ChatTurn(
+            id="c",
+            session_id="s",
+            role="tool",
+            content="orphan-result",
+            timestamp=base + timedelta(seconds=2),
+        ),
+    ]
+    # SlidingWindow(2) would pick [b, c]; pair-atomicity drops c
+    # because it has no preceding assistant in the selection.
+    out = await SlidingWindow(2).select(turns, "msg", {})
+    assert "c" not in [t.id for t in out]

--- a/packages/agentforge-core/src/agentforge_core/config/module_schemas.py
+++ b/packages/agentforge-core/src/agentforge_core/config/module_schemas.py
@@ -80,6 +80,23 @@ def validate_module_configs(
     if cfg.modules.pipeline is not None:
         for task_entry in cfg.modules.pipeline.tasks:
             _validate_named(r, "tasks", task_entry, strict=strict)
+    if cfg.modules.chat is not None:
+        if cfg.modules.chat.history is not None:
+            _validate_driver(
+                r,
+                "chat.history",
+                cfg.modules.chat.history.driver,
+                cfg.modules.chat.history.config,
+                strict=strict,
+            )
+        if cfg.modules.chat.truncation is not None:
+            _validate_driver(
+                r,
+                "chat.truncation",
+                cfg.modules.chat.truncation.strategy,
+                cfg.modules.chat.truncation.config,
+                strict=strict,
+            )
 
 
 def _validate_one(
@@ -131,6 +148,33 @@ def _validate_named(
     except ValidationError as exc:
         raise ModuleError(
             f"modules.{category}[{entry.name!r}].config failed validation: "
+            f"{exc.errors(include_url=False)}"
+        ) from exc
+
+
+def _validate_driver(
+    resolver: Resolver,
+    category: str,
+    name: str,
+    config: dict[str, Any],
+    *,
+    strict: bool,
+) -> None:
+    """Validate a driver-by-name + config dict (feat-020 chat hook)."""
+    try:
+        cls = resolver.resolve(category, name)
+    except ModuleError:
+        if strict:
+            raise
+        return
+    schema = _read_config_schema(cls)
+    if schema is None:
+        return
+    try:
+        schema.model_validate(config)
+    except ValidationError as exc:
+        raise ModuleError(
+            f"modules.{category}.config failed validation for {name!r}: "
             f"{exc.errors(include_url=False)}"
         ) from exc
 

--- a/packages/agentforge-core/src/agentforge_core/config/schema.py
+++ b/packages/agentforge-core/src/agentforge_core/config/schema.py
@@ -158,6 +158,51 @@ class GuardrailEntry(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
+class ChatHistoryDriverConfig(BaseModel):
+    """`modules.chat.history:` — driver + config for a chat history
+    store (feat-020)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    driver: str = Field(min_length=1)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatTruncationConfig(BaseModel):
+    """`modules.chat.truncation:` — strategy + config (feat-020)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    strategy: str = Field(min_length=1)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatSessionConfig(BaseModel):
+    """`modules.chat.session:` — per-session policy knobs (feat-020)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    per_turn_budget_usd: float | None = Field(default=None, ge=0.0)
+    per_session_budget_usd: float | None = Field(default=None, ge=0.0)
+    idempotency_window_s: float = Field(default=60.0, ge=0.0)
+    concurrency: Literal["queue", "reject", "replace"] = "queue"
+    safety_mode: Literal["buffer-then-stream", "stream-then-redact"] = "buffer-then-stream"
+
+
+class ChatConfig(BaseModel):
+    """`modules.chat:` — chat layer config (feat-020).
+
+    `history` may be ``None`` (defaults to in-memory). `truncation`
+    similarly defaults to `SlidingWindow(50)` when absent.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    history: ChatHistoryDriverConfig | None = None
+    truncation: ChatTruncationConfig | None = None
+    session: ChatSessionConfig = Field(default_factory=ChatSessionConfig)
+
+
 class PipelineTaskEntry(BaseModel):
     """One entry inside `modules.pipeline.tasks` (feat-015).
 
@@ -232,6 +277,7 @@ class ModulesConfig(BaseModel):
     protocols: list[ObservabilityEntry] = Field(default_factory=list)
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig)
     pipeline: PipelineConfig | None = None
+    chat: ChatConfig | None = None
 
 
 class ProviderConfig(BaseModel):

--- a/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
@@ -7,6 +7,7 @@ consumes them by reference to the abstraction, never the implementation.
 
 from __future__ import annotations
 
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
 from agentforge_core.contracts.embedding import EmbeddingClient
 from agentforge_core.contracts.evaluator import EvalResult, Evaluator
 from agentforge_core.contracts.finding import Finding
@@ -20,12 +21,14 @@ from agentforge_core.contracts.tool import Tool
 from agentforge_core.contracts.vector_store import VectorStore
 
 __all__ = [
+    "ChatHistoryStore",
     "EmbeddingClient",
     "EvalResult",
     "Evaluator",
     "Finding",
     "FindingRenderer",
     "GraphStore",
+    "HistoryTruncationStrategy",
     "LLMClient",
     "MemoryStore",
     "ReasoningStrategy",

--- a/packages/agentforge-core/src/agentforge_core/contracts/chat.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/chat.py
@@ -1,0 +1,118 @@
+"""Chat-agent contracts (feat-020).
+
+`ChatHistoryStore` and `HistoryTruncationStrategy` are the two locked
+ABCs the chat layer ships against. Drivers (in-memory + sqlite +
+postgres + redis) all implement the same `ChatHistoryStore` shape;
+truncation strategies (sliding-window, token-budget, summarise-oldest,
+hybrid) all implement the same `HistoryTruncationStrategy` shape.
+
+Per ADR-0007, methods on these ABCs are locked once the feature
+ships. Adding a method is a major version bump.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from agentforge_core.values.chat import ChatTurn, SessionInfo
+
+
+class ChatHistoryStore(ABC):
+    """Persistent store for chat turns, isolated by `session_id`.
+
+    All read/write methods take `session_id`; cross-session access
+    is impossible without explicitly passing the id. Drivers
+    typically index on `(session_id, created_at)` so `load()` is
+    sub-linear w.r.t. total store size.
+    """
+
+    @abstractmethod
+    async def append(self, turn: ChatTurn) -> None:
+        """Persist a single chat turn."""
+
+    @abstractmethod
+    async def load(
+        self,
+        session_id: str,
+        *,
+        limit: int | None = None,
+        before: datetime | None = None,
+        after: datetime | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        """Load turns for ``session_id`` in chronological order
+        (oldest first). Filters apply pre-limit."""
+
+    @abstractmethod
+    async def count(self, session_id: str) -> int:
+        """Total turn count for ``session_id``."""
+
+    @abstractmethod
+    async def delete_session(self, session_id: str) -> int:
+        """Delete every turn for ``session_id``. Returns the number
+        of turns removed."""
+
+    @abstractmethod
+    async def list_sessions(
+        self,
+        *,
+        owner: str | None = None,
+        limit: int = 100,
+        before: datetime | None = None,
+    ) -> list[SessionInfo]:
+        """List sessions, optionally filtered by owner. Ordered by
+        ``last_active_at`` descending."""
+
+    @abstractmethod
+    async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        """Merge ``metadata`` into the session's metadata dict.
+
+        Implementations may overwrite top-level keys; nested merging
+        is the caller's responsibility.
+        """
+
+    @abstractmethod
+    async def expire_before(self, cutoff: datetime) -> int:
+        """TTL sweep: delete every session whose ``last_active_at <
+        cutoff``. Returns the number of sessions removed. Drivers
+        without TTL support return 0."""
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release driver resources (DB pool, file handles, etc.)."""
+
+    def capabilities(self) -> set[str]:
+        """Optional capability bag.
+
+        Subset of: ``"ttl"``, ``"encryption_at_rest"``,
+        ``"full_text_search"``, ``"streaming_load"``.
+        """
+        return set()
+
+    def supports(self, capability: str) -> bool:
+        return capability in self.capabilities()
+
+
+class HistoryTruncationStrategy(ABC):
+    """Decides which prior turns to include in the next LLM call.
+
+    Truncation runs every turn, between `load()` and the agent call.
+    Returns a possibly-empty subset of ``all_turns`` (ordered).
+    Invariants every strategy honours (covered by the conformance
+    harness):
+
+    - Order-preserving (output is a subsequence of input).
+    - Tool-call / tool-result pairs are never split.
+    """
+
+    @abstractmethod
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        """Return the subset of ``all_turns`` to feed to the LLM."""

--- a/packages/agentforge-core/src/agentforge_core/testing/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/__init__.py
@@ -13,6 +13,7 @@ have to depend on the full runtime.
 from __future__ import annotations
 
 from agentforge_core.testing.conformance import (
+    run_chat_history_conformance,
     run_embedding_conformance,
     run_graph_conformance,
     run_input_validator_conformance,
@@ -21,10 +22,12 @@ from agentforge_core.testing.conformance import (
     run_strategy_conformance,
     run_task_conformance,
     run_tool_gate_conformance,
+    run_truncation_conformance,
     run_vector_conformance,
 )
 
 __all__ = [
+    "run_chat_history_conformance",
     "run_embedding_conformance",
     "run_graph_conformance",
     "run_input_validator_conformance",
@@ -33,5 +36,6 @@ __all__ = [
     "run_strategy_conformance",
     "run_task_conformance",
     "run_tool_gate_conformance",
+    "run_truncation_conformance",
     "run_vector_conformance",
 ]

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -950,10 +950,15 @@ async def run_truncation_conformance(strategy: HistoryTruncationStrategy) -> Non
     ]
     picked = await strategy.select(seq, "next msg", {})
     ids = [t.id for t in seq]
-    picked_ids = [t.id for t in picked]
-    # subsequence check
+    # Output must preserve order: original turns appear in the same
+    # relative order as in `seq`. Synthesised summary turns marked
+    # `metadata["agentforge_chat.summary"] == True` are allowed
+    # (`SummariseOldest`) and skipped from the subsequence check.
     iter_ids = iter(ids)
-    for pid in picked_ids:
-        assert pid in iter_ids, (
-            "truncation output must be a subsequence of input (order preserved, no inserted turns)"
+    for t in picked:
+        if t.metadata.get("agentforge_chat.summary") is True:
+            continue
+        assert t.id in iter_ids, (
+            "truncation output must preserve input order "
+            "(no reordered or inserted non-summary turns)"
         )

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -22,7 +22,9 @@ import itertools
 import math
 import typing
 from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
 
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
 from agentforge_core.contracts.embedding import EmbeddingClient
 from agentforge_core.contracts.graph_store import GraphStore
 from agentforge_core.contracts.guardrails import (
@@ -73,6 +75,12 @@ async def _collect(it: AsyncIterator[Claim]) -> list[Claim]:
 
 _EXPECTED_DELETE_COUNT = 2
 """Magic-number constant for the `delete()` conformance cases."""
+
+_EXPECTED_CHAT_TURNS_SID = 2
+"""Magic-number constant for the chat-history conformance cases."""
+
+_EXPECTED_CHAT_TURNS_SID_B = 1
+"""Magic-number constant for the chat-history conformance cases."""
 
 
 async def _run_delete_conformance(store: MemoryStore) -> None:
@@ -799,3 +807,153 @@ async def run_task_conformance(
         assert isinstance(f.category, str), "finding.category must be a string"
         assert hasattr(f, "message"), "finding must have a 'message' attribute"
         assert isinstance(f.message, str), "finding.message must be a string"
+
+
+# ----------------------------------------------------------------------
+# Chat conformance — feat-020.
+# ----------------------------------------------------------------------
+
+
+async def run_chat_history_conformance(store: ChatHistoryStore) -> None:
+    """Validate that a `ChatHistoryStore` honours the locked contract.
+
+    The store must be empty when this is called and is left empty
+    when the function returns.
+    """
+    from datetime import UTC, datetime  # noqa: PLC0415
+    from uuid import uuid4  # noqa: PLC0415
+
+    from agentforge_core.values.chat import ChatTurn  # noqa: PLC0415
+
+    sid = f"conf-{uuid4().hex[:8]}"
+    sid_b = f"conf-{uuid4().hex[:8]}"
+
+    def _turn(session: str, role: str, content: str, **kw: Any) -> ChatTurn:
+        return ChatTurn(
+            id=uuid4().hex,
+            session_id=session,
+            role=role,  # type: ignore[arg-type]
+            content=content,
+            timestamp=datetime.now(UTC),
+            **kw,
+        )
+
+    # 1. append + load round-trip.
+    t1 = _turn(sid, "user", "hello")
+    t2 = _turn(sid, "assistant", "hi there", run_id="run-1")
+    await store.append(t1)
+    await store.append(t2)
+    loaded = await store.load(sid)
+    assert len(loaded) == _EXPECTED_CHAT_TURNS_SID, (
+        f"load() must return both turns; got {len(loaded)}"
+    )
+    assert loaded[0].id == t1.id, "load() must return turns in chronological order"
+    assert loaded[1].id == t2.id
+
+    # 2. count.
+    n = await store.count(sid)
+    assert n == _EXPECTED_CHAT_TURNS_SID, f"count() must reflect appended turns; got {n}"
+
+    # 3. session isolation — a different session_id sees nothing.
+    other_turn = _turn(sid_b, "user", "different session")
+    await store.append(other_turn)
+    only_a = await store.load(sid)
+    assert all(t.session_id == sid for t in only_a), (
+        "load(session_id) must not bleed across sessions"
+    )
+    assert await store.count(sid_b) == _EXPECTED_CHAT_TURNS_SID_B
+
+    # 4. role filter.
+    only_assistant = await store.load(sid, roles=["assistant"])
+    assert all(t.role == "assistant" for t in only_assistant), (
+        "load(roles=...) must filter to those roles"
+    )
+
+    # 5. limit.
+    limited = await store.load(sid, limit=1)
+    assert len(limited) == 1, "load(limit=N) must return at most N turns"
+
+    # 6. list_sessions returns info for every active session.
+    sessions = await store.list_sessions()
+    ids = {s.id for s in sessions}
+    assert sid in ids, "list_sessions() must include the first session"
+    assert sid_b in ids, "list_sessions() must include the second session"
+
+    # 7. update_session_metadata merges keys.
+    await store.update_session_metadata(sid, {"owner": "alice", "tag": "x"})
+    after = await store.list_sessions()
+    matched = [s for s in after if s.id == sid]
+    assert matched, "session must still appear after update_session_metadata()"
+
+    # 8. owner filter on list_sessions.
+    owned = await store.list_sessions(owner="alice")
+    assert all(s.owner == "alice" for s in owned), (
+        "list_sessions(owner=X) must filter to that owner"
+    )
+
+    # 9. delete_session removes turns + returns count.
+    removed = await store.delete_session(sid)
+    assert removed == _EXPECTED_CHAT_TURNS_SID, (
+        f"delete_session must return turns removed; got {removed}"
+    )
+    assert await store.count(sid) == 0
+    after_other = await store.count(sid_b)
+    assert after_other == _EXPECTED_CHAT_TURNS_SID_B, "delete_session must not touch other sessions"
+
+    # 10. expire_before — drivers without TTL may return 0.
+    far_future = datetime(2099, 1, 1, tzinfo=UTC)
+    removed_b = await store.expire_before(far_future)
+    assert isinstance(removed_b, int), "expire_before must return an int"
+
+    # 11. capabilities is a set.
+    caps = store.capabilities()
+    assert isinstance(caps, set)
+    assert store.supports("definitely-not-a-real-capability") is False
+
+    # Clean up remaining session.
+    await store.delete_session(sid_b)
+    await store.expire_before(far_future)
+
+
+async def run_truncation_conformance(strategy: HistoryTruncationStrategy) -> None:
+    """Validate that a `HistoryTruncationStrategy` honours the
+    locked invariants.
+
+    Asserts:
+      1. Output is a subsequence of input (order preserved, no
+         injection).
+      2. Empty input → empty output.
+    """
+    from datetime import UTC, datetime  # noqa: PLC0415
+    from uuid import uuid4  # noqa: PLC0415
+
+    from agentforge_core.values.chat import ChatTurn  # noqa: PLC0415
+
+    def _turn(role: str, content: str) -> ChatTurn:
+        return ChatTurn(
+            id=uuid4().hex,
+            session_id="conf",
+            role=role,  # type: ignore[arg-type]
+            content=content,
+            timestamp=datetime.now(UTC),
+        )
+
+    empty: list[ChatTurn] = []
+    out = await strategy.select(empty, "msg", {})
+    assert out == [], "empty input must yield empty output"
+
+    seq = [
+        _turn("user", "a"),
+        _turn("assistant", "b"),
+        _turn("user", "c"),
+        _turn("assistant", "d"),
+    ]
+    picked = await strategy.select(seq, "next msg", {})
+    ids = [t.id for t in seq]
+    picked_ids = [t.id for t in picked]
+    # subsequence check
+    iter_ids = iter(ids)
+    for pid in picked_ids:
+        assert pid in iter_ids, (
+            "truncation output must be a subsequence of input (order preserved, no inserted turns)"
+        )

--- a/packages/agentforge-core/src/agentforge_core/values/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/values/__init__.py
@@ -7,6 +7,14 @@ requires a major bump.
 
 from __future__ import annotations
 
+from agentforge_core.values.chat import (
+    ChatChunk,
+    ChatChunkKind,
+    ChatResponse,
+    ChatRole,
+    ChatTurn,
+    SessionInfo,
+)
 from agentforge_core.values.claim import Claim
 from agentforge_core.values.graph import (
     GraphEdge,
@@ -51,6 +59,11 @@ __all__ = [
     "AppliedEnvVar",
     "AppliedManifest",
     "AppliedTemplate",
+    "ChatChunk",
+    "ChatChunkKind",
+    "ChatResponse",
+    "ChatRole",
+    "ChatTurn",
     "Claim",
     "EmbeddingResponse",
     "EnvVarEntry",
@@ -67,6 +80,7 @@ __all__ = [
     "Path",
     "PipelineResult",
     "RunResult",
+    "SessionInfo",
     "Step",
     "StepKind",
     "StopReason",

--- a/packages/agentforge-core/src/agentforge_core/values/chat.py
+++ b/packages/agentforge-core/src/agentforge_core/values/chat.py
@@ -1,0 +1,92 @@
+"""Chat-agent value types (feat-020).
+
+Frozen Pydantic models that ride the wire between `ChatSession`,
+`ChatHistoryStore` drivers, and the chat-http server.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentforge_core.values.messages import ToolCall
+
+ChatRole = Literal["user", "assistant", "system", "tool"]
+"""Closed enum of chat turn roles."""
+
+ChatChunkKind = Literal["text", "tool_call", "tool_result", "thinking", "done", "error"]
+"""Closed enum of streaming chunk kinds. Adding a new kind requires a
+minor version bump per ADR-0007. Receivers must ignore unknown kinds
+on the wire — forward-compat for future additions."""
+
+
+class ChatTurn(BaseModel):
+    """One persisted message in a chat session.
+
+    Stored by `ChatHistoryStore` drivers, surfaced through
+    `ChatSession.history()`, and emitted on the chat-http wire.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str
+    session_id: str
+    role: ChatRole
+    content: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    run_id: str | None = None
+    """Links assistant turns (and the tool turns produced inside them)
+    back to the AgentForge run that emitted them. None for user /
+    system turns."""
+    tool_calls: tuple[ToolCall, ...] = ()
+    tool_call_id: str | None = None
+    tokens_in: int = Field(default=0, ge=0)
+    tokens_out: int = Field(default=0, ge=0)
+    cost_usd: float = Field(default=0.0, ge=0.0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SessionInfo(BaseModel):
+    """Session-level metadata returned by `list_sessions` /
+    `delete_session` / `update_session_metadata`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str
+    owner: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    last_active_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    turn_count: int = Field(default=0, ge=0)
+    total_cost_usd: float = Field(default=0.0, ge=0.0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatChunk(BaseModel):
+    """One streaming chunk emitted by `ChatSession.stream()` /
+    `ChatServer` SSE+WS."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    kind: ChatChunkKind
+    content: str | dict[str, Any] | None = None
+    cumulative_text: str | None = None
+    turn_id: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatResponse(BaseModel):
+    """Aggregated response returned by `ChatSession.send()`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    content: str
+    turn_id: str
+    run_id: str
+    tool_calls: tuple[ToolCall, ...] = ()
+    tokens_in: int = Field(default=0, ge=0)
+    tokens_out: int = Field(default=0, ge=0)
+    cost_usd: float = Field(default=0.0, ge=0.0)
+    duration_ms: int = Field(default=0, ge=0)
+    finish_reason: str = "completed"

--- a/packages/agentforge-core/tests/unit/test_chat_conformance.py
+++ b/packages/agentforge-core/tests/unit/test_chat_conformance.py
@@ -1,0 +1,124 @@
+"""Chat conformance harness — exercises (feat-020).
+
+Uses an inline simple in-memory store to validate the harness
+itself behaves. The shipped `InMemoryChatHistory` in
+`agentforge-chat` runs the same harness in chunk 2.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+import pytest
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
+from agentforge_core.testing import (
+    run_chat_history_conformance,
+    run_truncation_conformance,
+)
+from agentforge_core.values.chat import ChatTurn, SessionInfo
+
+
+class _DictHistory(ChatHistoryStore):
+    """Tiny dict-backed in-memory store used only to exercise the
+    conformance harness."""
+
+    def __init__(self) -> None:
+        self._turns: list[ChatTurn] = []
+        self._meta: dict[str, dict[str, Any]] = {}
+        self._owners: dict[str, str | None] = {}
+
+    async def append(self, turn: ChatTurn) -> None:
+        self._turns.append(turn)
+
+    async def load(
+        self,
+        session_id: str,
+        *,
+        limit: int | None = None,
+        before: datetime | None = None,
+        after: datetime | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        out = [t for t in self._turns if t.session_id == session_id]
+        if before is not None:
+            out = [t for t in out if t.timestamp < before]
+        if after is not None:
+            out = [t for t in out if t.timestamp > after]
+        if roles is not None:
+            out = [t for t in out if t.role in roles]
+        out.sort(key=lambda t: t.timestamp)
+        if limit is not None:
+            out = out[:limit]
+        return out
+
+    async def count(self, session_id: str) -> int:
+        return sum(1 for t in self._turns if t.session_id == session_id)
+
+    async def delete_session(self, session_id: str) -> int:
+        removed = sum(1 for t in self._turns if t.session_id == session_id)
+        self._turns = [t for t in self._turns if t.session_id != session_id]
+        self._meta.pop(session_id, None)
+        self._owners.pop(session_id, None)
+        return removed
+
+    async def list_sessions(
+        self,
+        *,
+        owner: str | None = None,
+        limit: int = 100,
+        before: datetime | None = None,
+    ) -> list[SessionInfo]:
+        ids = {t.session_id for t in self._turns}
+        out: list[SessionInfo] = []
+        for sid in ids:
+            o = self._owners.get(sid)
+            if owner is not None and o != owner:
+                continue
+            out.append(
+                SessionInfo(
+                    id=sid,
+                    owner=o,
+                    metadata=self._meta.get(sid, {}),
+                    turn_count=sum(1 for t in self._turns if t.session_id == sid),
+                )
+            )
+        if before is not None:
+            out = [s for s in out if s.last_active_at < before]
+        return out[:limit]
+
+    async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        bag = self._meta.setdefault(session_id, {})
+        for k, v in metadata.items():
+            bag[k] = v
+        if "owner" in metadata:
+            self._owners[session_id] = metadata["owner"]
+
+    async def expire_before(self, cutoff: datetime) -> int:
+        del cutoff
+        return 0  # no TTL
+
+    async def close(self) -> None:
+        return None
+
+
+class _Keep2(HistoryTruncationStrategy):
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del next_user_message, context
+        return all_turns[-2:]
+
+
+@pytest.mark.asyncio
+async def test_chat_history_conformance_passes_on_dict_store() -> None:
+    await run_chat_history_conformance(_DictHistory())
+
+
+@pytest.mark.asyncio
+async def test_truncation_conformance_passes_on_simple_strategy() -> None:
+    await run_truncation_conformance(_Keep2())

--- a/packages/agentforge-core/tests/unit/test_chat_values.py
+++ b/packages/agentforge-core/tests/unit/test_chat_values.py
@@ -1,0 +1,45 @@
+"""Unit tests for chat value models (feat-020)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.values.chat import ChatChunk, ChatResponse, ChatTurn, SessionInfo
+from pydantic import ValidationError
+
+
+def test_chat_turn_minimal() -> None:
+    t = ChatTurn(id="01HX", session_id="s1", role="user", content="hi")
+    assert t.tokens_in == 0
+    assert t.cost_usd == 0.0
+    assert t.run_id is None
+
+
+def test_chat_turn_is_frozen() -> None:
+    t = ChatTurn(id="01HX", session_id="s1", role="user", content="hi")
+    with pytest.raises(ValidationError):
+        t.content = "boom"  # type: ignore[misc]
+
+
+def test_chat_turn_role_closed_enum() -> None:
+    with pytest.raises(ValidationError):
+        ChatTurn(id="01HX", session_id="s1", role="root", content="hi")  # type: ignore[arg-type]
+
+
+def test_chat_chunk_kind_closed_enum() -> None:
+    ChatChunk(kind="text", turn_id="t1", content="hello")
+    with pytest.raises(ValidationError):
+        ChatChunk(kind="snore", turn_id="t1")  # type: ignore[arg-type]
+
+
+def test_session_info_defaults() -> None:
+    info = SessionInfo(id="s1")
+    assert info.owner is None
+    assert info.turn_count == 0
+    assert info.total_cost_usd == 0.0
+
+
+def test_chat_response_round_trip() -> None:
+    r = ChatResponse(content="ok", turn_id="t", run_id="r")
+    blob = r.model_dump_json()
+    restored = ChatResponse.model_validate_json(blob)
+    assert restored == r

--- a/packages/agentforge-core/tests/unit/test_config_chat.py
+++ b/packages/agentforge-core/tests/unit/test_config_chat.py
@@ -1,0 +1,73 @@
+"""Unit tests for `modules.chat:` schema (feat-020)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.config.schema import (
+    AgentForgeConfig,
+    ChatConfig,
+    ChatSessionConfig,
+    ModulesConfig,
+)
+from pydantic import ValidationError
+
+
+def test_chat_config_defaults() -> None:
+    cfg = ChatConfig()
+    assert cfg.history is None
+    assert cfg.truncation is None
+    assert cfg.session.idempotency_window_s == 60.0
+    assert cfg.session.concurrency == "queue"
+    assert cfg.session.safety_mode == "buffer-then-stream"
+
+
+def test_modules_chat_defaults_to_none() -> None:
+    assert ModulesConfig().chat is None
+
+
+def test_session_rejects_negative_budget() -> None:
+    with pytest.raises(ValidationError):
+        ChatSessionConfig(per_turn_budget_usd=-0.01)
+
+
+def test_session_rejects_invalid_concurrency() -> None:
+    with pytest.raises(ValidationError):
+        ChatSessionConfig(concurrency="discard")  # type: ignore[arg-type]
+
+
+def test_session_rejects_invalid_safety_mode() -> None:
+    with pytest.raises(ValidationError):
+        ChatSessionConfig(safety_mode="dropout")  # type: ignore[arg-type]
+
+
+def test_chat_config_extra_keys_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ChatConfig(unknown_field=1)  # type: ignore[call-arg]
+
+
+def test_full_config_round_trip() -> None:
+    raw = {
+        "modules": {
+            "chat": {
+                "history": {"driver": "sqlite", "config": {"path": "./chat.db"}},
+                "truncation": {
+                    "strategy": "sliding_window",
+                    "config": {"max_turns": 100},
+                },
+                "session": {
+                    "per_turn_budget_usd": 0.5,
+                    "per_session_budget_usd": 5.0,
+                    "idempotency_window_s": 30,
+                    "concurrency": "reject",
+                },
+            }
+        }
+    }
+    cfg = AgentForgeConfig.model_validate(raw)
+    assert cfg.modules.chat is not None
+    assert cfg.modules.chat.history is not None
+    assert cfg.modules.chat.history.driver == "sqlite"
+    assert cfg.modules.chat.truncation is not None
+    assert cfg.modules.chat.truncation.strategy == "sliding_window"
+    assert cfg.modules.chat.session.per_turn_budget_usd == 0.5
+    assert cfg.modules.chat.session.concurrency == "reject"

--- a/packages/agentforge-core/tests/unit/test_contracts_chat.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_chat.py
@@ -1,0 +1,97 @@
+"""Unit tests for chat contracts (feat-020)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
+from agentforge_core.values.chat import ChatTurn, SessionInfo
+
+
+def test_chat_history_store_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        ChatHistoryStore()  # type: ignore[abstract]
+
+
+def test_truncation_strategy_cannot_be_instantiated() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        HistoryTruncationStrategy()  # type: ignore[abstract]
+
+
+class _StubHistory(ChatHistoryStore):
+    async def append(self, turn: ChatTurn) -> None:
+        return None
+
+    async def load(
+        self,
+        session_id: str,
+        *,
+        limit: int | None = None,
+        before: datetime | None = None,
+        after: datetime | None = None,
+        roles: list[str] | None = None,
+    ) -> list[ChatTurn]:
+        del session_id, limit, before, after, roles
+        return []
+
+    async def count(self, session_id: str) -> int:
+        del session_id
+        return 0
+
+    async def delete_session(self, session_id: str) -> int:
+        del session_id
+        return 0
+
+    async def list_sessions(
+        self,
+        *,
+        owner: str | None = None,
+        limit: int = 100,
+        before: datetime | None = None,
+    ) -> list[SessionInfo]:
+        del owner, limit, before
+        return []
+
+    async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        del session_id, metadata
+
+    async def expire_before(self, cutoff: datetime) -> int:
+        del cutoff
+        return 0
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_stub_history_satisfies_contract() -> None:
+    store = _StubHistory()
+    assert isinstance(store, ChatHistoryStore)
+    await store.append(
+        ChatTurn(id="x", session_id="s", role="user", content="hi", timestamp=datetime.now(UTC))
+    )
+    assert await store.count("s") == 0
+    assert store.capabilities() == set()
+    assert store.supports("ttl") is False
+
+
+class _NoOpTruncation(HistoryTruncationStrategy):
+    async def select(
+        self,
+        all_turns: list[ChatTurn],
+        next_user_message: str,
+        context: Mapping[str, Any],
+    ) -> list[ChatTurn]:
+        del next_user_message, context
+        return list(all_turns)
+
+
+@pytest.mark.asyncio
+async def test_stub_truncation_works() -> None:
+    s = _NoOpTruncation()
+    turns = [ChatTurn(id=str(i), session_id="s", role="user", content=str(i)) for i in range(3)]
+    out = await s.select(turns, "next", {})
+    assert out == turns

--- a/packages/agentforge/src/agentforge/resolver_register.py
+++ b/packages/agentforge/src/agentforge/resolver_register.py
@@ -27,3 +27,15 @@ def register_task(name: str) -> Callable[[T], T]:
     """Register a pipeline `Task` class under `(tasks, name)` in the
     global resolver. feat-015."""
     return register("tasks", name)
+
+
+def register_chat_history(name: str) -> Callable[[T], T]:
+    """Register a `ChatHistoryStore` driver under
+    `(chat.history, name)`. feat-020."""
+    return register("chat.history", name)
+
+
+def register_chat_truncation(name: str) -> Callable[[T], T]:
+    """Register a `HistoryTruncationStrategy` under
+    `(chat.truncation, name)`. feat-020."""
+    return register("chat.truncation", name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "agentforge-guard-nemo",
     "agentforge-guard-llamaguard",
     "agentforge-mcp",
+    "agentforge-chat",
 ]
 
 [tool.uv.workspace]
@@ -57,6 +58,7 @@ agentforge-guard-presidio = { workspace = true }
 agentforge-guard-nemo = { workspace = true }
 agentforge-guard-llamaguard = { workspace = true }
 agentforge-mcp = { workspace = true }
+agentforge-chat = { workspace = true }
 
 [tool.uv]
 package = false   # the root is a virtual workspace; not itself published
@@ -259,6 +261,7 @@ testpaths = [
     "packages/agentforge-guard-nemo/tests",
     "packages/agentforge-guard-llamaguard/tests",
     "packages/agentforge-mcp/tests",
+    "packages/agentforge-chat/tests",
     "tests",
 ]
 markers = [
@@ -303,6 +306,7 @@ source = [
     "packages/agentforge-guard-nemo/src",
     "packages/agentforge-guard-llamaguard/src",
     "packages/agentforge-mcp/src",
+    "packages/agentforge-chat/src",
 ]
 branch = true
 parallel = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "agentforge-guard-llamaguard",
     "agentforge-mcp",
     "agentforge-chat",
+    "agentforge-chat-http",
 ]
 
 [tool.uv.workspace]
@@ -59,6 +60,7 @@ agentforge-guard-nemo = { workspace = true }
 agentforge-guard-llamaguard = { workspace = true }
 agentforge-mcp = { workspace = true }
 agentforge-chat = { workspace = true }
+agentforge-chat-http = { workspace = true }
 
 [tool.uv]
 package = false   # the root is a virtual workspace; not itself published
@@ -262,6 +264,7 @@ testpaths = [
     "packages/agentforge-guard-llamaguard/tests",
     "packages/agentforge-mcp/tests",
     "packages/agentforge-chat/tests",
+    "packages/agentforge-chat-http/tests",
     "tests",
 ]
 markers = [
@@ -307,6 +310,7 @@ source = [
     "packages/agentforge-guard-llamaguard/src",
     "packages/agentforge-mcp/src",
     "packages/agentforge-chat/src",
+    "packages/agentforge-chat-http/src",
 ]
 branch = true
 parallel = true

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "agentforge",
     "agentforge-bedrock",
     "agentforge-chat",
+    "agentforge-chat-http",
     "agentforge-core",
     "agentforge-eval-geval",
     "agentforge-guard-llamaguard",
@@ -87,6 +88,29 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.20" },
 ]
 provides-extras = ["sqlite"]
+
+[[package]]
+name = "agentforge-chat-http"
+version = "0.0.0"
+source = { editable = "packages/agentforge-chat-http" }
+dependencies = [
+    { name = "agentforge" },
+    { name = "agentforge-chat" },
+    { name = "agentforge-core" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge", editable = "packages/agentforge" },
+    { name = "agentforge-chat", editable = "packages/agentforge-chat" },
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "uvicorn", specifier = ">=0.32" },
+]
 
 [[package]]
 name = "agentforge-core"
@@ -277,6 +301,7 @@ dependencies = [
     { name = "agentforge" },
     { name = "agentforge-bedrock" },
     { name = "agentforge-chat" },
+    { name = "agentforge-chat-http" },
     { name = "agentforge-core" },
     { name = "agentforge-eval-geval" },
     { name = "agentforge-guard-llamaguard" },
@@ -311,6 +336,7 @@ requires-dist = [
     { name = "agentforge", editable = "packages/agentforge" },
     { name = "agentforge-bedrock", editable = "packages/agentforge-bedrock" },
     { name = "agentforge-chat", editable = "packages/agentforge-chat" },
+    { name = "agentforge-chat-http", editable = "packages/agentforge-chat-http" },
     { name = "agentforge-core", editable = "packages/agentforge-core" },
     { name = "agentforge-eval-geval", editable = "packages/agentforge-eval-geval" },
     { name = "agentforge-guard-llamaguard", editable = "packages/agentforge-guard-llamaguard" },
@@ -508,6 +534,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -852,6 +890,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -983,6 +1037,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
     { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
     { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1982,6 +2073,18 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "stevedore"
 version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2063,6 +2166,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 members = [
     "agentforge",
     "agentforge-bedrock",
+    "agentforge-chat",
     "agentforge-core",
     "agentforge-eval-geval",
     "agentforge-guard-llamaguard",
@@ -64,6 +65,28 @@ requires-dist = [
     { name = "aioboto3", specifier = ">=13.0" },
     { name = "botocore", specifier = ">=1.35" },
 ]
+
+[[package]]
+name = "agentforge-chat"
+version = "0.0.0"
+source = { editable = "packages/agentforge-chat" }
+dependencies = [
+    { name = "agentforge" },
+    { name = "agentforge-core" },
+]
+
+[package.optional-dependencies]
+sqlite = [
+    { name = "aiosqlite" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge", editable = "packages/agentforge" },
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.20" },
+]
+provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-core"
@@ -253,6 +276,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "agentforge" },
     { name = "agentforge-bedrock" },
+    { name = "agentforge-chat" },
     { name = "agentforge-core" },
     { name = "agentforge-eval-geval" },
     { name = "agentforge-guard-llamaguard" },
@@ -286,6 +310,7 @@ dev = [
 requires-dist = [
     { name = "agentforge", editable = "packages/agentforge" },
     { name = "agentforge-bedrock", editable = "packages/agentforge-bedrock" },
+    { name = "agentforge-chat", editable = "packages/agentforge-chat" },
     { name = "agentforge-core", editable = "packages/agentforge-core" },
     { name = "agentforge-eval-geval", editable = "packages/agentforge-eval-geval" },
     { name = "agentforge-guard-llamaguard", editable = "packages/agentforge-guard-llamaguard" },


### PR DESCRIPTION
## Summary

- Ships canonical **feat-020 v0.2 scope**: three new workspace members (`agentforge-core` extensions + `agentforge-chat` + `agentforge-chat-http`) wrap one-shot `Agent` into a multi-turn, stateful chat session with multi-tenant isolation, per-turn / per-session budgets, idempotency, input/output guardrails, and a FastAPI REST + WS + SSE server.
- v0.3 follow-ups deferred per the scope-preference exception (one half clearly riskier): `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-slack` reference adapter, real per-token streaming through the strategy loop, cross-process per-session locking, provider-aware tokenisation.
- Six chunked commits, gate green at every step (ruff + mypy --strict + bandit + pytest + ≥90 % coverage on every package).

## Chunks

| Chunk | Commit | What landed |
|---|---|---|
| 1 | `2bd8f38` | `ChatHistoryStore` + `HistoryTruncationStrategy` ABCs; `ChatTurn` / `SessionInfo` / `ChatChunk` / `ChatResponse` frozen value models; `run_chat_history_conformance` + `run_truncation_conformance` harnesses. |
| 2 | `d6d0a73` | New `agentforge-chat` workspace member: `InMemoryChatHistory` + `SqliteChatHistory` (mirrors `SqliteMemoryStore`); four truncation strategies (sliding-window / token-budget / summarise-oldest / hybrid) with pair-atomicity invariant; entry-points under `agentforge.chat.history` / `agentforge.chat.truncation`; `manifest.yaml` for `agentforge add module chat`. Workspace + pre-commit + CI extended (dual-update rule). |
| 3 | `e4ff78d` | `ChatSession` (send + stream + history + reset + close + idempotency + per-turn/per-session budgets + guardrails wired). Per-session `asyncio.Lock` via `WeakValueDictionary`; LRU+TTL idempotency cache; sentence-segmenting `stream()` with buffer-then-stream semantics. |
| 4 | `200b38e` | New `agentforge-chat-http` workspace member: FastAPI `ChatServer` with REST + WS + SSE + bearer auth + cross-owner 403 + token-bucket rate limiting. `BearerAuthPolicy` + `EnvBearerAuth(token_env_var)` placeholder (refactors to feat-014's `AuthPolicy` when shipped). |
| 5 | `1369c95` | `modules.chat:` config schema (`ChatConfig` / `ChatHistoryDriverConfig` / `ChatTruncationConfig` / `ChatSessionConfig`) + `_validate_driver` validation hook + `build_chat_session_from_config(config, agent)` + `register_chat_history` / `register_chat_truncation` resolver helpers. |
| 6 | `b019c13` | Spec status → shipped + §11 Implementation Status + §12 Runbook + roadmap + CHANGELOG + state. |

## Deviations from the design

- **Streaming is buffer-then-stream only.** Strategy ABC has no `stream()` method yet; v0.2 sentence-segments the buffered assistant turn and emits `ChatChunk(kind="text")` chunks + a final `done` (or `error`) sentinel. Wire format is correct; real per-token streaming becomes a no-API-break enhancement later.
- **Cancellation is pre-LLM only.** Honoured between `history.load()` and `agent.run()`; WS disconnect propagates `cancellation.set()`. Mid-LLM cancellation needs the same strategy-streaming work.
- **Single-process locking.** Cross-process Redis lock is a v0.3 follow-up alongside the Redis driver.
- **`BearerAuthPolicy` is a v0.2-local stub.** feat-014's real `AuthPolicy` contract hasn't shipped yet; the chat-http policy becomes a thin adapter when it does.
- **Approximate token counting in `TokenBudget`** (4 chars ≈ 1 token). Provider-aware tokenisation deferred.
- **Postgres / Redis history drivers + Slack reference adapter + TypeScript port** all deferred (recorded in spec §11 Open items).

## Test plan

- [x] `uv run pre-commit run --all-files` green on every chunk (ruff format + ruff check + mypy --strict + bandit + pytest + ≥90 % coverage on touched packages).
- [x] Core: `test_contracts_chat.py` (ABC instantiation guards + stub satisfies contract), `test_chat_values.py` (frozen + Literal validation + JSON round-trip), `test_chat_conformance.py` (inline dict-backed store passes the harness; simple truncation strategy passes).
- [x] `agentforge-chat`: `test_in_memory_history.py` (full conformance), `test_sqlite_history.py` (full conformance + `:memory:`), `test_truncation.py` (all four strategies pass conformance + behavioural cases + pair-atomicity), `test_session.py` (14 cases covering single-turn, multi-turn memory, truncation wiring, idempotency, per-turn/per-session budgets, concurrent-send serialisation, reset, on_turn hook, stream chunks, stream error chunk, pre-LLM cancellation, custom truncation, close idempotency), `test_chat_build.py` (config-driven resolution).
- [x] `agentforge-chat-http`: `test_chat_server.py` (13 cases covering healthz, create-session, 401 / 403 / 429, POST messages JSON + SSE, GET history, DELETE cascades, list filtered by owner, WebSocket round-trip, missing env var rejects all tokens).
- [x] Core: `test_config_chat.py` (defaults + extra=forbid + Literal enums + budget non-negative + full round-trip).
- [ ] (deferred) Live integration smoke against a real LLM provider + scaffolded project — documented in spec §11 Open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)