### PR TITLE
chore(docs): reconcile shipped Status on feat-002/003/004/005/007

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,10 +1,10 @@
 ---
 feature: none
-state: idle
-branch: feat/014-a2a-protocol
-started_at: null
+state: in_progress
+branch: chore/reconcile-spec-status-drift
+started_at: 2026-05-12
 last_milestone_at: 2026-05-12
-last_shipped: feat-014 shipped via PR #27 (open for review)
+last_shipped: feat-014 shipped via PR #27 (merged 2026-05-12)
 blocker: null
 flags_for_user: []
 ---

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -33,12 +33,12 @@
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
 | **feat-001** | Core contracts & `Agent` orchestrator | shipped (Python; TS pending) | 0.1 | both | `agentforge-core`, `agentforge` |
-| **feat-002** | Reasoning strategies (ReAct stable; Plan-Execute / ToT / Multi-Agent experimental) | proposed | 0.1 (ReAct), 0.3 (rest) | both | `agentforge`, `agentforge-strategies-experimental` |
-| **feat-003** | LLM & embedding providers — `LLMClient` + `EmbeddingClient`, named-provider registry (multi-LLM agents: reasoning + judge + embedding), capability negotiation | proposed | 0.1 | both | `agentforge-core` + provider modules (`agentforge-anthropic`, `-bedrock`, `-openai`, `-voyage`, ...) |
-| **feat-004** | Tools system (`@tool` decorator, `Tool` ABC, default tool set) | proposed | 0.1 | both | `agentforge` |
-| **feat-005** | Persistence — `MemoryStore` ABC + drivers (sqlite, postgres, surrealdb, neo4j) | proposed | 0.2 (sqlite, postgres), 0.3 (surrealdb, neo4j) | both | `agentforge-memory-*` |
+| **feat-002** | Reasoning strategies (ReAct + Plan-Execute + ToT + Multi-Agent — all stable from v0.1) | shipped (Python) | 0.1 | both | `agentforge` (all four loops in-runtime) |
+| **feat-003** | LLM & embedding providers — `LLMClient` + `EmbeddingClient`, named-provider registry (multi-LLM agents: reasoning + judge + embedding), capability negotiation | shipped (Python — ABCs + registry + `agentforge-bedrock`) | 0.1 | both | `agentforge-core` + provider modules (`agentforge-bedrock` shipped; `agentforge-anthropic`, `-openai`, `-voyage`, ... deferred to v0.3) |
+| **feat-004** | Tools system (`@tool` decorator, `Tool` ABC, default tool set, `FakeTool`) | shipped (Python) | 0.1 | both | `agentforge` |
+| **feat-005** | Persistence — `MemoryStore` ABC + drivers (sqlite, postgres, surrealdb, neo4j) + `VectorStore` + `GraphStore` + RAG | shipped (Python — full surface; PRs #5/#7/#8 mis-labelled per spec §10) | 0.2 (sqlite, postgres), 0.3 (surrealdb, neo4j) | both | `agentforge-memory-sqlite`, `-postgres`, `-neo4j`, `-surrealdb` |
 | **feat-006** | Evaluators (deterministic + LLM-judge: correctness, faithfulness, groundedness, hallucination, relevance, helpfulness, coverage, format compliance, regression, consistency) | shipped (Python) | 0.2 | both | `agentforge`, `agentforge-eval-geval`, optional `-ragas`, `-deepeval`, `-toxicity`, `-codeexec` |
-| **feat-007** | Production rails — cost & resilience (budget, fallback chain, run_id propagation, idempotency) | proposed | 0.1 | both | `agentforge-core`, `agentforge` |
+| **feat-007** | Production rails — cost & resilience (budget, fallback chain, run_id propagation, idempotency) | shipped (Python) | 0.1 | both | `agentforge-core`, `agentforge` |
 | **feat-008** | Findings & output shapes (Simple/Patch/Narrative/MultiSpan + renderers) | shipped (Python) | 0.1 | both | `agentforge`, `agentforge-core` |
 | **feat-009** | Observability — structured logging (JSON) + distributed tracing (OTel) + hook fan-out; vendor backends (Langfuse / Phoenix / Evidently / StatsD) deferred to follow-up sub-feats | shipped (Python, OTel only) | 0.2 | both | `agentforge`, `agentforge-otel`, future `agentforge-langfuse`, `agentforge-phoenix`, `agentforge-evidently`, `agentforge-statsd` |
 

--- a/docs/features/feat-002-reasoning-strategies.md
+++ b/docs/features/feat-002-reasoning-strategies.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-002 |
 | **Title** | Reasoning strategies — ReAct, Plan-Execute, Tree-of-Thoughts, Multi-Agent (all stable from v0.1) |
-| **Status** | proposed |
+| **Status** | shipped (Python — ReAct + Plan-Execute + ToT + Multi-Agent loops) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Last updated** | 2026-05-10 |

--- a/docs/features/feat-003-llm-provider-abstraction.md
+++ b/docs/features/feat-003-llm-provider-abstraction.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-003 |
 | **Title** | LLM & embedding providers — `LLMClient` + `EmbeddingClient` ABCs, named-provider registry, capability negotiation |
-| **Status** | proposed |
+| **Status** | shipped (Python — `LLMClient` + `EmbeddingClient` ABCs + named-provider registry; `agentforge-bedrock`) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.1 |

--- a/docs/features/feat-004-tools-system.md
+++ b/docs/features/feat-004-tools-system.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-004 |
 | **Title** | Tools system — `@tool` decorator, `Tool` ABC, default tool set |
-| **Status** | proposed |
+| **Status** | shipped (Python — `Tool` ABC + `@tool` decorator + 4 default tools + `FakeTool`) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.1 |

--- a/docs/features/feat-005-persistence-and-memory.md
+++ b/docs/features/feat-005-persistence-and-memory.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-005 |
 | **Title** | Persistence — unified MemoryStore + drivers (sqlite, postgres, surrealdb, neo4j) |
-| **Status** | proposed |
+| **Status** | shipped (Python — `MemoryStore` + sqlite/postgres/neo4j/surrealdb + `VectorStore` + `GraphStore` + RAG; PRs #5/#7/#8 mis-labelled — see §10) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.2 (sqlite, postgres), 0.3 (surrealdb, neo4j) |

--- a/docs/features/feat-007-production-rails.md
+++ b/docs/features/feat-007-production-rails.md
@@ -6,7 +6,7 @@
 |---|---|
 | **ID** | feat-007 |
 | **Title** | Production rails — cost budget, fallback chain, run_id propagation, idempotency |
-| **Status** | proposed |
+| **Status** | shipped (Python — `BudgetPolicy` + `RunContext` + `idempotency_key_for` + `RunIdFilter` + `FallbackChain`) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
 | **Target version** | 0.1 |


### PR DESCRIPTION
## Summary

- Five canonical specs and their matching `docs/features/README.md` rows were still labelled `proposed` even though every feature has shipped (feat-002 via PR #3, feat-003 via PR #4, feat-004 via PR #10, feat-005 via the mis-labelled #5/#7/#8 trio, feat-007 via PR #11).
- Doc-only: flips the `Status` field at the top of each spec to `shipped (Python — <surface summary>)`, matching the pattern set by feat-008 / 010 / 011 / 012 / 013 / 014 / 015. Updates the matching README rows.

## What about the runbook backfill?

`feedback_workflow.md` item 8 noted that runbooks for feat-001–005 needed backfilling in a chore PR after feat-007 shipped. Verified: the canonical Runbook sections for those specs are already present and substantive (140-160 lines each). No runbook authoring needed; only the metadata drift remained.

## Test plan

- [x] `uv run pre-commit run --all-files` green (every gate skipped or passed; only markdown touched).
- [x] No `proposed` Status remains for any shipped feature (`grep "^| \*\*feat-00[1-9]" docs/features/README.md | grep proposed` returns nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)