### PR TITLE
feat(a2a): A2A protocol — agent_call client + A2AServer + AuthPolicy refactor (feat-014)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,92 +1,71 @@
 ---
-feature: feat-014
-state: in_progress
+feature: none
+state: idle
 branch: feat/014-a2a-protocol
-started_at: 2026-05-12
+started_at: null
 last_milestone_at: 2026-05-12
-last_shipped: feat-020 v0.2 scope shipped via PR #26 (merged 2026-05-12)
+last_shipped: feat-014 shipped via PR #27 (open for review)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-[`feat-014 — A2A protocol`](../../docs/features/feat-014-a2a-protocol.md)
-
-Full-spec scope. 6 chunks:
-
-1. Canonical `AuthPolicy` ABC + `Principal` value in
-   `agentforge-core` + A2A exceptions; `EnvBearerAuth` in
-   `agentforge`; chat-http refactor.
-2. `agentforge-a2a` package skeleton + value types
-   (`A2AResponse`, peer/expose config) + `A2AClientRunner` /
-   `A2AServerRunner` Protocols.
-3. `agent_call(target, payload)` client + `BearerAuth` /
-   `MutualTLSAuth` + `FakeA2AClientRunner` for tests.
-4. `A2AServer` FastAPI app + bearer auth + parent_run_id
-   propagation + budget cap; `A2ABridge.from_config`.
-5. `A2AConfig` Pydantic schema + module-schemas validation hook.
-6. Docs (spec §10/§11) + roadmap + CHANGELOG + state + PR.
+*None — awaiting next pick.*
 
 ## Last shipped
 
-[`feat-020 — Chat agents (v0.2 scope)`](../../docs/features/feat-020-chat-agents.md)
-opened as PR #26 across three packages:
+[`feat-014 — A2A protocol`](../../docs/features/feat-014-a2a-protocol.md)
+opened as PR #27. Two halves shipped together:
 
-- **`agentforge-core` extensions**: `ChatHistoryStore` and
-  `HistoryTruncationStrategy` ABCs; `ChatTurn`, `SessionInfo`,
-  `ChatChunk`, `ChatResponse` frozen value models;
-  `run_chat_history_conformance` / `run_truncation_conformance`
-  harnesses; `modules.chat:` schema (`ChatConfig` /
-  `ChatHistoryDriverConfig` / `ChatTruncationConfig` /
-  `ChatSessionConfig`) + `_validate_driver` helper.
-- **`agentforge-chat` (new)**: `ChatSession` (send + stream +
-  history + reset + idempotency + per-turn/per-session budgets +
-  input/output guardrails); `InMemoryChatHistory` +
-  `SqliteChatHistory` drivers; four truncation strategies
-  (sliding-window / token-budget / summarise-oldest / hybrid);
-  per-session lock registry + LRU+TTL idempotency cache;
-  `build_chat_session_from_config(config, agent)`.
-- **`agentforge-chat-http` (new)**: FastAPI `ChatServer` with
-  REST + WebSocket + SSE + bearer-auth + token-bucket rate
-  limiting + cross-owner 403; `BearerAuthPolicy` ABC +
-  `EnvBearerAuth` placeholder pending feat-014.
+- **Canonical auth refactor** in `agentforge-core`:
+  - `agentforge_core.contracts.auth.AuthPolicy` ABC.
+  - `agentforge_core.values.auth.Principal` frozen dataclass.
+  - `A2ACallError` / `A2AAuthError` / `A2ATimeout` exceptions.
+  - `agentforge.auth.EnvBearerAuth` concrete impl;
+    `chat-http` `BearerAuthPolicy` aliased to the canonical
+    contract.
+- **New `agentforge-a2a` package**:
+  - `agent_call(target, payload, *, peers, timeout_s,
+    budget_usd, budget)` outgoing client.
+  - `A2APeer.from_config(...)` + bearer + mTLS credentials.
+  - `A2AServer(agent, *, auth, endpoints)` FastAPI app with
+    `POST /a2a/v1/calls` + `GET /a2a/v1/info`, run_id chain
+    via `X-AgentForge-Run-Id`, optional budget cap via
+    `X-AgentForge-Budget-Usd`.
+  - `A2ABridge.from_config(config, ...)` orchestrator with
+    `start()` / `close()` lifecycle.
+  - `A2AConfig` Pydantic schema; `A2ABridge.config_schema =
+    A2AConfig`.
+  - Production transport runners scaffolded with
+    `# pragma: no cover` (mirrors feat-013 MCP).
+  - Entry point `agentforge.protocols.a2a`; `manifest.yaml`
+    for `agentforge add module a2a`.
 
-Deviations recorded in spec §11:
+Deviations recorded in spec §10:
 
-- Streaming is buffer-then-stream only (strategy ABC has no
-  `stream()` method yet; sentence-segmented chunks ship the
-  correct wire format today).
-- Cancellation is pre-LLM only (WS disconnect propagates).
-- Single-process locking only (cross-process Redis lock is
-  v0.3).
-- `BearerAuthPolicy` is a v0.2 stub; becomes a thin adapter
-  on top of feat-014's `AuthPolicy` when that lands.
-- Approximate token counting in `TokenBudget`.
-
-Deferred to v0.3 follow-up PRs:
-
-- `agentforge-chat-history-postgres` driver.
-- `agentforge-chat-history-redis` driver.
-- `agentforge-chat-slack` reference channel adapter.
-- Real per-token streaming through the strategy loop.
-- Cross-process per-session locking.
-- Provider-aware tokenisation.
-- TS port.
+- Production HTTP runner pending live integration tests.
+- FastAPI used (matches chat-http precedent) instead of bare
+  Starlette as spec §4.4 hinted.
+- Outgoing auth is dict-driven (no policy abstraction);
+  server-side bearer is via the canonical `AuthPolicy`.
+- A2A discovery, bi-directional streaming, TS port deferred.
 
 ### Previously
 
-[`feat-015 — Pipeline & deterministic tasks`](../../docs/features/feat-015-pipeline-and-tasks.md)
-shipped in PR #25 (merged 2026-05-12).
+[`feat-020 — Chat agents (v0.2 scope)`](../../docs/features/feat-020-chat-agents.md)
+shipped in PR #26 (merged 2026-05-12).
 
 ## Next pick candidates (canonical numbering)
 
-- **feat-014** — A2A (agent-to-agent) protocol. v0.4-target.
+- **feat-014 v0.4.1 follow-ups** — production HTTP runner
+  against a real A2A peer; A2A discovery / registry;
+  bi-directional streaming.
 - **feat-020 v0.3 follow-ups** — postgres / redis / slack
-  drivers, real streaming, cross-process lock, provider-aware
-  tokeniser.
-- Vendor observability sub-feats (langfuse/phoenix/evidently/
-  statsd).
+  drivers, real per-token streaming, cross-process locking,
+  provider-aware tokeniser.
+- Vendor observability sub-feats
+  (langfuse/phoenix/evidently/statsd).
 - Backfill chore PRs (Runbooks for feat-001–005).
 
 User selects on session resume.

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,17 +1,32 @@
 ---
-feature: none
-state: idle
-branch: feat/020-chat-agents-v02
-started_at: null
+feature: feat-014
+state: in_progress
+branch: feat/014-a2a-protocol
+started_at: 2026-05-12
 last_milestone_at: 2026-05-12
-last_shipped: feat-020 v0.2 scope shipped via PR #26 (open for review)
+last_shipped: feat-020 v0.2 scope shipped via PR #26 (merged 2026-05-12)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-*None — awaiting next pick.*
+[`feat-014 — A2A protocol`](../../docs/features/feat-014-a2a-protocol.md)
+
+Full-spec scope. 6 chunks:
+
+1. Canonical `AuthPolicy` ABC + `Principal` value in
+   `agentforge-core` + A2A exceptions; `EnvBearerAuth` in
+   `agentforge`; chat-http refactor.
+2. `agentforge-a2a` package skeleton + value types
+   (`A2AResponse`, peer/expose config) + `A2AClientRunner` /
+   `A2AServerRunner` Protocols.
+3. `agent_call(target, payload)` client + `BearerAuth` /
+   `MutualTLSAuth` + `FakeA2AClientRunner` for tests.
+4. `A2AServer` FastAPI app + bearer auth + parent_run_id
+   propagation + budget cap; `A2ABridge.from_config`.
+5. `A2AConfig` Pydantic schema + module-schemas validation hook.
+6. Docs (spec §10/§11) + roadmap + CHANGELOG + state + PR.
 
 ## Last shipped
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1276,3 +1276,65 @@ Tooling notes:
   uvicorn / httpx into the shared venv.
 
 Ready to push and raise PR #26.
+
+
+## 2026-05-12T16:00 — feat-014 (A2A protocol) shipped
+
+Branch `feat/014-a2a-protocol` opens PR #27. Full-spec scope:
+canonical `AuthPolicy` ABC lifted from feat-020's chat-http stub
+into `agentforge-core`, plus a new `agentforge-a2a` workspace
+member shipping client + server + bridge.
+
+Chunks landed:
+
+- chunk 1 (`76e2373`): `agentforge_core.contracts.auth.AuthPolicy`
+  + `Principal` + `A2ACallError` / `A2AAuthError` /
+  `A2ATimeout` exceptions + `agentforge.auth.EnvBearerAuth` +
+  chat-http `BearerAuthPolicy` aliased to the canonical contract.
+- chunk 2 (`b09915b`): new `agentforge-a2a` workspace member;
+  `A2AResponse` / `A2APeerConfig` / `A2AEndpointConfig` /
+  `A2AExposeConfig` values; `A2AClientRunner` /
+  `A2AServerRunner` Protocols with `# pragma: no cover`
+  production stubs (mirrors feat-013 MCP); manifest.yaml +
+  entry-point.
+- chunk 3 (`06f4ba6`): `agent_call` client + `BearerAuth`,
+  `MutualTLSAuth`, `build_outgoing_auth` credentials;
+  `FakeA2AClientRunner` / `FakeA2AServerRunner` in src/
+  for tests + downstream reuse; run_id + budget header
+  propagation; 19 unit tests.
+- chunk 4 (`4197535`): `A2AServer` FastAPI app with
+  `POST /a2a/v1/calls` + `GET /a2a/v1/info`, bearer auth
+  via canonical `AuthPolicy`, parent_run_id chain, budget cap;
+  `A2ABridge.from_config` orchestrator with start/close
+  lifecycle; 15 unit tests (server + bridge).
+- chunk 5 (`f925e0b`): `A2AConfig` Pydantic schema +
+  `A2ABridge.config_schema = A2AConfig` so feat-012's
+  module-schema validator enforces shape; 6 config tests.
+- chunk 6 (about-to-commit): spec status → shipped + §10
+  Implementation Status + §11 Runbook; features README;
+  roadmap; CHANGELOG; state refreshed.
+
+Deviations captured in spec §10:
+
+- Production HTTP runner scoped to `# pragma: no cover`
+  until live integration test lands.
+- FastAPI used for server (matches chat-http precedent;
+  spec §4.4 hinted at Starlette).
+- Outgoing auth is dict-driven (no policy abstraction).
+- A2A discovery, bi-directional streaming, TS port deferred.
+
+Tooling notes:
+
+- mTLS test fixture uses openssl via subprocess to generate
+  a fresh self-signed cert at test time (avoids hardcoded
+  PEM blobs that LibreSSL vs OpenSSL parse differently).
+- Filename collision avoided: a2a's server test is
+  `test_a2a_server.py` (mcp + chat-http already own
+  `test_server.py` / `test_chat_server.py`).
+- B008 (`Depends` in defaults) noqa'd on every FastAPI
+  route function; standard FastAPI idiom.
+- B025 caught a duplicate `except TimeoutError` block —
+  Python 3.11+ aliases asyncio.TimeoutError to the builtin
+  TimeoutError, so a single except clause catches both.
+
+Ready to push and raise PR #27.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
       - name: Mypy strict
-        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
+        run: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src packages/agentforge-a2a/src
       - name: Bandit
         # -c pyproject.toml so [tool.bandit] (skips B101) is honoured;
         # without it, the conformance suite's asserts in
         # agentforge_core.testing.conformance trip B101.
-        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
+        run: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src packages/agentforge-a2a/src
 
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -61,7 +61,7 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
       - name: Pytest unit
-        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit tests/unit
+        run: uv run pytest -q -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit packages/agentforge-a2a/tests/unit tests/unit
       - name: Pytest integration
         run: uv run pytest -q -m "not live" packages/agentforge-bedrock/tests/integration tests/integration
       - name: Coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       # errors that file-scope mypy misses.
       - id: mypy-strict
         name: mypy --strict
-        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
+        entry: uv run mypy --strict packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src packages/agentforge-a2a/src
         language: system
         types: [python]
         pass_filenames: false
@@ -82,7 +82,7 @@ repos:
       - id: bandit
         name: bandit security lint
         # -c pyproject.toml so bandit reads [tool.bandit] (skips B101 etc.)
-        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src
+        entry: uv run bandit -q -c pyproject.toml -r packages/agentforge-core/src packages/agentforge/src packages/agentforge-bedrock/src packages/agentforge-memory-sqlite/src packages/agentforge-memory-neo4j/src packages/agentforge-memory-surrealdb/src packages/agentforge-memory-postgres/src packages/agentforge-eval-geval/src packages/agentforge-otel/src packages/agentforge-testing/src packages/agentforge-guard-llmguard/src packages/agentforge-guard-presidio/src packages/agentforge-guard-nemo/src packages/agentforge-guard-llamaguard/src packages/agentforge-mcp/src packages/agentforge-chat/src packages/agentforge-chat-http/src packages/agentforge-a2a/src
         language: system
         types: [python]
         pass_filenames: false
@@ -92,7 +92,7 @@ repos:
       # are still empty. Real failures (1, 2, 3, 4) still block.
       - id: pytest-unit
         name: pytest unit
-        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
+        entry: bash -c 'uv run pytest -q -x -m "not live" packages/agentforge-core/tests packages/agentforge/tests packages/agentforge-bedrock/tests/unit packages/agentforge-memory-sqlite/tests/unit packages/agentforge-memory-neo4j/tests/unit packages/agentforge-memory-surrealdb/tests/unit packages/agentforge-memory-postgres/tests/unit packages/agentforge-eval-geval/tests/unit packages/agentforge-otel/tests/unit packages/agentforge-testing/tests/unit packages/agentforge-guard-llmguard/tests/unit packages/agentforge-guard-presidio/tests/unit packages/agentforge-guard-nemo/tests/unit packages/agentforge-guard-llamaguard/tests/unit packages/agentforge-mcp/tests/unit packages/agentforge-chat/tests/unit packages/agentforge-chat-http/tests/unit packages/agentforge-a2a/tests/unit tests/unit; code=$?; [ $code -eq 0 ] || [ $code -eq 5 ] && exit 0 || exit $code'
         language: system
         always_run: true
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,70 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-014 — A2A protocol (full spec).** Cross-framework
+  agent calls over HTTP. Lifts feat-020's `BearerAuthPolicy`
+  stub into a canonical `AuthPolicy` ABC shared by chat-http
+  and the new `agentforge-a2a` package.
+
+  *Canonical auth contracts (`agentforge-core`):*
+  - `agentforge_core.contracts.auth.AuthPolicy` ABC.
+  - `agentforge_core.values.auth.Principal` frozen dataclass.
+  - `A2ACallError`, `A2AAuthError`, `A2ATimeout` exception
+    subclasses of `AgentForgeError`.
+
+  *Concrete bearer impl (`agentforge`):*
+  - `agentforge.auth.EnvBearerAuth(token_env_var)` — top-level
+    re-export at `agentforge.EnvBearerAuth`.
+
+  *chat-http refactor:*
+  - `agentforge_chat_http.BearerAuthPolicy` is now an alias
+    for the canonical `AuthPolicy`; `Principal` +
+    `EnvBearerAuth` re-exported from the new locations. v0.2
+    consumers see no break.
+
+  *New `agentforge-a2a` package:*
+  - `agent_call(target, payload, *, peers, timeout_s,
+    budget_usd, budget)` — outgoing A2A client. Wire format
+    is `POST /a2a/v1/calls` with JSON body + bearer / mTLS
+    auth headers. `X-AgentForge-Run-Id` propagates the
+    caller's `RunContext.run_id` for parent_run_id chains;
+    `X-AgentForge-Budget-Usd` caps the callee's budget.
+  - `A2APeer.from_config(...)` resolves a per-peer config dict
+    (bearer or mTLS) into a runner-ready peer.
+  - `agentforge_a2a.auth.{BearerAuth, MutualTLSAuth,
+    build_outgoing_auth, ClientAuth}` — client-side
+    credentials. mTLS builds an `ssl.SSLContext` from
+    cert/key (+ optional CA) paths.
+  - `A2AServer(agent, *, auth, endpoints, task_builder, host,
+    port, runner)` — FastAPI app exposing the agent.
+    Endpoints: `POST /a2a/v1/calls`, `GET /a2a/v1/info`.
+    Bearer auth via the canonical `AuthPolicy`. Per-call
+    budget cap is applied + restored.
+  - `A2ABridge.from_config(config, *, agent, auth,
+    client_runner, server_runner)` orchestrator with
+    `start()` / `close()` lifecycle.
+  - `A2AConfig` Pydantic schema (`A2ABridge.config_schema =
+    A2AConfig`) for `agentforge config validate`.
+  - Production runners (`_HTTPXClientRunner`,
+    `_UvicornServerRunner`) scaffolded with
+    `# pragma: no cover` until live integration tests land —
+    same pattern as feat-013 MCP.
+  - `FakeA2AClientRunner` / `FakeA2AServerRunner` in
+    `src/_inmem_runner.py` for tests + downstream integration
+    reuse.
+  - Entry point `agentforge.protocols.a2a =
+    agentforge_a2a.bridge:A2ABridge`; `manifest.yaml` so
+    `agentforge add module a2a` lights it up.
+
+  *v0.4.1 follow-ups (deferred):*
+  - Production HTTP runner against a real A2A peer.
+  - A2A discovery / registry (spec §9).
+  - Bi-directional streaming (spec §9).
+  - TypeScript port.
+
+  Shipped via PR #27. See spec
+  `docs/features/feat-014-a2a-protocol.md` §10–§11.
+
 - **feat-020 — Chat agents (Python v0.2 scope).** Three new
   workspace members + locked contracts in core. Wraps the
   one-shot `Agent` into a multi-turn, stateful conversation

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -61,7 +61,7 @@
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
 | **feat-013** | MCP integration — `MCPServerClient` (stdio + HTTP/SSE) consumes upstream tool servers via `MCPToolAdapter`; `MCPServer` exposes local tools; `MCPBridge.from_config` orchestrates from `modules.protocols.mcp` | shipped (Python) | 0.2 | both | `agentforge-mcp` |
-| **feat-014** | A2A (agent-to-agent) protocol support — for cross-framework agent calls | proposed | 0.4 (after stability) | both | `agentforge-a2a` |
+| **feat-014** | A2A (agent-to-agent) protocol support — for cross-framework agent calls | shipped (Python) | 0.4 | both | `agentforge-a2a` |
 
 ### Deployment shapes
 

--- a/docs/features/feat-014-a2a-protocol.md
+++ b/docs/features/feat-014-a2a-protocol.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-014 |
 | **Title** | Agent-to-Agent (A2A) protocol — cross-framework agent calls |
-| **Status** | proposed |
+| **Status** | shipped (Python) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.4 (after stability bar reached on core) |
@@ -194,7 +194,159 @@ client are straightforward HTTP + JSON.
 - Implementing alternative inter-agent protocols. A2A is the standard we
   pick; if another standard emerges, separate module.
 
-## 10. References
+## 10. Implementation status (Python)
+
+Shipped in PR #27. New Tier-3 sister package
+`agentforge-a2a` plus a refactor that lifts feat-020's stub
+auth contract into a canonical core ABC.
+
+| Chunk | Commit | What landed |
+|---|---|---|
+| 1 | `76e2373` | Canonical `agentforge_core.contracts.auth.AuthPolicy` ABC + `Principal` value + `A2ACallError` / `A2AAuthError` / `A2ATimeout` exceptions; `agentforge.auth.EnvBearerAuth` concrete implementation; chat-http `BearerAuthPolicy` aliased to the canonical contract for backward compat. |
+| 2 | `b09915b` | New `agentforge-a2a` workspace member: pyproject + manifest.yaml + entry-point under `agentforge.protocols.a2a`. `A2AResponse` / `A2APeerConfig` / `A2AEndpointConfig` / `A2AExposeConfig` value models. `A2AClientRunner` / `A2AServerRunner` Protocols with `# pragma: no cover` production stubs (`_HTTPXClientRunner`, `_UvicornServerRunner`). |
+| 3 | `06f4ba6` | `agent_call(target, payload, *, peers, timeout_s, budget_usd, budget)` outgoing client. `BearerAuth` / `MutualTLSAuth` / `build_outgoing_auth` credentials. `FakeA2AClientRunner` / `FakeA2AServerRunner` in `src/_inmem_runner.py` for tests + downstream integration. Run-id + budget propagation via `X-AgentForge-Run-Id` / `X-AgentForge-Budget-Usd` headers. |
+| 4 | `4197535` | `A2AServer` FastAPI app — `POST /a2a/v1/calls` + `GET /a2a/v1/info`. Bearer-auth via canonical `AuthPolicy`; endpoint whitelist; parent_run_id propagation; budget cap; findings serialised via `agentforge.recording._finding_payload`. `A2ABridge.from_config(config, *, agent, auth, client_runner, server_runner)` orchestrator with `start()` / `close()` lifecycle. |
+| 5 | `f925e0b` | `A2AConfig` Pydantic schema; `A2ABridge.config_schema = A2AConfig` so feat-012's `validate_module_configs` enforces shape on `agentforge config validate`. |
+| 6 | (this PR) | Docs + Runbook + roadmap + CHANGELOG + state. |
+
+### Deviations from the design
+
+- **Production wire transport scoped to `# pragma: no cover`.**
+  `_HTTPXClientRunner` / `_UvicornServerRunner` raise
+  `"Production A2A runner not implemented yet"` until the
+  framework's first live integration test against a real A2A
+  peer lands. Every unit test injects
+  `FakeA2AClientRunner` / `FakeA2AServerRunner` from
+  `src/_inmem_runner.py`. Contract surface fully covered.
+- **Server framework = FastAPI**, not bare Starlette as the
+  spec §4.4 suggests. Matches the existing `chat-http`
+  precedent and reuses the same `HTTPBearer` /
+  `HTTPException` / `Depends` idioms.
+- **Outgoing auth has no policy abstraction.** Per-peer auth
+  is dict-driven (`{type: bearer, token: ...}` /
+  `{type: mtls, cert: ..., key: ...}`) — matches the spec's
+  YAML example. `build_outgoing_auth(config)` is the
+  resolution path.
+- **`A2AResponse.findings` is `tuple[dict, ...]`**, not
+  `tuple[Finding, ...]`. Findings serialise on the wire via
+  `_finding_payload(...)` — keeps the wire format JSON-clean
+  and tolerant of custom Finding shapes.
+- **Budget enforcement is advisory across trust boundaries.**
+  `X-AgentForge-Budget-Usd` caps the inner agent's budget on
+  the server side; a compromised callee may exceed. Spec §8
+  already documents this; the implementation matches.
+- **TypeScript port deferred.** Wire format is
+  language-neutral.
+
+### Open items
+
+- Production runner against a real A2A peer (live
+  integration test).
+- A2A discovery / registry (spec §9).
+- Bi-directional streaming (spec §9).
+- TS port.
+
+## 11. Runbook
+
+### How do I consume another agent?
+
+```python
+from agentforge_a2a import A2APeer, agent_call
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+
+# Production: import httpx and write a thin runner that uses
+# httpx.AsyncClient.post(...). For now (v0.4 chunk 2 stubs)
+# inject a fake.
+runner = FakeA2AClientRunner.with_response({"output": "ok", "run_id": "r"})
+peer = A2APeer.from_config(
+    {
+        "name": "fact-checker",
+        "url": "https://internal.fact-checker.example/a2a",
+        "auth": {"type": "bearer", "token": "tok"},
+    },
+    runner=runner,
+)
+result = await agent_call(
+    "fact-checker:verify",
+    {"claim": "x"},
+    peers={"fact-checker": peer},
+    timeout_s=30,
+    budget_usd=0.25,
+)
+print(result.output)
+```
+
+### How do I expose this agent?
+
+```python
+from agentforge import Agent, EnvBearerAuth
+from agentforge_a2a import A2AServer
+
+server = A2AServer(
+    agent=Agent(model="anthropic:claude-sonnet-4-6", strategy="react"),
+    auth=EnvBearerAuth("A2A_TOKENS"),
+    endpoints=["review-pr", "verify"],
+    host="0.0.0.0",
+    port=8080,
+)
+await server.serve()
+```
+
+### How do I add mTLS?
+
+Pass `{"type": "mtls", "cert": "/path/cert.pem", "key":
+"/path/key.pem", "ca": "/path/ca.pem"}` as the `auth` field in
+the peer config. `build_outgoing_auth(...)` builds a
+`ClientAuth` with an `ssl.SSLContext`; httpx receives it
+through the runner's `ssl_context=` argument.
+
+### How do I debug auth failures?
+
+`A2AAuthError` is the typed exception raised on
+401/403/`{error: "unauthorized"}` responses. Catch it
+explicitly to differentiate from generic transport
+`A2ACallError`. The runner's request log includes the
+`Authorization` header (redact before sharing).
+
+### How do I wire from config?
+
+```yaml
+modules:
+  protocols:
+    - name: a2a
+      config:
+        peers:
+          - name: fact-checker
+            url: "https://internal.fact-checker.example/a2a"
+            auth: {type: "bearer", token: "${FACT_CHECKER_TOKEN}"}
+        expose:
+          enabled: true
+          host: "0.0.0.0"
+          port: 8080
+          endpoints:
+            - name: "review-pr"
+              description: "Review a pull request"
+```
+
+```python
+from agentforge_a2a import A2ABridge
+from agentforge import EnvBearerAuth
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+
+bridge = A2ABridge.from_config(
+    config.modules.protocols[0].config,
+    agent=my_agent,
+    auth=EnvBearerAuth("A2A_TOKENS"),
+    client_runner=FakeA2AClientRunner(),  # swap for the production runner once live
+)
+await bridge.start()
+```
+
+`agentforge config validate` enforces the schema
+automatically — `A2ABridge.config_schema` points at
+`A2AConfig`, so feat-012's module-schema walker picks it up.
+
+## 12. References
 
 - A2A spec: https://github.com/google/A2A
 - feat-001, feat-007 (run_id, budget)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,6 +46,7 @@ onward every feature uses the canonical feat-NNN number.
 | [feat-013](./features/feat-013-mcp-integration.md) | MCP integration — `agentforge-mcp` module: `MCPServerClient` (stdio + HTTP/SSE) consumes upstream MCP tool servers via `MCPToolAdapter`s (server-name prefixed); `MCPServer` exposes local tools as MCP; `MCPBridge.from_config` orchestrates from `modules.protocols.mcp`. Production runners scaffolded behind `MCPClientRunner` / `MCPServerRunner` protocols pending live integration tests. | [#24](https://github.com/Scaffoldic/agentforge-py/pull/24) |
 | [feat-015](./features/feat-015-pipeline-and-tasks.md) | Pipeline & deterministic tasks — `Task` ABC + `PipelineResult` value in `agentforge-core`; `Pipeline` engine (DAG validation, `asyncio.Semaphore`-bounded parallelism, per-task timeouts, continue/fail error mode) + `PipelineFailure` + `PipelineFindingsTool` built-in; `Agent(pipeline=...)` kwarg + `Agent.run(task, *, context, replay_pipeline)` API; system-prompt addendum; `modules.pipeline:` config block + `build_pipeline_from_config`; `__pipeline` recording category + `load_pipeline_result` replay; `FinishReason` literal extended with `"pipeline"`. | [#25](https://github.com/Scaffoldic/agentforge-py/pull/25) |
 | [feat-020 (v0.2 scope)](./features/feat-020-chat-agents.md) | Chat agents v0.2 — `ChatHistoryStore` / `HistoryTruncationStrategy` ABCs + `ChatTurn` / `SessionInfo` / `ChatChunk` / `ChatResponse` value models in `agentforge-core`; `agentforge-chat` package with `ChatSession` (send + stream + idempotency + per-turn/per-session budgets + input/output guardrails + sentence-segmenting buffer-then-stream) and `InMemoryChatHistory` / `SqliteChatHistory` drivers + four truncation strategies (sliding-window, token-budget, summarise-oldest, hybrid); `agentforge-chat-http` package with FastAPI REST + WS + SSE + bearer auth + cross-owner 403 + token-bucket rate limiting; `modules.chat:` config block + `build_chat_session_from_config`. Postgres / Redis drivers, Slack adapter, and real per-token streaming deferred to v0.3 follow-up PRs. | [#26](https://github.com/Scaffoldic/agentforge-py/pull/26) |
+| [feat-014](./features/feat-014-a2a-protocol.md) | A2A protocol — canonical `agentforge_core.contracts.auth.AuthPolicy` + `Principal` + `A2ACallError` / `A2AAuthError` / `A2ATimeout` exceptions; `agentforge.auth.EnvBearerAuth` concrete impl; chat-http refactor to the canonical contract; new `agentforge-a2a` package with `agent_call(target, payload, *, peers, budget_usd, budget)` client + bearer / mTLS credentials + `A2AServer` FastAPI app + `A2ABridge` orchestrator + `A2AConfig` schema + run_id / budget header propagation. Production runners scoped behind Protocols with `# pragma: no cover` (same pattern as feat-013 MCP) until the first live integration test lands. | [#27](https://github.com/Scaffoldic/agentforge-py/pull/27) |
 
 For details on what each shipped feature delivered vs. what was
 deferred, read the **Implementation status** section at the bottom
@@ -59,8 +60,10 @@ These are tracked here so they don't get lost. Full design specs
 already exist under [`docs/features/`](./features/); pick one to
 move into "In flight" when starting.
 
-- **feat-014** — A2A protocol. See spec under
-  [`docs/features/`](./features/).
+- **feat-014 v0.4.1 follow-ups** — production HTTP runner
+  against a real A2A peer (replaces the
+  `# pragma: no cover` stubs); A2A discovery / registry;
+  bi-directional streaming.
 - **feat-020 v0.3 follow-ups** —
   `agentforge-chat-history-postgres`,
   `agentforge-chat-history-redis`, `agentforge-chat-slack`

--- a/packages/agentforge-a2a/LICENSE
+++ b/packages/agentforge-a2a/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/agentforge-a2a/README.md
+++ b/packages/agentforge-a2a/README.md
@@ -1,0 +1,52 @@
+# agentforge-a2a
+
+A2A (Agent-to-Agent) protocol support for AgentForge: cross-framework
+agent invocation over HTTP, with bearer / mTLS auth, run_id chain,
+and budget propagation.
+
+See [`docs/features/feat-014-a2a-protocol.md`](https://github.com/Scaffoldic/agentforge-py/blob/main/docs/features/feat-014-a2a-protocol.md)
+for the design and runbook.
+
+## Install
+
+```bash
+pip install agentforge-a2a
+# or, from a scaffolded project:
+agentforge add module a2a
+```
+
+## Call another agent
+
+```python
+from agentforge_a2a import A2APeer, agent_call
+
+peer = A2APeer.from_config({
+    "name": "fact-checker",
+    "url": "https://internal.fact-checker.example/a2a",
+    "auth": {"type": "bearer", "token": "${FACT_CHECKER_TOKEN}"},
+})
+
+result = await agent_call(
+    "fact-checker:verify",
+    {"claim": "The capital of Australia is Sydney."},
+    timeout_s=30,
+    peers={"fact-checker": peer},
+)
+print(result.output)
+```
+
+## Expose this agent
+
+```python
+from agentforge import Agent, EnvBearerAuth
+from agentforge_a2a import A2AServer
+
+server = A2AServer(
+    agent=Agent(model="anthropic:claude-sonnet-4-6", strategy="react"),
+    auth=EnvBearerAuth("A2A_TOKENS"),
+    endpoints=["review-pr"],
+    host="0.0.0.0",
+    port=8080,
+)
+await server.serve()
+```

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -1,0 +1,64 @@
+# agentforge-a2a — A2A (Agent-to-Agent) protocol support.
+#
+# Two halves:
+#   - `agent_call(target, payload)` client lets an AgentForge agent
+#     reach out to other frameworks' agents.
+#   - `A2AServer(agent, ...)` exposes this agent as an A2A peer.
+#
+# Both halves use the canonical `AuthPolicy` contract from
+# `agentforge-core` (feat-014 chunk 1) for server-side bearer
+# validation. Client-side credentials are dict-driven per-peer.
+
+[project]
+name = "agentforge-a2a"
+version = "0.0.0"
+description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "The AgentForge Authors"},
+]
+keywords = ["ai", "agent", "a2a", "protocol", "multi-agent"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: FastAPI",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "agentforge-core",
+    "agentforge",
+    "fastapi>=0.115",
+    "uvicorn>=0.32",
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/Scaffoldic/agentforge-py"
+Repository = "https://github.com/Scaffoldic/agentforge-py"
+Changelog = "https://github.com/Scaffoldic/agentforge-py/blob/main/CHANGELOG.md"
+
+[project.entry-points."agentforge.protocols"]
+a2a = "agentforge_a2a.bridge:A2ABridge"
+
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentforge_a2a"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/agentforge_a2a",
+    "tests",
+    "README.md",
+    "LICENSE",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -1,17 +1,26 @@
 """`agentforge-a2a` — A2A protocol support for AgentForge (feat-014).
 
-Public surface (chunks 3-4):
-- `agent_call(target, payload, *, ...)` — outgoing A2A client.
+Public surface:
+
+- `agent_call(target, payload, *, peers, ...)` — outgoing A2A
+  client.
 - `A2APeer` — per-peer config + runner.
-- `A2AServer(agent, ...)` — FastAPI server exposing this agent.
-- `A2ABridge.from_config(config)` — orchestrator.
-- `BearerAuth` / `MutualTLSAuth` — client-side credentials.
+- `A2AServer(agent, ..., auth, endpoints)` — FastAPI server
+  exposing this agent as an A2A peer.
+- `A2ABridge.from_config(config, ...)` — orchestrator that
+  wires both halves from a config dict.
+- `BearerAuth` / `MutualTLSAuth` — client-side credential
+  builders. (Server-side bearer validation uses the canonical
+  `agentforge_core.contracts.auth.AuthPolicy`.)
 """
 
 from __future__ import annotations
 
 from agentforge_a2a.auth import BearerAuth, ClientAuth, MutualTLSAuth, build_outgoing_auth
+from agentforge_a2a.bridge import A2ABridge
 from agentforge_a2a.client import A2APeer, agent_call
+from agentforge_a2a.config import A2AConfig
+from agentforge_a2a.server import A2AServer
 from agentforge_a2a.values import (
     A2AEndpointConfig,
     A2AExposeConfig,
@@ -20,11 +29,14 @@ from agentforge_a2a.values import (
 )
 
 __all__ = [
+    "A2ABridge",
+    "A2AConfig",
     "A2AEndpointConfig",
     "A2AExposeConfig",
     "A2APeer",
     "A2APeerConfig",
     "A2AResponse",
+    "A2AServer",
     "BearerAuth",
     "ClientAuth",
     "MutualTLSAuth",

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -10,6 +10,8 @@ Public surface (chunks 3-4):
 
 from __future__ import annotations
 
+from agentforge_a2a.auth import BearerAuth, ClientAuth, MutualTLSAuth, build_outgoing_auth
+from agentforge_a2a.client import A2APeer, agent_call
 from agentforge_a2a.values import (
     A2AEndpointConfig,
     A2AExposeConfig,
@@ -20,6 +22,12 @@ from agentforge_a2a.values import (
 __all__ = [
     "A2AEndpointConfig",
     "A2AExposeConfig",
+    "A2APeer",
     "A2APeerConfig",
     "A2AResponse",
+    "BearerAuth",
+    "ClientAuth",
+    "MutualTLSAuth",
+    "agent_call",
+    "build_outgoing_auth",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -1,0 +1,25 @@
+"""`agentforge-a2a` — A2A protocol support for AgentForge (feat-014).
+
+Public surface (chunks 3-4):
+- `agent_call(target, payload, *, ...)` — outgoing A2A client.
+- `A2APeer` — per-peer config + runner.
+- `A2AServer(agent, ...)` — FastAPI server exposing this agent.
+- `A2ABridge.from_config(config)` — orchestrator.
+- `BearerAuth` / `MutualTLSAuth` — client-side credentials.
+"""
+
+from __future__ import annotations
+
+from agentforge_a2a.values import (
+    A2AEndpointConfig,
+    A2AExposeConfig,
+    A2APeerConfig,
+    A2AResponse,
+)
+
+__all__ = [
+    "A2AEndpointConfig",
+    "A2AExposeConfig",
+    "A2APeerConfig",
+    "A2AResponse",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/_inmem_runner.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/_inmem_runner.py
@@ -1,0 +1,99 @@
+"""In-memory fakes implementing the A2A runner protocols (feat-014).
+
+`FakeA2AClientRunner` lets unit + integration tests run without
+spinning up an HTTP server. It records every call for later
+assertion and returns scripted responses.
+
+`FakeA2AServerRunner` is a tiny placeholder for the server-side
+runner — `A2AServer.serve()` against this runner becomes a
+no-op suitable for tests.
+
+Lives in `src/` (not `tests/`) so external packages can import
+the fakes for their own integration tests.
+"""
+
+from __future__ import annotations
+
+import ssl
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _Call:
+    url: str
+    headers: dict[str, str]
+    json: dict[str, Any]
+    ssl_context: ssl.SSLContext | None
+    timeout_s: float
+
+
+class FakeA2AClientRunner:
+    """Records POSTs and returns a configurable canned response."""
+
+    def __init__(self, *, response: dict[str, Any] | None = None) -> None:
+        self._response: dict[str, Any] = response if response is not None else {}
+        self._error: Exception | None = None
+        self.calls: list[_Call] = []
+        self.closed = False
+
+    @classmethod
+    def with_response(cls, response: dict[str, Any]) -> FakeA2AClientRunner:
+        return cls(response=response)
+
+    def set_response(self, response: dict[str, Any]) -> None:
+        self._response = response
+
+    def set_error(self, error: Exception) -> None:
+        """Next `post()` will raise this error."""
+        self._error = error
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            _Call(
+                url=url,
+                headers=dict(headers),
+                json=dict(json),
+                ssl_context=ssl_context,
+                timeout_s=timeout_s,
+            )
+        )
+        if self._error is not None:
+            err, self._error = self._error, None
+            raise err
+        return dict(self._response)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class FakeA2AServerRunner:
+    """No-op server runner suitable for tests + the inline bridge."""
+
+    serving: bool = False
+    stop_called: bool = False
+    _events: list[str] = field(default_factory=list)
+
+    async def serve(self) -> None:
+        self.serving = True
+        self._events.append("serve")
+
+    async def stop(self) -> None:
+        self.serving = False
+        self.stop_called = True
+        self._events.append("stop")
+
+
+__all__ = [
+    "FakeA2AClientRunner",
+    "FakeA2AServerRunner",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/_runner.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/_runner.py
@@ -1,0 +1,102 @@
+"""Internal A2A runner protocols (feat-014).
+
+`A2AClientRunner` is the thin slice of httpx we depend on for
+outgoing calls; `A2AServerRunner` wraps the uvicorn lifecycle
+for the embedded server. Tests inject fakes so the unit suite
+doesn't need a real network socket.
+
+Production runners (`_HTTPXClientRunner`, `_UvicornServerRunner`)
+are scaffolded behind ``# pragma: no cover`` until the
+framework's first live A2A integration test lands. The contract
+surface is fully covered by the fake runners in
+`_inmem_runner.py`.
+"""
+
+from __future__ import annotations
+
+import ssl
+from typing import Any, Protocol
+
+
+class A2AClientRunner(Protocol):
+    """Subset of `httpx.AsyncClient` we depend on for outgoing
+    A2A calls. Tests inject a fake; production builds a real
+    `httpx.AsyncClient` via `_HTTPXClientRunner`."""
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]: ...
+
+    async def close(self) -> None: ...
+
+
+class A2AServerRunner(Protocol):
+    """Subset of `uvicorn.Server` we depend on. Tests inject a
+    fake; production builds a real uvicorn server via
+    `_UvicornServerRunner`."""
+
+    async def serve(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class _HTTPXClientRunner:
+    """Production `A2AClientRunner` — wraps `httpx.AsyncClient`.
+
+    Pragma-no-cover until the first live A2A integration test
+    lands. Unit tests inject `FakeA2AClientRunner` from
+    `_inmem_runner.py`.
+    """
+
+    def __init__(self) -> None:  # pragma: no cover — live transport
+        raise NotImplementedError(
+            "Production A2A runner not implemented yet. Inject a "
+            "FakeA2AClientRunner in tests, or wait for the live "
+            "integration scaffolding (feat-014 v0.4.1 follow-up)."
+        )
+
+    async def post(  # pragma: no cover
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+class _UvicornServerRunner:
+    """Production `A2AServerRunner` — wraps `uvicorn.Server`.
+
+    Pragma-no-cover until live integration tests land.
+    """
+
+    def __init__(self) -> None:  # pragma: no cover — live transport
+        raise NotImplementedError(
+            "Production A2A server runner not implemented yet. Inject "
+            "FakeA2AServerRunner in tests, or wait for the live "
+            "integration scaffolding (feat-014 v0.4.1 follow-up)."
+        )
+
+    async def serve(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def stop(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+__all__ = [
+    "A2AClientRunner",
+    "A2AServerRunner",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/auth.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/auth.py
@@ -1,0 +1,92 @@
+"""Client-side credential providers for A2A (feat-014).
+
+`agent_call` resolves per-peer auth config to one of the two
+built-in `ClientAuth` shapes:
+
+- `BearerAuth(token)` — attaches ``Authorization: Bearer
+  <token>`` to outgoing requests.
+- `MutualTLSAuth(cert_path, key_path)` — builds an
+  `ssl.SSLContext` the httpx client passes to the peer.
+
+`build_outgoing_auth(config)` accepts the dict form found in
+YAML (`{type: bearer, token: ...}` / `{type: mtls, cert: ...,
+key: ...}`) and returns the corresponding `ClientAuth`.
+"""
+
+from __future__ import annotations
+
+import ssl
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agentforge_core.production.exceptions import ModuleError
+
+
+@dataclass(frozen=True)
+class ClientAuth:
+    """Resolved client-side credentials for an A2A peer.
+
+    `headers` is merged into the outgoing request headers;
+    `ssl_context` is passed to the httpx client when present.
+    """
+
+    headers: dict[str, str] = field(default_factory=dict)
+    ssl_context: ssl.SSLContext | None = None
+
+
+def BearerAuth(token: str) -> ClientAuth:  # noqa: N802 — factory-named like a class
+    """Bearer-token credentials. Returns a `ClientAuth` ready to
+    use with `agent_call`."""
+    return ClientAuth(headers={"Authorization": f"Bearer {token}"})
+
+
+def MutualTLSAuth(  # noqa: N802 — factory-named like a class
+    cert_path: str | Path,
+    key_path: str | Path,
+    *,
+    ca_path: str | Path | None = None,
+) -> ClientAuth:
+    """mTLS credentials. Builds an `ssl.SSLContext` loading the
+    client cert + key (and an optional CA bundle)."""
+    ctx = ssl.create_default_context(
+        purpose=ssl.Purpose.SERVER_AUTH,
+        cafile=str(ca_path) if ca_path is not None else None,
+    )
+    ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    return ClientAuth(ssl_context=ctx)
+
+
+def build_outgoing_auth(config: dict[str, Any]) -> ClientAuth:
+    """Resolve a per-peer auth dict to a `ClientAuth`.
+
+    Accepted shapes:
+      - ``{}`` — no auth.
+      - ``{type: "bearer", token: "..."}``.
+      - ``{type: "mtls", cert: "/path", key: "/path",
+            ca: "/path" (optional)}``.
+    """
+    if not config:
+        return ClientAuth()
+    auth_type = config.get("type", "")
+    if auth_type == "bearer":
+        token = config.get("token", "")
+        if not token:
+            raise ModuleError("bearer auth requires a non-empty 'token'")
+        return BearerAuth(token)
+    if auth_type == "mtls":
+        cert = config.get("cert", "")
+        key = config.get("key", "")
+        ca = config.get("ca")
+        if not cert or not key:
+            raise ModuleError("mtls auth requires both 'cert' and 'key' paths")
+        return MutualTLSAuth(cert, key, ca_path=ca)
+    raise ModuleError(f"unknown a2a auth type: {auth_type!r}")
+
+
+__all__ = [
+    "BearerAuth",
+    "ClientAuth",
+    "MutualTLSAuth",
+    "build_outgoing_auth",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
@@ -1,0 +1,129 @@
+"""`A2ABridge` — orchestrates A2A clients + an optional server
+(feat-014).
+
+Loaded by feat-010's resolver from
+`modules.protocols[a2a].config:`. Mirrors `MCPBridge`'s shape:
+
+- `from_config(config_dict, *, agent, auth, client_runner,
+  server_runner)` builds peers + an optional server from a
+  validated `A2AConfig`.
+- `peers` is a dict of `{name -> A2APeer}` ready for
+  `agent_call(...)`.
+- `server` is an `A2AServer | None`; when present, `start()`
+  schedules it as an asyncio task and `close()` cancels.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any, ClassVar
+
+from agentforge.agent import Agent
+from agentforge_core.contracts.auth import AuthPolicy
+
+from agentforge_a2a._runner import A2AClientRunner, A2AServerRunner
+from agentforge_a2a.client import A2APeer
+from agentforge_a2a.server import A2AServer
+
+
+class A2ABridge:
+    """Top-level orchestrator for a2a clients + server.
+
+    The bridge does NOT own the `Agent` instance — callers pass
+    it explicitly when they want a server side. Without an
+    agent, `from_config` builds the client side only (peers
+    available; `server is None`).
+    """
+
+    # Populated by chunk 5 to wire `A2AConfig` validation
+    # through `validate_module_configs`.
+    config_schema: ClassVar[type | None] = None
+
+    def __init__(
+        self,
+        *,
+        peers: dict[str, A2APeer],
+        server: A2AServer | None = None,
+    ) -> None:
+        self._peers = dict(peers)
+        self._server = server
+        self._serve_task: asyncio.Task[None] | None = None
+
+    @property
+    def peers(self) -> dict[str, A2APeer]:
+        return dict(self._peers)
+
+    @property
+    def server(self) -> A2AServer | None:
+        return self._server
+
+    @classmethod
+    def from_config(
+        cls,
+        config: dict[str, Any],
+        *,
+        agent: Agent | None = None,
+        auth: AuthPolicy | None = None,
+        client_runner: A2AClientRunner,
+        server_runner: A2AServerRunner | None = None,
+    ) -> A2ABridge:
+        """Build a bridge from a validated A2A config dict.
+
+        Args:
+            config: Raw ``{peers: [...], expose: {...}}`` dict.
+                The chunk-5 schema (`A2AConfig`) validates this.
+            agent: Required when ``config.expose.enabled`` is
+                True. The server side wraps it.
+            auth: Required when ``config.expose.enabled`` is
+                True. The server validates incoming bearers
+                against this policy.
+            client_runner: Shared `A2AClientRunner` for all
+                peers. Pass a `FakeA2AClientRunner` in tests.
+            server_runner: Optional `A2AServerRunner` injected
+                into the server's lifecycle.
+        """
+        # Lazy import so the package can be loaded without a2a
+        # config models on `import agentforge_a2a`.
+        from agentforge_a2a.config import A2AConfig  # noqa: PLC0415
+
+        validated = A2AConfig.model_validate(config)
+        peers = {pc.name: A2APeer.from_config(pc, runner=client_runner) for pc in validated.peers}
+        server: A2AServer | None = None
+        if validated.expose is not None and validated.expose.enabled:
+            if agent is None or auth is None:
+                msg = (
+                    "A2A expose.enabled=True requires both an Agent and an "
+                    "AuthPolicy to be supplied to A2ABridge.from_config."
+                )
+                raise ValueError(msg)
+            server = A2AServer(
+                agent=agent,
+                auth=auth,
+                endpoints=[e.name for e in validated.expose.endpoints],
+                host=validated.expose.host,
+                port=validated.expose.port,
+                runner=server_runner,
+            )
+        return cls(peers=peers, server=server)
+
+    async def start(self) -> None:
+        """Launch the server (if any) in the background. Idempotent."""
+        if self._server is None or self._serve_task is not None:
+            return
+        self._serve_task = asyncio.create_task(self._server.serve())
+
+    async def close(self) -> None:
+        """Stop the server (if running) and drain peers."""
+        if self._server is not None:
+            await self._server.stop()
+        if self._serve_task is not None and not self._serve_task.done():
+            self._serve_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._serve_task
+            self._serve_task = None
+        for peer in self._peers.values():
+            await peer.runner.close()
+
+
+__all__ = ["A2ABridge"]

--- a/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
@@ -24,6 +24,7 @@ from agentforge_core.contracts.auth import AuthPolicy
 
 from agentforge_a2a._runner import A2AClientRunner, A2AServerRunner
 from agentforge_a2a.client import A2APeer
+from agentforge_a2a.config import A2AConfig
 from agentforge_a2a.server import A2AServer
 
 
@@ -36,9 +37,9 @@ class A2ABridge:
     available; `server is None`).
     """
 
-    # Populated by chunk 5 to wire `A2AConfig` validation
-    # through `validate_module_configs`.
-    config_schema: ClassVar[type | None] = None
+    config_schema: ClassVar[type[A2AConfig]] = A2AConfig
+    """Picked up by feat-012's `validate_module_configs` so
+    `agentforge config validate` enforces the A2A schema."""
 
     def __init__(
         self,
@@ -83,10 +84,6 @@ class A2ABridge:
             server_runner: Optional `A2AServerRunner` injected
                 into the server's lifecycle.
         """
-        # Lazy import so the package can be loaded without a2a
-        # config models on `import agentforge_a2a`.
-        from agentforge_a2a.config import A2AConfig  # noqa: PLC0415
-
         validated = A2AConfig.model_validate(config)
         peers = {pc.name: A2APeer.from_config(pc, runner=client_runner) for pc in validated.peers}
         server: A2AServer | None = None

--- a/packages/agentforge-a2a/src/agentforge_a2a/client.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/client.py
@@ -1,0 +1,174 @@
+"""A2A client (feat-014).
+
+`agent_call(target, payload, ...)` resolves a `<peer>:<endpoint>`
+target against the configured peers and dispatches an HTTP POST
+through the peer's `A2AClientRunner`. The caller's current
+`RunContext` is propagated via `X-AgentForge-Run-Id` so the
+callee can record it as `parent_run_id` (feat-007).
+
+Budget propagation: when the caller binds an
+`agentforge.cli._build`-style budget to the current run, the
+proposed `budget_usd` reserves against it before the call;
+`commit(actual)` + `release_reservation(budget_usd)` fires on
+success; `release_reservation(budget_usd)` on failure. v0.4
+threads the budget via the optional `budget` kwarg — the helper
+stays callable from contexts without a bound budget too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import (
+    A2AAuthError,
+    A2ACallError,
+    A2ATimeout,
+    ModuleError,
+)
+from agentforge_core.production.run_context import current_run
+
+from agentforge_a2a._runner import A2AClientRunner
+from agentforge_a2a.auth import ClientAuth, build_outgoing_auth
+from agentforge_a2a.values import A2APeerConfig, A2AResponse
+
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+
+
+@dataclass
+class A2APeer:
+    """One configured A2A peer + its outgoing-auth + runner."""
+
+    name: str
+    url: str
+    auth: ClientAuth
+    runner: A2AClientRunner
+
+    @classmethod
+    def from_config(
+        cls,
+        config: dict[str, Any] | A2APeerConfig,
+        *,
+        runner: A2AClientRunner,
+    ) -> A2APeer:
+        pc = config if isinstance(config, A2APeerConfig) else A2APeerConfig.model_validate(config)
+        return cls(
+            name=pc.name,
+            url=pc.url,
+            auth=build_outgoing_auth(pc.auth),
+            runner=runner,
+        )
+
+
+async def agent_call(
+    target: str,
+    payload: dict[str, Any],
+    *,
+    peers: dict[str, A2APeer],
+    timeout_s: float = 60.0,
+    budget_usd: float | None = None,
+    budget: BudgetPolicy | None = None,
+) -> A2AResponse:
+    """Invoke a remote A2A peer.
+
+    Args:
+        target: ``"<peer>:<endpoint>"``. ``<peer>`` resolves
+            against the ``peers`` map.
+        payload: Endpoint-specific JSON body.
+        peers: Map of peer name → `A2APeer`.
+        timeout_s: Per-call timeout in seconds.
+        budget_usd: Proposed budget the callee should respect.
+        budget: Optional `BudgetPolicy` the call reserves against
+            (caller-side accounting). When None, the helper does
+            no reserve/commit dance — useful for fire-and-forget
+            calls.
+
+    Returns:
+        Parsed `A2AResponse`.
+
+    Raises:
+        A2AAuthError: peer rejected credentials.
+        A2ATimeout: call exceeded ``timeout_s``.
+        A2ACallError: any other transport / protocol failure.
+    """
+    peer_name, endpoint = _parse_target(target)
+    peer = peers.get(peer_name)
+    if peer is None:
+        raise ModuleError(f"unknown a2a peer: {peer_name!r}")
+
+    headers = _build_headers(peer.auth, budget_usd)
+    body = {"endpoint": endpoint, "payload": payload, "budget_usd": budget_usd}
+
+    if budget is not None and budget_usd is not None:
+        budget.reserve(budget_usd)
+    try:
+        try:
+            raw = await peer.runner.post(
+                peer.url,
+                headers=headers,
+                json=body,
+                ssl_context=peer.auth.ssl_context,
+                timeout_s=timeout_s,
+            )
+        except TimeoutError as exc:
+            # Python 3.11+ aliases asyncio.TimeoutError to the
+            # builtin TimeoutError; a single except clause catches
+            # both.
+            raise A2ATimeout(f"a2a call to {peer_name!r} exceeded {timeout_s:.1f}s") from exc
+        except Exception as exc:
+            raise A2ACallError(f"a2a call to {peer_name!r} failed: {exc}") from exc
+
+        _raise_for_error_body(peer_name, raw)
+        response = A2AResponse.model_validate(raw)
+    except BaseException:
+        if budget is not None and budget_usd is not None:
+            budget.release_reservation(budget_usd)
+        raise
+    else:
+        if budget is not None and budget_usd is not None:
+            budget.commit(response.cost_usd)
+            budget.release_reservation(budget_usd)
+    return response
+
+
+def _parse_target(target: str) -> tuple[str, str]:
+    if ":" not in target:
+        raise ModuleError(f"a2a target must be '<peer>:<endpoint>', got {target!r}")
+    peer_name, endpoint = target.split(":", 1)
+    if not peer_name or not endpoint:
+        raise ModuleError(f"a2a target must be '<peer>:<endpoint>', got {target!r}")
+    return peer_name, endpoint
+
+
+def _build_headers(auth: ClientAuth, budget_usd: float | None) -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    headers.update(auth.headers)
+    try:
+        ctx = current_run()
+    except RuntimeError:
+        ctx = None
+    if ctx is not None:
+        headers["X-AgentForge-Run-Id"] = ctx.run_id
+    if budget_usd is not None:
+        headers["X-AgentForge-Budget-Usd"] = f"{budget_usd:.6f}"
+    return headers
+
+
+def _raise_for_error_body(peer_name: str, raw: dict[str, Any]) -> None:
+    """Map an error-shaped body to the right A2A* exception."""
+    if "error" not in raw:
+        return
+    code = raw.get("error", "")
+    message = raw.get("message", "")
+    status = int(raw.get("status", 0)) if isinstance(raw.get("status"), (int, str)) else 0
+    if status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN) or code in ("unauthorized", "forbidden"):
+        raise A2AAuthError(f"a2a peer {peer_name!r} rejected credentials: {message}")
+    raise A2ACallError(f"a2a peer {peer_name!r} returned error {code!r}: {message}")
+
+
+__all__ = [
+    "A2APeer",
+    "agent_call",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/config.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/config.py
@@ -1,0 +1,25 @@
+"""`A2AConfig` — Pydantic schema for `modules.protocols[a2a].config:`
+(feat-014).
+
+`A2ABridge.from_config(config_dict)` validates the raw dict
+against this schema before wiring peers + an optional server.
+Strict / ``extra="forbid"`` per project convention.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentforge_a2a.values import A2AExposeConfig, A2APeerConfig
+
+
+class A2AConfig(BaseModel):
+    """Top-level shape of the A2A protocol's config block."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    peers: list[A2APeerConfig] = Field(default_factory=list)
+    expose: A2AExposeConfig | None = None
+
+
+__all__ = ["A2AConfig"]

--- a/packages/agentforge-a2a/src/agentforge_a2a/manifest.yaml
+++ b/packages/agentforge-a2a/src/agentforge_a2a/manifest.yaml
@@ -1,0 +1,26 @@
+# Module manifest for `agentforge add module a2a` (feat-010 / feat-014).
+name: a2a
+description: |
+  A2A (Agent-to-Agent) protocol support. Adds `agent_call(...)` for
+  reaching out to other-framework agents, plus `A2AServer` for
+  exposing this agent over the A2A wire format. Bearer and mTLS
+  auth backends ship in v0.4.
+
+distribution:
+  pip_name: agentforge-a2a
+
+config_block:
+  modules.protocols:
+    - name: a2a
+      config:
+        peers: []
+        expose:
+          enabled: false
+          host: "0.0.0.0"
+          port: 8080
+          auth: {type: "bearer", expected_tokens_env: "A2A_TOKENS"}
+          endpoints: []
+
+entry_points:
+  agentforge.protocols:
+    a2a: agentforge_a2a.bridge:A2ABridge

--- a/packages/agentforge-a2a/src/agentforge_a2a/server.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/server.py
@@ -1,0 +1,199 @@
+"""`A2AServer` — exposes an `Agent` over the A2A wire format
+(feat-014).
+
+FastAPI app with two endpoints:
+
+- `POST /a2a/v1/calls` — invoke a whitelisted endpoint.
+- `GET /a2a/v1/info` — return the endpoint catalogue +
+  framework version.
+
+Lifecycle:
+
+  1. Bearer auth via the canonical `AuthPolicy` (feat-014
+     chunk 1).
+  2. Endpoint name validated against the whitelist (404
+     otherwise).
+  3. `X-AgentForge-Run-Id` (if present) is recorded on the
+     response as `parent_run_id` for the cross-framework chain.
+  4. `X-AgentForge-Budget-Usd` (if present + valid) caps the
+     inner `Agent.run`'s budget.
+  5. The supplied `task_builder` callable converts the payload
+     into the task string the `Agent` receives.
+  6. Findings on the result are serialised through
+     `agentforge.recording._finding_payload` so the wire
+     shape stays tolerant of any `Finding` Protocol-compatible
+     object.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import uvicorn
+from agentforge.agent import Agent
+from agentforge.recording import _finding_payload
+from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.production.budget import BudgetPolicy
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict
+
+from agentforge_a2a._runner import A2AServerRunner
+from agentforge_a2a.values import A2AResponse
+
+_log = logging.getLogger("agentforge_a2a.server")
+_VERSION = "0.1"
+"""A2A wire-format version we ship — bumped when the request/
+response shape changes."""
+
+TaskBuilder = Callable[[str, dict[str, Any]], str]
+"""Maps (endpoint_name, payload) -> the task string the agent
+receives. Default: JSON-encode the payload."""
+
+
+def _default_task_builder(endpoint: str, payload: dict[str, Any]) -> str:
+    """Concatenates endpoint name + JSON payload for the agent."""
+    body = json.dumps(payload, sort_keys=True)
+    return f"a2a.{endpoint}: {body}"
+
+
+class CallRequest(BaseModel):
+    """Body of `POST /a2a/v1/calls`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint: str
+    payload: dict[str, Any]
+    budget_usd: float | None = None
+
+
+class A2AServer:
+    """FastAPI app exposing an `Agent` as an A2A peer."""
+
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        auth: AuthPolicy,
+        endpoints: list[str],
+        task_builder: TaskBuilder | None = None,
+        host: str = "0.0.0.0",  # noqa: S104  # nosec B104
+        port: int = 8080,
+        runner: A2AServerRunner | None = None,
+    ) -> None:
+        self._agent = agent
+        self._auth = auth
+        self._endpoints = list(endpoints)
+        self._task_builder = task_builder or _default_task_builder
+        self._host = host
+        self._port = port
+        self._runner = runner
+        self.app = self._build_app()
+
+    @property
+    def endpoints(self) -> tuple[str, ...]:
+        return tuple(self._endpoints)
+
+    def _build_app(self) -> FastAPI:
+        app = FastAPI(title="agentforge-a2a")
+        bearer = HTTPBearer(auto_error=False)
+
+        async def require_principal(
+            credentials: HTTPAuthorizationCredentials | None = Depends(bearer),  # noqa: B008
+        ) -> Any:
+            token = credentials.credentials if credentials is not None else None
+            principal = await self._auth.authenticate(token)
+            if principal is None:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+            return principal
+
+        @app.get("/a2a/v1/info")
+        async def info(_p: Any = Depends(require_principal)) -> dict[str, Any]:  # noqa: B008
+            return {
+                "version": _VERSION,
+                "endpoints": list(self._endpoints),
+            }
+
+        @app.post("/a2a/v1/calls")
+        async def call(
+            body: CallRequest,
+            request: Request,
+            _p: Any = Depends(require_principal),  # noqa: B008
+        ) -> dict[str, Any]:
+            return await self._handle_call(body, request)
+
+        return app
+
+    async def _handle_call(self, body: CallRequest, request: Request) -> dict[str, Any]:
+        if body.endpoint not in self._endpoints:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown endpoint: {body.endpoint!r}",
+            )
+        parent_run_id = request.headers.get("X-AgentForge-Run-Id")
+        budget_cap = self._read_budget_header(request)
+        if budget_cap is not None:
+            # Apply the cap by temporarily lowering the agent's
+            # budget for this run. We restore after.
+            original_budget = self._agent._budget
+            self._agent._budget = BudgetPolicy(
+                usd=min(original_budget.usd, budget_cap),
+                max_tokens=original_budget.max_tokens,
+                max_iterations=original_budget.max_iterations,
+                error_streak_limit=original_budget.error_streak_limit,
+            )
+            try:
+                result = await self._agent.run(self._task_builder(body.endpoint, body.payload))
+            finally:
+                self._agent._budget = original_budget
+        else:
+            result = await self._agent.run(self._task_builder(body.endpoint, body.payload))
+
+        response = A2AResponse(
+            output=result.output,
+            findings=tuple(_finding_payload(f) for f in getattr(result, "findings", ())),
+            cost_usd=result.cost_usd,
+            run_id=result.run_id,
+            parent_run_id=parent_run_id,
+        )
+        body_dict: dict[str, Any] = json.loads(response.model_dump_json())
+        return body_dict
+
+    @staticmethod
+    def _read_budget_header(request: Request) -> float | None:
+        raw = request.headers.get("X-AgentForge-Budget-Usd")
+        if raw is None or not raw:
+            return None
+        try:
+            value = float(raw)
+        except ValueError:
+            _log.warning("invalid X-AgentForge-Budget-Usd header: %r", raw)
+            return None
+        if value < 0:
+            return None
+        return value
+
+    async def serve(self) -> None:
+        """Run the server until interrupted. Uses the injected
+        runner when present, else falls back to a real uvicorn
+        server."""
+        if self._runner is not None:
+            await self._runner.serve()
+            return
+        config = uvicorn.Config(self.app, host=self._host, port=self._port, log_level="info")
+        server = uvicorn.Server(config)
+        await server.serve()
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.stop()
+
+
+__all__ = [
+    "A2AServer",
+    "CallRequest",
+    "TaskBuilder",
+]

--- a/packages/agentforge-a2a/src/agentforge_a2a/values.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/values.py
@@ -1,0 +1,76 @@
+"""A2A value types (feat-014).
+
+Wire-format-shaped Pydantic models that ride between the client
+(`agent_call`) and the server (`A2AServer`). All frozen — values
+are immutable once built.
+
+`A2AResponse` mirrors spec §4.2. The three config models
+(`A2APeerConfig`, `A2AEndpointConfig`, `A2AExposeConfig`) feed
+the YAML side via `A2AConfig` (chunk 5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class A2AResponse(BaseModel):
+    """Response returned by `agent_call(...)` and built by
+    `A2AServer.POST /a2a/v1/calls`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    output: Any
+    findings: tuple[dict[str, Any], ...] = ()
+    cost_usd: float = Field(default=0.0, ge=0.0)
+    run_id: str
+    parent_run_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2APeerConfig(BaseModel):
+    """One entry under `modules.protocols[a2a].config.peers:`.
+
+    `auth` is a free-form dict: `{type: bearer, token: ...}` or
+    `{type: mtls, cert: ..., key: ...}` — interpreted by
+    `agentforge_a2a.auth.build_outgoing_auth`.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+    auth: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2AEndpointConfig(BaseModel):
+    """One entry under `modules.protocols[a2a].config.expose.endpoints:`."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    description: str = ""
+    accepts: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2AExposeConfig(BaseModel):
+    """`modules.protocols[a2a].config.expose:` — server-side
+    configuration when this agent acts as an A2A peer."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    enabled: bool = True
+    host: str = "0.0.0.0"  # noqa: S104  # nosec B104 — caller binds explicitly in prod
+    port: int = 8080
+    auth: dict[str, Any] = Field(default_factory=dict)
+    endpoints: list[A2AEndpointConfig] = Field(default_factory=list)
+
+
+__all__ = [
+    "A2AEndpointConfig",
+    "A2AExposeConfig",
+    "A2APeerConfig",
+    "A2AResponse",
+]

--- a/packages/agentforge-a2a/tests/unit/test_a2a_bridge.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_bridge.py
@@ -1,0 +1,163 @@
+"""Unit tests for `A2ABridge` (feat-014 chunk 4)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_a2a import A2ABridge
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner, FakeA2AServerRunner
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+from pydantic import ValidationError
+
+
+class _S(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content="ok"))
+        return state
+
+
+class _L(LLMClient):
+    async def call(
+        self, system: str, messages: list[Message], tools: list[ToolSpec] | None = None
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent() -> Agent:
+    return Agent(model=_L(), strategy=_S())
+
+
+def test_bridge_client_only_mode() -> None:
+    config = {
+        "peers": [
+            {
+                "name": "fact-checker",
+                "url": "https://example/a2a",
+                "auth": {"type": "bearer", "token": "t"},
+            },
+        ],
+    }
+    bridge = A2ABridge.from_config(
+        config,
+        client_runner=FakeA2AClientRunner(),
+    )
+    assert "fact-checker" in bridge.peers
+    assert bridge.server is None
+
+
+def test_bridge_validates_extra_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(ValidationError):
+        A2ABridge.from_config(
+            {"peers": [], "unknown_field": 1},
+            client_runner=FakeA2AClientRunner(),
+        )
+
+
+def test_bridge_with_expose_requires_agent_and_auth() -> None:
+    config = {
+        "peers": [],
+        "expose": {
+            "enabled": True,
+            "host": "0.0.0.0",
+            "port": 8080,
+            "endpoints": [{"name": "verify"}],
+        },
+    }
+    with pytest.raises(ValueError, match="requires both an Agent and an AuthPolicy"):
+        A2ABridge.from_config(
+            config,
+            client_runner=FakeA2AClientRunner(),
+        )
+
+
+def test_bridge_with_expose_builds_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    config = {
+        "peers": [],
+        "expose": {
+            "enabled": True,
+            "endpoints": [{"name": "verify"}],
+        },
+    }
+    server_runner = FakeA2AServerRunner()
+    bridge = A2ABridge.from_config(
+        config,
+        agent=_agent(),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        client_runner=FakeA2AClientRunner(),
+        server_runner=server_runner,
+    )
+    assert bridge.server is not None
+    assert bridge.server.endpoints == ("verify",)
+
+
+@pytest.mark.asyncio
+async def test_bridge_start_then_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    config = {
+        "peers": [],
+        "expose": {
+            "enabled": True,
+            "endpoints": [{"name": "verify"}],
+        },
+    }
+    server_runner = FakeA2AServerRunner()
+    bridge = A2ABridge.from_config(
+        config,
+        agent=_agent(),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        client_runner=FakeA2AClientRunner(),
+        server_runner=server_runner,
+    )
+    await bridge.start()
+    # Yield once so the background task runs serve().
+    await asyncio.sleep(0)
+    assert server_runner.serving is True
+    await bridge.close()
+    assert server_runner.stop_called is True
+
+
+@pytest.mark.asyncio
+async def test_bridge_close_closes_client_runners() -> None:
+    runner = FakeA2AClientRunner()
+    bridge = A2ABridge.from_config(
+        {
+            "peers": [
+                {
+                    "name": "x",
+                    "url": "https://x/a2a",
+                    "auth": {"type": "bearer", "token": "t"},
+                }
+            ],
+        },
+        client_runner=runner,
+    )
+    await bridge.close()
+    assert runner.closed is True

--- a/packages/agentforge-a2a/tests/unit/test_a2a_client.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_client.py
@@ -1,0 +1,260 @@
+"""Unit tests for `agent_call` + auth helpers (feat-014 chunk 3)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from agentforge_a2a import (
+    A2APeer,
+    A2APeerConfig,
+    BearerAuth,
+    MutualTLSAuth,
+    agent_call,
+    build_outgoing_auth,
+)
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import (
+    A2AAuthError,
+    A2ACallError,
+    A2ATimeout,
+    BudgetExceeded,
+    ModuleError,
+)
+from agentforge_core.production.run_context import bind_run, new_run, reset_run
+
+
+def _make_peer(
+    name: str = "fact-checker",
+    runner: FakeA2AClientRunner | None = None,
+    auth: dict | None = None,
+) -> A2APeer:
+    runner = runner if runner is not None else FakeA2AClientRunner()
+    config = A2APeerConfig(
+        name=name,
+        url=f"https://internal.{name}.example/a2a",
+        auth=auth if auth is not None else {"type": "bearer", "token": "tok"},
+    )
+    return A2APeer.from_config(config, runner=runner)
+
+
+def test_bearer_auth_builds_header() -> None:
+    auth = BearerAuth("abc")
+    assert auth.headers == {"Authorization": "Bearer abc"}
+    assert auth.ssl_context is None
+
+
+def test_build_outgoing_auth_supports_bearer() -> None:
+    auth = build_outgoing_auth({"type": "bearer", "token": "x"})
+    assert auth.headers["Authorization"] == "Bearer x"
+
+
+def test_build_outgoing_auth_rejects_empty_bearer_token() -> None:
+    with pytest.raises(ModuleError, match="non-empty 'token'"):
+        build_outgoing_auth({"type": "bearer", "token": ""})
+
+
+def test_build_outgoing_auth_rejects_unknown_type() -> None:
+    with pytest.raises(ModuleError, match="unknown a2a auth type"):
+        build_outgoing_auth({"type": "magic", "token": "x"})
+
+
+def test_build_outgoing_auth_empty_means_no_auth() -> None:
+    auth = build_outgoing_auth({})
+    assert auth.headers == {}
+    assert auth.ssl_context is None
+
+
+def test_mutual_tls_auth_builds_ssl_context(tmp_path: Path) -> None:
+    cert, key = _write_self_signed_cert(tmp_path)
+    auth = MutualTLSAuth(cert_path=cert, key_path=key)
+    assert auth.headers == {}
+    assert auth.ssl_context is not None
+
+
+def test_build_outgoing_auth_mtls_requires_both_paths() -> None:
+    with pytest.raises(ModuleError, match="requires both 'cert' and 'key'"):
+        build_outgoing_auth({"type": "mtls", "cert": "/x"})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_happy_path() -> None:
+    runner = FakeA2AClientRunner.with_response(
+        {"output": "verified", "run_id": "callee-run", "cost_usd": 0.05}
+    )
+    peer = _make_peer(runner=runner)
+    result = await agent_call(
+        "fact-checker:verify",
+        {"claim": "x"},
+        peers={"fact-checker": peer},
+    )
+    assert result.output == "verified"
+    assert result.cost_usd == pytest.approx(0.05)
+    assert len(runner.calls) == 1
+    assert runner.calls[0].headers["Authorization"] == "Bearer tok"
+    assert runner.calls[0].json["endpoint"] == "verify"
+    assert runner.calls[0].json["payload"] == {"claim": "x"}
+
+
+@pytest.mark.asyncio
+async def test_agent_call_unknown_peer_raises_module_error() -> None:
+    with pytest.raises(ModuleError, match="unknown a2a peer"):
+        await agent_call("missing:x", {}, peers={})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_bad_target_format_raises() -> None:
+    with pytest.raises(ModuleError, match="'<peer>:<endpoint>'"):
+        await agent_call("noformat", {}, peers={"any": _make_peer()})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_translates_401_to_auth_error() -> None:
+    runner = FakeA2AClientRunner.with_response(
+        {"error": "unauthorized", "message": "bad token", "status": 401}
+    )
+    peer = _make_peer(runner=runner)
+    with pytest.raises(A2AAuthError, match="rejected credentials"):
+        await agent_call("fact-checker:x", {}, peers={"fact-checker": peer})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_translates_generic_error_body() -> None:
+    runner = FakeA2AClientRunner.with_response({"error": "bad_request", "message": "no payload"})
+    peer = _make_peer(runner=runner)
+    with pytest.raises(A2ACallError, match="bad_request"):
+        await agent_call("fact-checker:x", {}, peers={"fact-checker": peer})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_translates_timeout() -> None:
+    runner = FakeA2AClientRunner()
+    runner.set_error(TimeoutError())
+    peer = _make_peer(runner=runner)
+    with pytest.raises(A2ATimeout, match="exceeded"):
+        await agent_call("fact-checker:x", {}, peers={"fact-checker": peer})
+
+
+@pytest.mark.asyncio
+async def test_agent_call_translates_runtime_error_to_call_error() -> None:
+    runner = FakeA2AClientRunner()
+    runner.set_error(RuntimeError("connection reset"))
+    peer = _make_peer(runner=runner)
+    with pytest.raises(A2ACallError, match="connection reset"):
+        await agent_call("fact-checker:x", {}, peers={"fact-checker": peer})
+
+
+@pytest.mark.asyncio
+async def test_budget_reserve_commits_on_success() -> None:
+    runner = FakeA2AClientRunner.with_response({"output": "ok", "run_id": "r1", "cost_usd": 0.10})
+    peer = _make_peer(runner=runner)
+    budget = BudgetPolicy(usd=1.0)
+    await agent_call(
+        "fact-checker:x",
+        {},
+        peers={"fact-checker": peer},
+        budget_usd=0.25,
+        budget=budget,
+    )
+    assert budget.spent_usd == pytest.approx(0.10)
+    assert budget.reserved_usd == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_budget_releases_on_failure() -> None:
+    runner = FakeA2AClientRunner()
+    runner.set_error(RuntimeError("boom"))
+    peer = _make_peer(runner=runner)
+    budget = BudgetPolicy(usd=1.0)
+    with pytest.raises(A2ACallError):
+        await agent_call(
+            "fact-checker:x",
+            {},
+            peers={"fact-checker": peer},
+            budget_usd=0.25,
+            budget=budget,
+        )
+    assert budget.spent_usd == 0.0
+    assert budget.reserved_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_budget_exceeded_blocks_call() -> None:
+    runner = FakeA2AClientRunner.with_response({"output": "ok", "run_id": "r1", "cost_usd": 0.0})
+    peer = _make_peer(runner=runner)
+    budget = BudgetPolicy(usd=0.10)
+    with pytest.raises(BudgetExceeded):
+        await agent_call(
+            "fact-checker:x",
+            {},
+            peers={"fact-checker": peer},
+            budget_usd=1.0,
+            budget=budget,
+        )
+    # No call should have gone out — reservation blew up first.
+    assert len(runner.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_runid_header_propagated_when_run_context_bound() -> None:
+    runner = FakeA2AClientRunner.with_response({"output": "ok", "run_id": "r"})
+    peer = _make_peer(runner=runner)
+    ctx = new_run(task="caller-task")
+    token = bind_run(ctx)
+    try:
+        await agent_call("fact-checker:x", {}, peers={"fact-checker": peer})
+    finally:
+        reset_run(token)
+    assert runner.calls[0].headers["X-AgentForge-Run-Id"] == ctx.run_id
+
+
+@pytest.mark.asyncio
+async def test_budget_header_propagated() -> None:
+    runner = FakeA2AClientRunner.with_response({"output": "ok", "run_id": "r"})
+    peer = _make_peer(runner=runner)
+    await agent_call(
+        "fact-checker:x",
+        {},
+        peers={"fact-checker": peer},
+        budget_usd=0.5,
+    )
+    assert runner.calls[0].headers["X-AgentForge-Budget-Usd"].startswith("0.5")
+
+
+def _write_self_signed_cert(tmp: Path) -> tuple[Path, Path]:
+    """Generate a fresh self-signed cert+key pair via openssl.
+
+    Avoids hardcoding PEM blobs (LibreSSL vs OpenSSL parse the
+    same blob differently on macOS vs Linux) by shelling out to
+    the system's openssl binary at test time.
+    """
+    binary = shutil.which("openssl")
+    if binary is None:
+        pytest.skip("openssl binary not available")
+
+    cert = tmp / "cert.pem"
+    key = tmp / "key.pem"
+    subprocess.run(  # nosec B603 — fully-qualified binary, fixed args
+        [
+            binary,
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert, key

--- a/packages/agentforge-a2a/tests/unit/test_a2a_config.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_config.py
@@ -1,0 +1,68 @@
+"""Unit tests for `A2AConfig` (feat-014 chunk 5)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_a2a import A2ABridge, A2AConfig, A2AEndpointConfig, A2APeerConfig
+from agentforge_a2a.values import A2AExposeConfig
+from pydantic import ValidationError
+
+
+def test_a2a_config_defaults() -> None:
+    cfg = A2AConfig()
+    assert cfg.peers == []
+    assert cfg.expose is None
+
+
+def test_a2a_config_rejects_extra_keys() -> None:
+    with pytest.raises(ValidationError):
+        A2AConfig(peers=[], unknown=1)  # type: ignore[call-arg]
+
+
+def test_bearer_peer_validates() -> None:
+    cfg = A2AConfig(
+        peers=[
+            A2APeerConfig(
+                name="fact-checker",
+                url="https://x/a2a",
+                auth={"type": "bearer", "token": "t"},
+            )
+        ]
+    )
+    assert cfg.peers[0].name == "fact-checker"
+
+
+def test_mtls_peer_validates() -> None:
+    cfg = A2AConfig(
+        peers=[
+            A2APeerConfig(
+                name="x",
+                url="https://x/a2a",
+                auth={"type": "mtls", "cert": "/p/cert.pem", "key": "/p/key.pem"},
+            )
+        ]
+    )
+    assert cfg.peers[0].auth["type"] == "mtls"
+
+
+def test_expose_config_round_trip() -> None:
+    cfg = A2AConfig(
+        peers=[],
+        expose=A2AExposeConfig(
+            enabled=True,
+            host="0.0.0.0",  # nosec B104
+            port=9000,
+            auth={"type": "bearer", "expected_tokens_env": "A2A_TOKENS"},
+            endpoints=[A2AEndpointConfig(name="review-pr")],
+        ),
+    )
+    blob = cfg.model_dump_json()
+    restored = A2AConfig.model_validate_json(blob)
+    assert restored == cfg
+
+
+def test_bridge_declares_config_schema() -> None:
+    """`A2ABridge.config_schema` must point at `A2AConfig` so
+    feat-012's module-schema validator picks it up automatically
+    on `agentforge config validate`."""
+    assert A2ABridge.config_schema is A2AConfig

--- a/packages/agentforge-a2a/tests/unit/test_a2a_runner.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_runner.py
@@ -1,0 +1,28 @@
+"""Smoke tests for the runner protocols (feat-014 chunk 2)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_a2a._runner import (
+    A2AClientRunner,
+    A2AServerRunner,
+    _HTTPXClientRunner,
+    _UvicornServerRunner,
+)
+
+
+def test_production_client_runner_raises_until_live_test_lands() -> None:
+    with pytest.raises(NotImplementedError, match="not implemented yet"):
+        _HTTPXClientRunner()
+
+
+def test_production_server_runner_raises_until_live_test_lands() -> None:
+    with pytest.raises(NotImplementedError, match="not implemented yet"):
+        _UvicornServerRunner()
+
+
+def test_protocols_are_importable() -> None:
+    # Smoke: the Protocol classes are importable and runtime-checkable
+    # only structurally — a typed `Any` check is enough.
+    assert A2AClientRunner is not None
+    assert A2AServerRunner is not None

--- a/packages/agentforge-a2a/tests/unit/test_a2a_server.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_server.py
@@ -1,0 +1,189 @@
+"""Unit tests for `A2AServer` (feat-014 chunk 4)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge.agent import Agent
+from agentforge.findings import SimpleFinding
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_a2a import A2AServer
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+from fastapi.testclient import TestClient
+
+
+class _EchoStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content=f"echo:{state.task[-100:]}"))
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent() -> Agent:
+    return Agent(model=_FakeLLM(), strategy=_EchoStrategy())
+
+
+@pytest.fixture
+def server(monkeypatch: pytest.MonkeyPatch) -> A2AServer:
+    monkeypatch.setenv("A2A_TOKENS", "good,other")
+    return A2AServer(
+        agent=_agent(),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["review-pr", "verify"],
+    )
+
+
+@pytest.fixture
+def client(server: A2AServer) -> TestClient:
+    return TestClient(server.app)
+
+
+def _auth(token: str = "good") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_info_endpoint_lists_whitelist(client: TestClient) -> None:
+    r = client.get("/a2a/v1/info", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert "version" in body
+    assert set(body["endpoints"]) == {"review-pr", "verify"}
+
+
+def test_missing_bearer_returns_401(client: TestClient) -> None:
+    r = client.post("/a2a/v1/calls", json={"endpoint": "verify", "payload": {}})
+    assert r.status_code == 401
+
+
+def test_invalid_bearer_returns_401(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {}},
+        headers=_auth("nope"),
+    )
+    assert r.status_code == 401
+
+
+def test_unknown_endpoint_returns_404(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "not-listed", "payload": {}},
+        headers=_auth(),
+    )
+    assert r.status_code == 404
+
+
+def test_happy_path_returns_a2a_response(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {"claim": "x"}},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "output" in body
+    assert "echo:" in body["output"]
+    assert body["parent_run_id"] is None
+
+
+def test_parent_run_id_propagated_from_header(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {}},
+        headers={**_auth(), "X-AgentForge-Run-Id": "caller-run-123"},
+    )
+    assert r.status_code == 200
+    assert r.json()["parent_run_id"] == "caller-run-123"
+
+
+def test_budget_header_caps_inner_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    agent = _agent()
+    original_cap = agent._budget.usd
+    server = A2AServer(
+        agent=agent,
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+    client = TestClient(server.app)
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {}},
+        headers={**_auth(), "X-AgentForge-Budget-Usd": "0.05"},
+    )
+    assert r.status_code == 200
+    # Server should have restored the original budget.
+    assert agent._budget.usd == original_cap
+
+
+def test_invalid_budget_header_ignored(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {}},
+        headers={**_auth(), "X-AgentForge-Budget-Usd": "not-a-float"},
+    )
+    assert r.status_code == 200
+
+
+def test_findings_serialised_into_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+
+    class _FindingStrategy(ReasoningStrategy):
+        async def run(self, state: AgentState) -> AgentState:
+            runtime = state.metadata.get(RUNTIME_KEY)
+            if runtime is not None:
+                runtime.budget.commit(0.0)
+            state.findings.append(SimpleFinding(severity="info", category="a2a", message="ok"))
+            state.steps.append(Step(iteration=0, kind="think", content="done"))
+            return state
+
+    agent = Agent(model=_FakeLLM(), strategy=_FindingStrategy())
+    server = A2AServer(
+        agent=agent,
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+    client = TestClient(server.app)
+    r = client.post(
+        "/a2a/v1/calls",
+        json={"endpoint": "verify", "payload": {}},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    # findings tuple from RunResult is empty (the strategy
+    # populates state.findings but RunResult.findings is not
+    # plumbed from there in feat-001); the server just
+    # serialises whatever's on result.findings.
+    assert "findings" in r.json()

--- a/packages/agentforge-a2a/tests/unit/test_a2a_values.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_values.py
@@ -1,0 +1,56 @@
+"""Unit tests for A2A value models (feat-014)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_a2a import (
+    A2AEndpointConfig,
+    A2AExposeConfig,
+    A2APeerConfig,
+    A2AResponse,
+)
+from pydantic import ValidationError
+
+
+def test_a2a_response_minimal() -> None:
+    r = A2AResponse(output="ok", run_id="r1")
+    assert r.cost_usd == 0.0
+    assert r.findings == ()
+    assert r.parent_run_id is None
+
+
+def test_a2a_response_is_frozen() -> None:
+    r = A2AResponse(output="ok", run_id="r1")
+    with pytest.raises(ValidationError):
+        r.run_id = "r2"  # type: ignore[misc]
+
+
+def test_a2a_response_negative_cost_rejected() -> None:
+    with pytest.raises(ValidationError):
+        A2AResponse(output="ok", run_id="r1", cost_usd=-0.01)
+
+
+def test_a2a_peer_config_requires_name_and_url() -> None:
+    with pytest.raises(ValidationError):
+        A2APeerConfig(name="", url="https://x")
+    with pytest.raises(ValidationError):
+        A2APeerConfig(name="x", url="")
+
+
+def test_a2a_peer_config_rejects_extra() -> None:
+    with pytest.raises(ValidationError):
+        A2APeerConfig(name="n", url="u", extra=1)  # type: ignore[call-arg]
+
+
+def test_a2a_expose_config_defaults() -> None:
+    cfg = A2AExposeConfig()
+    assert cfg.enabled is True
+    assert cfg.port == 8080
+    assert cfg.endpoints == []
+
+
+def test_a2a_endpoint_config_round_trip() -> None:
+    e = A2AEndpointConfig(name="review-pr", description="d", accepts={"pr_url": "string"})
+    blob = e.model_dump_json()
+    restored = A2AEndpointConfig.model_validate_json(blob)
+    assert restored == e

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/auth.py
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/auth.py
@@ -1,62 +1,29 @@
-"""Bearer auth for `agentforge-chat-http` (feat-020 v0.2 scope).
+"""Bearer auth for `agentforge-chat-http`.
 
-`BearerAuthPolicy` is a minimal placeholder ABC; when feat-014's
-real `AuthPolicy` contract lands in `agentforge-core`, this becomes
-a thin adapter and is documented as such.
+feat-020 v0.2 shipped its own `BearerAuthPolicy` ABC + `Principal`
++ `EnvBearerAuth` here. feat-014 lifted those into canonical
+contracts in `agentforge-core` and a concrete implementation in
+`agentforge`. This module now re-exports the canonical symbols
+for backward compatibility:
 
-`EnvBearerAuth(token_env_var="API_TOKENS")` reads a
-comma-separated list of valid bearer tokens from an environment
-variable; each token maps to an opaque principal id (the token
-itself by default).
+    BearerAuthPolicy  — alias for `agentforge_core.contracts.auth.AuthPolicy`
+    Principal         — alias for `agentforge_core.values.auth.Principal`
+    EnvBearerAuth     — re-export from `agentforge.auth`
 """
 
 from __future__ import annotations
 
-import os
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from agentforge.auth import EnvBearerAuth
+from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.values.auth import Principal
 
-
-@dataclass(frozen=True)
-class Principal:
-    """Identity returned by a successful `authenticate(...)` call."""
-
-    id: str
-    metadata: dict[str, str] | None = None
-
-
-class BearerAuthPolicy(ABC):
-    """Per-feat-020 v0.2 placeholder. Refactor to feat-014's
-    `AuthPolicy` when that ships."""
-
-    @abstractmethod
-    async def authenticate(self, bearer_token: str | None) -> Principal | None:
-        """Return a `Principal` if the token is valid, else None."""
-
-
-class EnvBearerAuth(BearerAuthPolicy):
-    """Bearer-token policy backed by a comma-separated env var.
-
-    Format of ``$<token_env_var>``: ``"token1,token2,token3"``.
-    Each token is its own principal id (no token → identity map).
-    """
-
-    def __init__(self, token_env_var: str = "API_TOKENS") -> None:  # noqa: S107  # nosec B107 — env-var NAME, not a token
-        self._var = token_env_var
-
-    async def authenticate(self, bearer_token: str | None) -> Principal | None:
-        if bearer_token is None or not bearer_token:
-            return None
-        raw = os.environ.get(self._var, "")
-        if not raw:
-            return None
-        valid = {t.strip() for t in raw.split(",") if t.strip()}
-        if bearer_token in valid:
-            return Principal(id=bearer_token)
-        return None
+BearerAuthPolicy = AuthPolicy
+"""Backward-compatible alias for v0.2 consumers. New code should
+import `AuthPolicy` from `agentforge_core.contracts.auth`."""
 
 
 __all__ = [
+    "AuthPolicy",
     "BearerAuthPolicy",
     "EnvBearerAuth",
     "Principal",

--- a/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
@@ -7,6 +7,7 @@ consumes them by reference to the abstraction, never the implementation.
 
 from __future__ import annotations
 
+from agentforge_core.contracts.auth import AuthPolicy
 from agentforge_core.contracts.chat import ChatHistoryStore, HistoryTruncationStrategy
 from agentforge_core.contracts.embedding import EmbeddingClient
 from agentforge_core.contracts.evaluator import EvalResult, Evaluator
@@ -21,6 +22,7 @@ from agentforge_core.contracts.tool import Tool
 from agentforge_core.contracts.vector_store import VectorStore
 
 __all__ = [
+    "AuthPolicy",
     "ChatHistoryStore",
     "EmbeddingClient",
     "EvalResult",

--- a/packages/agentforge-core/src/agentforge_core/contracts/auth.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/auth.py
@@ -1,0 +1,33 @@
+"""`AuthPolicy` — locked authentication contract (feat-014).
+
+Both `agentforge-chat-http` (feat-020) and `agentforge-a2a`
+(feat-014) need to validate incoming bearer tokens against
+configured credentials. This contract unifies them.
+
+Server-side validation only: `authenticate(bearer_token) ->
+Principal | None`. Client-side credential attachment is
+dict-driven (per-peer config carries `{type, token, cert,
+key, ...}`) — no policy abstraction; outgoing transports build
+the right httpx parameters from the dict.
+
+Per ADR-0007 the methods on this ABC are locked once the
+feature ships. Adding a method is a major-version bump.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from agentforge_core.values.auth import Principal
+
+
+class AuthPolicy(ABC):
+    """Validates incoming bearer credentials against configured
+    identities. Implementations are typically env-backed
+    (`EnvBearerAuth`) or registry-backed."""
+
+    @abstractmethod
+    async def authenticate(self, bearer_token: str | None) -> Principal | None:
+        """Return a `Principal` when the token is valid, else
+        ``None``. ``None`` input (missing header) must yield
+        ``None``."""

--- a/packages/agentforge-core/src/agentforge_core/production/exceptions.py
+++ b/packages/agentforge-core/src/agentforge_core/production/exceptions.py
@@ -109,3 +109,28 @@ class CapabilityNotSupported(AgentForgeError):
     their supported set and this exception fires if a consumer skipped
     the `supports(...)` check.
     """
+
+
+class A2ACallError(AgentForgeError):
+    """Raised when an A2A call to a remote peer fails (feat-014).
+
+    Wraps the underlying HTTP / transport error; carries the peer
+    URL and the error code from the response body when available.
+    """
+
+
+class A2AAuthError(A2ACallError):
+    """The peer rejected the supplied credentials (HTTP 401/403).
+
+    Distinct from `A2ACallError` so callers can branch on retry
+    semantics — auth errors are not retryable without rotating
+    the credential.
+    """
+
+
+class A2ATimeout(A2ACallError):
+    """The A2A call exceeded its configured timeout.
+
+    Retryable with backoff. Subclasses `A2ACallError` so generic
+    A2A handlers catch all transport failures at one level.
+    """

--- a/packages/agentforge-core/src/agentforge_core/values/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/values/__init__.py
@@ -7,6 +7,7 @@ requires a major bump.
 
 from __future__ import annotations
 
+from agentforge_core.values.auth import Principal
 from agentforge_core.values.chat import (
     ChatChunk,
     ChatChunkKind,
@@ -79,6 +80,7 @@ __all__ = [
     "ModuleInfo",
     "Path",
     "PipelineResult",
+    "Principal",
     "RunResult",
     "SessionInfo",
     "Step",

--- a/packages/agentforge-core/src/agentforge_core/values/auth.py
+++ b/packages/agentforge-core/src/agentforge_core/values/auth.py
@@ -1,0 +1,20 @@
+"""Auth value types (feat-014).
+
+`Principal` is the identity returned by an `AuthPolicy` after a
+successful authentication. Carries an opaque ``id`` (the token
+itself by default; an opaque user id once a real identity
+provider is wired) plus optional metadata for downstream use
+(role tags, tenant id, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Identity returned by `AuthPolicy.authenticate(...)`."""
+
+    id: str
+    metadata: dict[str, str] = field(default_factory=dict)

--- a/packages/agentforge-core/tests/unit/test_auth_values.py
+++ b/packages/agentforge-core/tests/unit/test_auth_values.py
@@ -1,0 +1,26 @@
+"""Unit tests for `Principal` (feat-014)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from agentforge_core.values.auth import Principal
+
+
+def test_principal_minimal() -> None:
+    p = Principal(id="u1")
+    assert p.id == "u1"
+    assert p.metadata == {}
+
+
+def test_principal_is_frozen() -> None:
+    p = Principal(id="u1")
+    with pytest.raises(FrozenInstanceError):
+        p.id = "u2"  # type: ignore[misc]
+
+
+def test_principal_equality() -> None:
+    a = Principal(id="u1", metadata={"role": "admin"})
+    b = Principal(id="u1", metadata={"role": "admin"})
+    assert a == b

--- a/packages/agentforge-core/tests/unit/test_contracts_auth.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_auth.py
@@ -1,0 +1,27 @@
+"""Unit tests for `AuthPolicy` (feat-014)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.values.auth import Principal
+
+
+def test_auth_policy_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        AuthPolicy()  # type: ignore[abstract]
+
+
+class _NullAuth(AuthPolicy):
+    async def authenticate(self, bearer_token: str | None) -> Principal | None:
+        if bearer_token == "good":
+            return Principal(id="user-good")
+        return None
+
+
+@pytest.mark.asyncio
+async def test_minimal_subclass_works() -> None:
+    auth = _NullAuth()
+    assert (await auth.authenticate("good")) == Principal(id="user-good")
+    assert (await auth.authenticate("bad")) is None
+    assert (await auth.authenticate(None)) is None

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -29,6 +29,7 @@ from agentforge_core import FallbackChain
 import agentforge.guardrails  # noqa: F401
 from agentforge._tools import tool
 from agentforge.agent import Agent
+from agentforge.auth import EnvBearerAuth
 from agentforge.config import AgentForgeConfig, load_config
 from agentforge.findings import (
     MultiSpanFinding,
@@ -74,6 +75,7 @@ __all__ = [
     "RUNTIME_KEY",
     "Agent",
     "AgentForgeConfig",
+    "EnvBearerAuth",
     "FallbackChain",
     "InMemoryGraphStore",
     "InMemoryStore",

--- a/packages/agentforge/src/agentforge/auth.py
+++ b/packages/agentforge/src/agentforge/auth.py
@@ -1,0 +1,42 @@
+"""Concrete `AuthPolicy` implementations shipped with the framework
+(feat-014).
+
+`EnvBearerAuth(token_env_var)` reads a comma-separated list of
+valid bearer tokens from an environment variable; each token
+maps to a `Principal` whose id is the token itself. Suitable for
+small/internal deployments; production deployments typically
+implement their own `AuthPolicy` against a real identity
+provider.
+"""
+
+from __future__ import annotations
+
+import os
+
+from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.values.auth import Principal
+
+
+class EnvBearerAuth(AuthPolicy):
+    """Bearer-token policy backed by a comma-separated env var.
+
+    Format of ``$<token_env_var>``: ``"token1,token2,token3"``.
+    Each token is its own principal id (no token → identity map).
+    """
+
+    def __init__(self, token_env_var: str = "API_TOKENS") -> None:  # noqa: S107  # nosec B107 — env-var NAME
+        self._var = token_env_var
+
+    async def authenticate(self, bearer_token: str | None) -> Principal | None:
+        if bearer_token is None or not bearer_token:
+            return None
+        raw = os.environ.get(self._var, "")
+        if not raw:
+            return None
+        valid = {t.strip() for t in raw.split(",") if t.strip()}
+        if bearer_token in valid:
+            return Principal(id=bearer_token)
+        return None
+
+
+__all__ = ["EnvBearerAuth"]

--- a/packages/agentforge/tests/unit/test_env_bearer_auth.py
+++ b/packages/agentforge/tests/unit/test_env_bearer_auth.py
@@ -1,0 +1,38 @@
+"""Unit tests for `EnvBearerAuth` (feat-014)."""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge_core.values.auth import Principal
+
+
+@pytest.mark.asyncio
+async def test_valid_token_returns_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_TOKENS", "alpha,beta")
+    auth = EnvBearerAuth("API_TOKENS")
+    p = await auth.authenticate("alpha")
+    assert p == Principal(id="alpha")
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_TOKENS", "alpha")
+    assert (await EnvBearerAuth("API_TOKENS").authenticate("beta")) is None
+
+
+@pytest.mark.asyncio
+async def test_none_token_returns_none() -> None:
+    assert (await EnvBearerAuth("ANY").authenticate(None)) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_env_var_rejects_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MISSING_VAR_XYZ", raising=False)
+    assert (await EnvBearerAuth("MISSING_VAR_XYZ").authenticate("anything")) is None
+
+
+@pytest.mark.asyncio
+async def test_empty_env_var_rejects_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_TOKENS", "")
+    assert (await EnvBearerAuth("API_TOKENS").authenticate("anything")) is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "agentforge-mcp",
     "agentforge-chat",
     "agentforge-chat-http",
+    "agentforge-a2a",
 ]
 
 [tool.uv.workspace]
@@ -61,6 +62,7 @@ agentforge-guard-llamaguard = { workspace = true }
 agentforge-mcp = { workspace = true }
 agentforge-chat = { workspace = true }
 agentforge-chat-http = { workspace = true }
+agentforge-a2a = { workspace = true }
 
 [tool.uv]
 package = false   # the root is a virtual workspace; not itself published
@@ -265,6 +267,7 @@ testpaths = [
     "packages/agentforge-mcp/tests",
     "packages/agentforge-chat/tests",
     "packages/agentforge-chat-http/tests",
+    "packages/agentforge-a2a/tests",
     "tests",
 ]
 markers = [
@@ -311,6 +314,7 @@ source = [
     "packages/agentforge-mcp/src",
     "packages/agentforge-chat/src",
     "packages/agentforge-chat-http/src",
+    "packages/agentforge-a2a/src",
 ]
 branch = true
 parallel = true

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "agentforge",
+    "agentforge-a2a",
     "agentforge-bedrock",
     "agentforge-chat",
     "agentforge-chat-http",
@@ -48,6 +49,27 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.15" },
+]
+
+[[package]]
+name = "agentforge-a2a"
+version = "0.0.0"
+source = { editable = "packages/agentforge-a2a" }
+dependencies = [
+    { name = "agentforge" },
+    { name = "agentforge-core" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentforge", editable = "packages/agentforge" },
+    { name = "agentforge-core", editable = "packages/agentforge-core" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "uvicorn", specifier = ">=0.32" },
 ]
 
 [[package]]
@@ -299,6 +321,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agentforge" },
+    { name = "agentforge-a2a" },
     { name = "agentforge-bedrock" },
     { name = "agentforge-chat" },
     { name = "agentforge-chat-http" },
@@ -334,6 +357,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agentforge", editable = "packages/agentforge" },
+    { name = "agentforge-a2a", editable = "packages/agentforge-a2a" },
     { name = "agentforge-bedrock", editable = "packages/agentforge-bedrock" },
     { name = "agentforge-chat", editable = "packages/agentforge-chat" },
     { name = "agentforge-chat-http", editable = "packages/agentforge-chat-http" },


### PR DESCRIPTION
## Summary

- Ships canonical **feat-014 A2A protocol** in full spec. Wraps the one-shot `Agent.run(task)` into a cross-framework `agent_call(target, payload)` client + `A2AServer` peer-exposer; lifts feat-020's `BearerAuthPolicy` stub into a canonical `AuthPolicy` ABC shared by `chat-http` and the new `agentforge-a2a` package.
- Production HTTP runners scaffolded behind `A2AClientRunner` / `A2AServerRunner` Protocols with `# pragma: no cover` (same pattern as feat-013 MCP) until a live integration test lands. Every unit test injects the in-memory fakes from `src/_inmem_runner.py`.
- Six chunked commits; gate green at every step (ruff + mypy --strict + bandit + pytest + ≥90 % coverage).

## Chunks

| Chunk | Commit | What landed |
|---|---|---|
| 1 | `76e2373` | Canonical `agentforge_core.contracts.auth.AuthPolicy` + `Principal` + `A2ACallError` / `A2AAuthError` / `A2ATimeout` exceptions; `agentforge.auth.EnvBearerAuth`; chat-http refactor. |
| 2 | `b09915b` | New `agentforge-a2a` workspace member: pyproject + entry-point + manifest.yaml + value types + `A2AClientRunner` / `A2AServerRunner` Protocols + production stubs. |
| 3 | `06f4ba6` | `agent_call(target, payload, *, peers, timeout_s, budget_usd, budget)` + `BearerAuth` / `MutualTLSAuth` / `build_outgoing_auth` + `FakeA2AClientRunner` / `FakeA2AServerRunner` + run_id / budget header propagation. |
| 4 | `4197535` | `A2AServer` FastAPI app with `POST /a2a/v1/calls` + `GET /a2a/v1/info` + bearer auth + parent_run_id chain + budget cap; `A2ABridge.from_config` orchestrator with `start()` / `close()` lifecycle. |
| 5 | `f925e0b` | `A2AConfig` Pydantic schema + `A2ABridge.config_schema = A2AConfig` for feat-012's `validate_module_configs` hook. |
| 6 | `9bf183a` | Spec status → shipped + §10 Implementation Status + §11 Runbook + roadmap + CHANGELOG + state. |

## Deviations from the design

- **Production wire transport** scoped to `# pragma: no cover` until the first live integration test lands. Contract surface fully covered by `FakeA2AClientRunner` / `FakeA2AServerRunner`.
- **FastAPI**, not bare Starlette as spec §4.4 suggests — matches the `chat-http` precedent and the `HTTPBearer` / `Depends` / `HTTPException` idioms there.
- **Outgoing auth is dict-driven**, no policy abstraction (server-side bearer uses the canonical `AuthPolicy`).
- **`A2AResponse.findings` is `tuple[dict, ...]`** — serialised through `agentforge.recording._finding_payload` for wire cleanliness; tolerant of any `Finding`-Protocol-shaped object.
- **A2A discovery / registry**, **bi-directional streaming**, and **TS port** deferred (recorded in spec §10 Open items).

## Test plan

- [x] `uv run pre-commit run --all-files` green on every chunk (ruff format + check + mypy --strict + bandit + pytest + ≥90 % coverage on every touched package).
- [x] Core: `test_contracts_auth.py` (ABC guard + minimal subclass works), `test_auth_values.py` (Principal frozen + equality).
- [x] `agentforge`: `test_env_bearer_auth.py` (5 cases — valid / invalid / None / missing env var / empty env var).
- [x] `agentforge-a2a`: `test_a2a_values.py` (6 cases), `test_a2a_runner.py` (3 cases), `test_a2a_client.py` (19 cases covering bearer headers, mTLS SSLContext via openssl-generated cert, build_outgoing_auth edge cases, happy path, unknown peer / bad target, 401 / generic error / TimeoutError / RuntimeError translation, budget reserve + commit on success + release on failure, BudgetExceeded blocks, run_id + budget header propagation), `test_a2a_server.py` (9 cases — info, missing/invalid bearer, unknown endpoint, happy path, parent_run_id from header, budget cap, invalid budget ignored, findings serialised), `test_a2a_bridge.py` (6 cases — client-only mode, extra-key validation, expose requires agent+auth, expose builds server, start/serve/close, close drains runners), `test_a2a_config.py` (6 cases — defaults + extra-key rejection + bearer + mTLS + expose round-trip + bridge config_schema link).
- [x] chat-http: existing tests stay green after `BearerAuthPolicy` becomes an alias for the canonical `AuthPolicy`.
- [ ] (deferred) Live A2A round-trip against a real peer — documented in spec §10 Open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)