### PR TITLE
chore(release): release-notes template + pre-release checklist + tagging rule + v0.2.0 backlog reconciliation

### DIFF
--- a/.claude/checklists/pre-release.md
+++ b/.claude/checklists/pre-release.md
@@ -1,0 +1,117 @@
+# Pre-release checklist
+
+Run this checklist top-to-bottom before pushing a `vX.Y.Z` git
+tag and publishing the GitHub Release. Coordinated release train
+per ADR-0015 — every workspace package bumps to the same minor
+in lockstep.
+
+## 1. Branch + state
+
+- [ ] On `main`. Clean working tree (`git status`).
+- [ ] Synced with `origin/main` (`git pull --ff-only`).
+- [ ] Every feature PR for the target minor is merged. Open PRs
+      either ship in this train or move to the next.
+
+## 2. Version bump
+
+- [ ] Every member of `[tool.uv.workspace.members]` has its
+      `pyproject.toml` `[project] version` bumped to `X.Y.Z`.
+- [ ] Root `pyproject.toml` (if it carries a version) is bumped.
+- [ ] No pinned dep on `agentforge-core` (or any in-train
+      package) is left at an earlier minor.
+
+```bash
+# One-shot check:
+rg -n '^version = "' packages/*/pyproject.toml
+```
+
+## 3. Gate
+
+- [ ] `uv sync` succeeds against the bumped versions.
+- [ ] `uv run pre-commit run --all-files` is green
+      (ruff format + ruff check + mypy --strict + bandit +
+      pytest + ≥90 % coverage).
+- [ ] CI on `main` is green for the commit being tagged.
+
+## 4. CHANGELOG
+
+- [ ] `CHANGELOG.md`'s `[Unreleased]` section has every notable
+      change since the last tag. (Per Keep a Changelog v1.1
+      under `Added` / `Changed` / `Deprecated` / `Removed` /
+      `Fixed` / `Security`.)
+- [ ] Rename `## [Unreleased]` → `## [X.Y.Z] — YYYY-MM-DD`.
+- [ ] Append a fresh empty `## [Unreleased]` section above it
+      for the next cycle.
+- [ ] Each entry references the canonical spec
+      (`docs/features/feat-NNN-*.md`) or ADR where applicable.
+
+## 5. Release notes
+
+- [ ] Copy `.claude/templates/release-notes.md` to
+      `docs/releases/vX.Y.Z.md`.
+- [ ] Fill **every** section. Highlights, breaking changes,
+      coordinated release train table, cross-language status,
+      shipped features, acknowledgements. The template's
+      comments call out what each section needs.
+- [ ] No placeholder text (`<feature title>`, `<…>`, etc.)
+      remains.
+- [ ] Migration guide present when there is any breaking change;
+      "**None**" written out when there isn't.
+
+## 6. Docs sync
+
+- [ ] `docs/features/README.md` — every feature shipped in this
+      train shows `shipped` (not `proposed`).
+- [ ] Each shipped spec's metadata Status field reads
+      `shipped (Python — <surface>)` (or equivalent).
+- [ ] `docs/roadmap.md` Shipped table lists the new release row;
+      Backlog reflects what slid to the next train.
+- [ ] `README.md` install snippets pin the new version (if they
+      pin at all).
+
+## 7. State
+
+- [ ] `.claude/state/current.md` `last_shipped` updated.
+- [ ] `.claude/state/log.md` has a `## YYYY-MM-DDTHH:MM —
+      vX.Y.Z released` entry summarising what landed.
+
+## 8. Tag + publish
+
+- [ ] `git tag -a vX.Y.Z -m "AgentForge vX.Y.Z — <codename>"`.
+- [ ] `git push origin vX.Y.Z`.
+- [ ] `gh release create vX.Y.Z --notes-file docs/releases/vX.Y.Z.md`.
+- [ ] Verify the GitHub Release page renders the notes
+      correctly; attach any binary artefacts if applicable.
+
+## 9. Post-release
+
+- [ ] PyPI: each workspace package built and uploaded
+      (`uv build` + `twine upload` per package; or the
+      automation that will replace this once CI publishing
+      lands).
+- [ ] Announcement drafted (README / discussions / blog).
+- [ ] Bump the `[Unreleased]` section of CHANGELOG.md back to
+      empty for the next cycle (covered in §4 — verify).
+- [ ] Open a `chore/post-release-cleanup` PR if any drift was
+      surfaced during the train (rare but possible).
+
+---
+
+## Cadence reference
+
+Per ADR-0015:
+
+- During 0.x — release train every 2 weeks.
+- Patch releases (0.x.y → 0.x.(y+1)) between trains are bug
+  fixes only.
+- Breaking changes ship at minor bumps and **require** a
+  migration guide in the release notes.
+
+## References
+
+- [`.claude/templates/release-notes.md`](../templates/release-notes.md)
+- [`.claude/standards/git.md`](../standards/git.md) §Tagging &
+  releases
+- [ADR-0015 — Coordinated release train](../../docs/adr/0015-coordinated-release-train.md)
+- [Keep a Changelog v1.1](https://keepachangelog.com/en/1.1.0/)
+- [Semantic Versioning](https://semver.org/spec/v2.0.0.html)

--- a/.claude/standards/git.md
+++ b/.claude/standards/git.md
@@ -128,12 +128,69 @@ Required PR contents:
 - **Committing secrets** — pre-commit detects keys; if one slips,
   rotate immediately and history-rewrite (only if not yet pushed).
 
+## Tagging & releases
+
+AgentForge ships under a **coordinated release train** per
+[ADR-0015](../../docs/adr/0015-coordinated-release-train.md):
+every framework release (`vX.Y.Z`) bumps every in-scope
+workspace package to the same minor in lockstep. Patch
+releases between trains are bug fixes only.
+
+### Rules
+
+- **Every `vX.Y.Z` tag REQUIRES release notes.** Notes live at
+  `docs/releases/vX.Y.Z.md`, generated from the template at
+  [`.claude/templates/release-notes.md`](../templates/release-notes.md).
+  The GitHub Release body is the rendered file (`gh release
+  create --notes-file …`).
+- **Every tag follows the pre-release checklist** at
+  [`.claude/checklists/pre-release.md`](../checklists/pre-release.md).
+  Skipping the checklist is forbidden — it's the only place
+  the cross-cutting drift checks (CHANGELOG ↔ spec status ↔
+  roadmap ↔ state) are enforced in one pass.
+- **Tag format:** annotated tags only (`git tag -a vX.Y.Z -m
+  "…"`). Never push lightweight tags.
+- **Versioning:** strict SemVer ([semver.org](https://semver.org)).
+  During 0.x, every minor (0.Y → 0.(Y+1)) may carry breaking
+  changes; patches (0.x.y → 0.x.(y+1)) are bug fixes only.
+- **No skipping versions.** The next release after `vN` is
+  `v(N+1)` in the natural minor sequence. Spec metadata's
+  `Target version` field is **aspirational** — it records
+  when a feature was originally planned, not which tag
+  actually carries it. When tag cadence and original target
+  diverge, the tag wins.
+- **Release-notes format:** Keep a Changelog v1.1 section
+  vocabulary (`Added` / `Changed` / `Deprecated` / `Removed`
+  / `Fixed` / `Security`) under curated highlights up top.
+- **Coordinated train table required:** every release notes
+  page lists every workspace package and the version it went
+  to in this train. Missing rows are a release blocker.
+- **Cross-language status block required:** state Python /
+  TypeScript readiness explicitly per
+  [ADR-0002](../../docs/adr/0002-multi-language-python-typescript.md)
+  — "Python ships first during 0.x; TS catches up to parity
+  by 0.4."
+
+### Workflow
+
+1. Open a `chore/release-vX.Y.Z` branch off green `main`.
+2. Bump every package's `pyproject.toml` version.
+3. Run [`.claude/checklists/pre-release.md`](../checklists/pre-release.md)
+   end-to-end.
+4. Fill `docs/releases/vX.Y.Z.md` from the template.
+5. Update `CHANGELOG.md` (rename `[Unreleased]` → `[X.Y.Z]
+   — YYYY-MM-DD`; add a fresh empty `[Unreleased]`).
+6. PR through the normal gate. Squash-merge.
+7. Pull main; tag; push; create GitHub Release.
+
 ## Git hygiene tools
 
 - **Pre-commit** runs the full check suite (see
   `.claude/standards/testing.md`).
 - **Commit-msg hook** validates Conventional Commits format.
 - **`gh pr create`** is the standard PR-raising path.
+- **`gh release create vX.Y.Z --notes-file docs/releases/vX.Y.Z.md`**
+  is the standard publish path.
 
 ## Multi-author commits
 
@@ -147,6 +204,12 @@ Required PR contents:
 ## References
 
 - [Conventional Commits](https://www.conventionalcommits.org/)
+- [Keep a Changelog v1.1](https://keepachangelog.com/en/1.1.0/)
+- [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - [`.claude/development-pipeline.md`](../development-pipeline.md)
 - [`.claude/checklists/pre-commit.md`](../checklists/pre-commit.md)
 - [`.claude/checklists/pre-pr.md`](../checklists/pre-pr.md)
+- [`.claude/checklists/pre-release.md`](../checklists/pre-release.md)
+- [`.claude/templates/release-notes.md`](../templates/release-notes.md)
+- [ADR-0015 — Coordinated release train](../../docs/adr/0015-coordinated-release-train.md)
+- [ADR-0007 — Locked ABC versioning](../../docs/adr/0007-locked-abc-versioning.md)

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,7 +1,7 @@
 ---
 feature: none
 state: in_progress
-branch: chore/reconcile-spec-status-drift
+branch: chore/release-notes-template-and-version-cleanup
 started_at: 2026-05-12
 last_milestone_at: 2026-05-12
 last_shipped: feat-014 shipped via PR #27 (merged 2026-05-12)
@@ -56,17 +56,35 @@ Deviations recorded in spec §10:
 [`feat-020 — Chat agents (v0.2 scope)`](../../docs/features/feat-020-chat-agents.md)
 shipped in PR #26 (merged 2026-05-12).
 
-## Next pick candidates (canonical numbering)
+## Next pick candidates
 
-- **feat-014 v0.4.1 follow-ups** — production HTTP runner
-  against a real A2A peer; A2A discovery / registry;
-  bi-directional streaming.
-- **feat-020 v0.3 follow-ups** — postgres / redis / slack
-  drivers, real per-token streaming, cross-process locking,
-  provider-aware tokeniser.
-- Vendor observability sub-feats
-  (langfuse/phoenix/evidently/statsd).
-- Backfill chore PRs (Runbooks for feat-001–005).
+We haven't tagged anything yet. The next release is **v0.1.0**
+— every 0.1-target spec is shipped. After that the natural
+minor sequence is v0.2, v0.3, v0.4, 1.0 per
+[ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
+
+**Release prep (recommended first):**
+- Run [`.claude/checklists/pre-release.md`](../checklists/pre-release.md);
+  fill `docs/releases/v0.1.0.md` from
+  [`.claude/templates/release-notes.md`](../templates/release-notes.md);
+  tag and publish.
+
+**Post-0.1 feature backlog:**
+- **feat-014 follow-ups** — production HTTP A2A runner; A2A
+  discovery / registry; bi-directional streaming.
+- **feat-013 follow-up** — production MCP runner against a real
+  server.
+- **feat-020 follow-ups** — `agentforge-chat-history-postgres`,
+  `-redis`, `-slack` adapter, real per-token streaming,
+  cross-process locking, provider-aware tokeniser.
+- **Vendor observability sub-feats** —
+  `agentforge-langfuse`, `-phoenix`, `-evidently`, `-statsd`.
+- **Sub-feat backlog** — GraphRAG hybrid retrieval, BM25 +
+  vector hybrid search, `Reranker` ABC, schema migrations.
+
+Spec `Target version` metadata is aspirational and predates any
+release. When a feature lands earlier or later than its declared
+target, the tag wins.
 
 User selects on session resume.
 

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -58,33 +58,47 @@ shipped in PR #26 (merged 2026-05-12).
 
 ## Next pick candidates
 
-We haven't tagged anything yet. The next release is **v0.1.0**
-— every 0.1-target spec is shipped. After that the natural
-minor sequence is v0.2, v0.3, v0.4, 1.0 per
+We haven't tagged anything yet. The next two releases are
+**v0.1.0** (everything shipped to date) and **v0.2.0** (the
+entire current backlog). Sequence continues v0.3 → v0.4 →
+1.0 per
 [ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
 
 **Release prep (recommended first):**
-- Run [`.claude/checklists/pre-release.md`](../checklists/pre-release.md);
-  fill `docs/releases/v0.1.0.md` from
-  [`.claude/templates/release-notes.md`](../templates/release-notes.md);
-  tag and publish.
 
-**Post-0.1 feature backlog:**
+1. Run [`.claude/checklists/pre-release.md`](../checklists/pre-release.md).
+2. Fill `docs/releases/v0.1.0.md` from
+   [`.claude/templates/release-notes.md`](../templates/release-notes.md).
+3. Bump every workspace `pyproject.toml` to `0.1.0`.
+4. PR, merge, tag, publish via
+   `gh release create v0.1.0 --notes-file docs/releases/v0.1.0.md`.
+
+**v0.2.0 backlog (everything below ships in the next tag):**
+
+- **feat-013 follow-up** — production MCP runner against a
+  real server (replaces `# pragma: no cover` stubs).
 - **feat-014 follow-ups** — production HTTP A2A runner; A2A
   discovery / registry; bi-directional streaming.
-- **feat-013 follow-up** — production MCP runner against a real
-  server.
-- **feat-020 follow-ups** — `agentforge-chat-history-postgres`,
-  `-redis`, `-slack` adapter, real per-token streaming,
-  cross-process locking, provider-aware tokeniser.
-- **Vendor observability sub-feats** —
-  `agentforge-langfuse`, `-phoenix`, `-evidently`, `-statsd`.
-- **Sub-feat backlog** — GraphRAG hybrid retrieval, BM25 +
-  vector hybrid search, `Reranker` ABC, schema migrations.
+- **feat-020 follow-ups** —
+  `agentforge-chat-history-postgres`,
+  `agentforge-chat-history-redis`, `agentforge-chat-slack`
+  adapter, real per-token streaming through the strategy
+  loop, cross-process locking, provider-aware tokeniser.
+- **feat-009 vendor backends** — `agentforge-langfuse`,
+  `-phoenix`, `-evidently`, `-statsd`.
+- **Sub-feat backlog** (no canonical numbers yet) — GraphRAG
+  hybrid retrieval, BM25 + vector hybrid search, `Reranker`
+  ABC, schema migrations.
 
-Spec `Target version` metadata is aspirational and predates any
-release. When a feature lands earlier or later than its declared
-target, the tag wins.
+After v0.2.0 lands, v0.3.0 is reserved for the next round of
+community / ecosystem feedback (intentionally empty at v0.1.0
+cut). v0.4.0 brings TypeScript to parity with the Python
+v0.2 surface per
+[ADR-0002](../../docs/adr/0002-multi-language-python-typescript.md).
+
+Spec `Target version` metadata is aspirational and predates
+any release. When a feature lands earlier or later than its
+declared target, the tag wins.
 
 User selects on session resume.
 

--- a/.claude/templates/release-notes.md
+++ b/.claude/templates/release-notes.md
@@ -1,0 +1,196 @@
+# AgentForge vX.Y.Z — <release codename>
+
+> **Template usage.** Copy this file to
+> `docs/releases/vX.Y.Z.md` (create the directory on first use)
+> and fill in every section before tagging. The pre-release
+> checklist at `.claude/checklists/pre-release.md` walks you
+> through it. The final rendered notes become the body of the
+> GitHub Release attached to the `vX.Y.Z` tag.
+
+<!-- The codename is optional but recommended; pick a memorable
+     word that captures the release's theme (e.g. "Foundation",
+     "Modules", "Streaming"). It shows up in announcements and
+     gives consumers a quick mental anchor. -->
+
+---
+
+## Highlights
+
+<!-- 3-5 visible bullets, each one or two sentences. Lead with
+     what consumers can *do* now that they couldn't before. A
+     code snippet of ≤ 8 lines per highlight is welcome. Use
+     this section to set the headline; the per-category
+     sections below cover the long tail. -->
+
+- **`<feature title>`** — <one-sentence pitch>. <Optional 1-line
+  code example showing the new surface.>
+- **`<feature title>`** — <pitch>.
+- **`<feature title>`** — <pitch>.
+
+---
+
+## What's new
+
+<!-- Curate the user-facing changes. Pull from CHANGELOG.md but
+     trim implementation chatter. Each bullet should answer "what
+     can the user do differently now?", not "what did the diff
+     touch?". -->
+
+### Added
+
+- <New public surface, new package, new CLI command. One bullet
+  per locked-contract addition. Link to the canonical spec at
+  `docs/features/feat-NNN-*.md` for details.>
+
+### Changed
+
+- <Behaviour change a consumer might notice. Note backwards
+  compatibility status explicitly.>
+
+### Deprecated
+
+- <Symbol scheduled for removal in a later minor. Include the
+  replacement and the planned removal version.>
+
+### Removed
+
+- <Symbol gone in this release. Should always be paired with a
+  prior `Deprecated` entry in an earlier release.>
+
+### Fixed
+
+- <Bug fix that changes observable behaviour. Skip pure refactors
+  / test-only fixes.>
+
+### Security
+
+- <Security-relevant changes. Always called out separately.>
+
+---
+
+## Breaking changes
+
+<!-- Required section. If there are none, write "None." A 0.x →
+     0.(x+1) bump may carry breaking changes per ADR-0007; a 0.x.y
+     → 0.x.(y+1) patch must not. -->
+
+**None** — or — list each breaking change with:
+
+1. **What changed:** <one sentence>
+2. **Why:** <one sentence; cite spec / ADR>
+3. **Migration:** <code-level instructions>
+
+---
+
+## Migration guide
+
+<!-- Only present for releases with breaking changes or
+     non-trivial deprecations. Walk a consumer from the prior
+     release to this one. Code snippets > prose. -->
+
+### Upgrading from vX.(Y-1).0
+
+```diff
+- from agentforge.old_path import OldName
++ from agentforge.new_path import NewName
+```
+
+---
+
+## Coordinated release train
+
+<!-- Per ADR-0015, every framework release bumps every in-scope
+     workspace package to the same minor version. List which
+     packages went out and what version they're on after this
+     release. -->
+
+The release train cut on `<YYYY-MM-DD>` bumps every in-scope
+package to `vX.Y.Z`:
+
+| Package | Version | Surface change |
+|---|---|---|
+| `agentforge-core` | `X.Y.Z` | <one-line summary or "no change"> |
+| `agentforge` | `X.Y.Z` | <…> |
+| `agentforge-bedrock` | `X.Y.Z` | <…> |
+| `agentforge-memory-sqlite` | `X.Y.Z` | <…> |
+| `agentforge-memory-postgres` | `X.Y.Z` | <…> |
+| `agentforge-memory-neo4j` | `X.Y.Z` | <…> |
+| `agentforge-memory-surrealdb` | `X.Y.Z` | <…> |
+| `agentforge-eval-geval` | `X.Y.Z` | <…> |
+| `agentforge-otel` | `X.Y.Z` | <…> |
+| `agentforge-testing` | `X.Y.Z` | <…> |
+| `agentforge-guard-llmguard` | `X.Y.Z` | <…> |
+| `agentforge-guard-presidio` | `X.Y.Z` | <…> |
+| `agentforge-guard-nemo` | `X.Y.Z` | <…> |
+| `agentforge-guard-llamaguard` | `X.Y.Z` | <…> |
+| `agentforge-mcp` | `X.Y.Z` | <…> |
+| `agentforge-chat` | `X.Y.Z` | <…> |
+| `agentforge-chat-http` | `X.Y.Z` | <…> |
+| `agentforge-a2a` | `X.Y.Z` | <…> |
+
+<!-- Add or remove rows as packages join or leave the train. -->
+
+---
+
+## Cross-language status
+
+<!-- Per ADR-0002, Python ships first during 0.x; TypeScript
+     catches up to parity by 0.4. State explicitly which language
+     this release covers and where the other stands. -->
+
+- **Python:** released as `vX.Y.Z` on PyPI.
+- **TypeScript:** <`pending` | `vN.M.K` | "not yet started">.
+
+---
+
+## Install / upgrade
+
+```bash
+# New install
+pip install "agentforge[bedrock]==X.Y.Z"
+
+# Upgrade
+pip install --upgrade "agentforge==X.Y.Z"
+```
+
+For a project scaffolded with an earlier `agentforge new`, run:
+
+```bash
+agentforge upgrade --to X.Y.Z
+```
+
+(Three-way merge per feat-011; review the diff before accepting.)
+
+---
+
+## Shipped features
+
+<!-- Group by the matching spec at `docs/features/feat-NNN-*.md`.
+     For multi-version features (e.g. feat-020 v0.2 scope), list
+     which slice landed in this release. -->
+
+| Spec | Surface delivered in this release |
+|---|---|
+| [feat-NNN](../features/feat-NNN-slug.md) | <bullet rollup> |
+
+---
+
+## Acknowledgements
+
+<!-- Thank contributors. The first release should mention every
+     person who's authored or reviewed; subsequent releases just
+     since-last-tag. -->
+
+Thanks to <names / handles>. Generated with [Claude
+Code](https://claude.com/claude-code) (Anthropic) as the primary
+AI co-author across feat-001…feat-020 per the
+`Co-Authored-By:` commit trailers.
+
+---
+
+## Full changelog
+
+- [`CHANGELOG.md`](../CHANGELOG.md) — every package's curated
+  notes for this release.
+- `git log v<X.(Y-1).Z>..vX.Y.Z --oneline` — every commit.
+- Compare view: `https://github.com/Scaffoldic/agentforge-py/compare/vX.(Y-1).Z...vX.Y.Z`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,22 @@ Don't reference anything outside this repo.
 - CI runs the same checks plus a multi-OS test matrix (Linux,
   macOS, Windows) on Python 3.13.
 
+### Tagging + releases
+
+- Every `vX.Y.Z` tag **requires release notes** at
+  `docs/releases/vX.Y.Z.md`, generated from the template in
+  [`.claude/templates/release-notes.md`](./.claude/templates/release-notes.md)
+  and walked through [`.claude/checklists/pre-release.md`](./.claude/checklists/pre-release.md).
+  The GitHub Release body is the rendered file. Full rules in
+  [`.claude/standards/git.md`](./.claude/standards/git.md)
+  §Tagging & releases.
+- Coordinated release train per
+  [ADR-0015](./docs/adr/0015-coordinated-release-train.md):
+  every framework release bumps every in-scope workspace
+  package to the same minor.
+- No skipping versions. Spec metadata's `Target version` is
+  aspirational; the actual tag a feature lands in wins.
+
 ## How to add a new module package
 
 1. Create `packages/agentforge-<X>/` with the structure used by

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,8 +21,8 @@
 ## Versioning targets
 
 - **0.1** — minimum viable framework: hello-world in 3 lines, **all four reasoning loops (ReAct + Plan-Execute + ToT + Multi-Agent) shipped stable**, in-memory state, one provider, basic tools, scaffolding `new`, basic safety defaults (prompt-injection regex + PII redaction + tool capability gate), runbooks + `AGENTS.md` shipped in every scaffold.
-- **0.2** — modules: `add module`, persistence drivers (SQLite + Postgres), MCP, evaluators (deterministic + LLM-judge), full safety guardrail module ecosystem (LLM Guard, Presidio, NeMo, Llama Guard), chat agents (`ChatSession` + memory/sqlite history + HTTP/WebSocket/SSE server).
-- **0.3** — upgrade: `agentforge upgrade` with three-way merge; remaining persistence drivers (SurrealDB + Neo4j); remaining chat history drivers (Postgres + Redis); reference channel adapter (Slack).
+- **0.2** — modules + ecosystem: `add module`, persistence drivers (SQLite + Postgres + SurrealDB + Neo4j), MCP (incl. production runner), A2A (incl. production runner + discovery + bi-directional streaming), evaluators (deterministic + LLM-judge), full safety guardrail module ecosystem (LLM Guard, Presidio, NeMo, Llama Guard), chat agents full stack (memory + sqlite + postgres + redis history drivers + chat-http + slack reference adapter + real per-token streaming + cross-process locking), vendor observability backends (Langfuse, Phoenix, Evidently, StatsD), advanced retrieval (GraphRAG hybrid, BM25 + vector fusion, `Reranker` ABC, schema migrations).
+- **0.3** — reserved for the next round of community / ecosystem feedback; intentionally empty at v0.1.0 cut. Use this slot when 0.2 starts to overflow.
 - **0.4** — TypeScript reaches parity with Python 0.2 surface.
 - **1.0** — stability bar: contracts frozen, semver enforced, full evaluator + observability + safety stack.
 
@@ -34,53 +34,53 @@
 |---|---|---|---|---|---|
 | **feat-001** | Core contracts & `Agent` orchestrator | shipped (Python; TS pending) | 0.1 | both | `agentforge-core`, `agentforge` |
 | **feat-002** | Reasoning strategies (ReAct + Plan-Execute + ToT + Multi-Agent — all stable from v0.1) | shipped (Python) | 0.1 | both | `agentforge` (all four loops in-runtime) |
-| **feat-003** | LLM & embedding providers — `LLMClient` + `EmbeddingClient`, named-provider registry (multi-LLM agents: reasoning + judge + embedding), capability negotiation | shipped (Python — ABCs + registry + `agentforge-bedrock`) | 0.1 | both | `agentforge-core` + provider modules (`agentforge-bedrock` shipped; `agentforge-anthropic`, `-openai`, `-voyage`, ... deferred to v0.3) |
+| **feat-003** | LLM & embedding providers — `LLMClient` + `EmbeddingClient`, named-provider registry (multi-LLM agents: reasoning + judge + embedding), capability negotiation | shipped (Python — ABCs + registry + `agentforge-bedrock`) | 0.1 | both | `agentforge-core` + provider modules (`agentforge-bedrock` shipped; `agentforge-anthropic`, `-openai`, `-voyage`, ... deferred to v0.2) |
 | **feat-004** | Tools system (`@tool` decorator, `Tool` ABC, default tool set, `FakeTool`) | shipped (Python) | 0.1 | both | `agentforge` |
-| **feat-005** | Persistence — `MemoryStore` ABC + drivers (sqlite, postgres, surrealdb, neo4j) + `VectorStore` + `GraphStore` + RAG | shipped (Python — full surface; PRs #5/#7/#8 mis-labelled per spec §10) | 0.2 (sqlite, postgres), 0.3 (surrealdb, neo4j) | both | `agentforge-memory-sqlite`, `-postgres`, `-neo4j`, `-surrealdb` |
-| **feat-006** | Evaluators (deterministic + LLM-judge: correctness, faithfulness, groundedness, hallucination, relevance, helpfulness, coverage, format compliance, regression, consistency) | shipped (Python) | 0.2 | both | `agentforge`, `agentforge-eval-geval`, optional `-ragas`, `-deepeval`, `-toxicity`, `-codeexec` |
+| **feat-005** | Persistence — `MemoryStore` ABC + drivers (sqlite, postgres, surrealdb, neo4j) + `VectorStore` + `GraphStore` + RAG | shipped (Python — full surface; PRs #5/#7/#8 mis-labelled per spec §10) | 0.1 | both | `agentforge-memory-sqlite`, `-postgres`, `-neo4j`, `-surrealdb` |
+| **feat-006** | Evaluators (deterministic + LLM-judge: correctness, faithfulness, groundedness, hallucination, relevance, helpfulness, coverage, format compliance, regression, consistency) | shipped (Python) | 0.1 | both | `agentforge`, `agentforge-eval-geval`, optional `-ragas`, `-deepeval`, `-toxicity`, `-codeexec` |
 | **feat-007** | Production rails — cost & resilience (budget, fallback chain, run_id propagation, idempotency) | shipped (Python) | 0.1 | both | `agentforge-core`, `agentforge` |
 | **feat-008** | Findings & output shapes (Simple/Patch/Narrative/MultiSpan + renderers) | shipped (Python) | 0.1 | both | `agentforge`, `agentforge-core` |
-| **feat-009** | Observability — structured logging (JSON) + distributed tracing (OTel) + hook fan-out; vendor backends (Langfuse / Phoenix / Evidently / StatsD) deferred to follow-up sub-feats | shipped (Python, OTel only) | 0.2 | both | `agentforge`, `agentforge-otel`, future `agentforge-langfuse`, `agentforge-phoenix`, `agentforge-evidently`, `agentforge-statsd` |
+| **feat-009** | Observability — structured logging (JSON) + distributed tracing (OTel) + hook fan-out; vendor backends (Langfuse / Phoenix / Evidently / StatsD) slated for v0.2 | shipped (Python, OTel only) | 0.1 (framework + OTel — shipped), 0.2 (vendor backends) | both | `agentforge`, `agentforge-otel`, future `agentforge-langfuse`, `agentforge-phoenix`, `agentforge-evidently`, `agentforge-statsd` |
 
 ### Safety & security
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-018** | Safety guardrails — `InputValidator` / `OutputValidator` / `ToolCallGate` ABCs; built-in prompt-injection + PII + capability gates; modules for LLM Guard, Presidio, NeMo Guardrails, Llama Guard | shipped (Python) | 0.1 (basics), 0.2 (full ecosystem) | both | `agentforge-core` (ABCs + values + conformance), `agentforge` (built-ins + engine), `agentforge-guard-llmguard`, `agentforge-guard-presidio`, `agentforge-guard-nemo`, `agentforge-guard-llamaguard` |
+| **feat-018** | Safety guardrails — `InputValidator` / `OutputValidator` / `ToolCallGate` ABCs; built-in prompt-injection + PII + capability gates; modules for LLM Guard, Presidio, NeMo Guardrails, Llama Guard | shipped (Python — ABCs + built-ins + 4 vendor packages) | 0.1 | both | `agentforge-core` (ABCs + values + conformance), `agentforge` (built-ins + engine), `agentforge-guard-llmguard`, `agentforge-guard-presidio`, `agentforge-guard-nemo`, `agentforge-guard-llamaguard` |
 
 ### Module system
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-010** | Module discovery & resolution — entry-point auto-load + `Resolver.list_installed` + full `agentforge list/add/remove/swap module` CLI + manifest-driven module wiring | shipped (Python) | 0.2 | both | `agentforge` (CLI), `agentforge-core` (resolver + manifest) |
-| **feat-011** | Scaffolding & upgrade (`agentforge new`, `agentforge upgrade`, `agentforge fork`, six starter templates, marker-header file ownership) | shipped (Python) | 0.1 (new), 0.3 (upgrade) | both | `agentforge` (CLI; templates ship in-wheel) |
+| **feat-010** | Module discovery & resolution — entry-point auto-load + `Resolver.list_installed` + full `agentforge list/add/remove/swap module` CLI + manifest-driven module wiring | shipped (Python) | 0.1 | both | `agentforge` (CLI), `agentforge-core` (resolver + manifest) |
+| **feat-011** | Scaffolding & upgrade (`agentforge new`, `agentforge upgrade`, `agentforge fork`, six starter templates, marker-header file ownership) | shipped (Python) | 0.1 | both | `agentforge` (CLI; templates ship in-wheel) |
 | **feat-012** | Configuration system (`agentforge.yaml` schema, env var interpolation, validation, dotted-path overrides, layered env files, module-side schema integration, `agentforge config` CLI) | shipped (Python) | 0.1 | both | `agentforge-core`, `agentforge` |
 
 ### Protocols & interop
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-013** | MCP integration — `MCPServerClient` (stdio + HTTP/SSE) consumes upstream tool servers via `MCPToolAdapter`; `MCPServer` exposes local tools; `MCPBridge.from_config` orchestrates from `modules.protocols.mcp` | shipped (Python) | 0.2 | both | `agentforge-mcp` |
-| **feat-014** | A2A (agent-to-agent) protocol support — for cross-framework agent calls | shipped (Python) | 0.4 | both | `agentforge-a2a` |
+| **feat-013** | MCP integration — `MCPServerClient` (stdio + HTTP/SSE) consumes upstream tool servers via `MCPToolAdapter`; `MCPServer` exposes local tools; `MCPBridge.from_config` orchestrates from `modules.protocols.mcp` | shipped (Python — contracts + adapter + client + server + bridge; production runner slated for v0.2) | 0.1 (shipped scope), 0.2 (production runner) | both | `agentforge-mcp` |
+| **feat-014** | A2A (agent-to-agent) protocol support — for cross-framework agent calls | shipped (Python — contracts + client + server + bridge; production runner + discovery + bi-directional streaming slated for v0.2) | 0.1 (shipped scope), 0.2 (production runner + discovery + streaming) | both | `agentforge-a2a` |
 
 ### Deployment shapes
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-020** | Chat agents — `ChatSession` wrapper, `ChatHistoryStore` (memory/sqlite/postgres/redis drivers), streaming, HTTP/WebSocket/SSE server, multi-tenant isolation, per-turn cost/guardrails, idempotency, cancellation | shipped (Python v0.2 scope) | 0.2 (contracts + memory + sqlite + chat-http — shipped), 0.3 (postgres + redis + reference channel adapter + real per-token streaming) | both | `agentforge-chat`, `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-http`, optional `agentforge-chat-slack` |
+| **feat-020** | Chat agents — `ChatSession` wrapper, `ChatHistoryStore` (memory/sqlite/postgres/redis drivers), streaming, HTTP/WebSocket/SSE server, multi-tenant isolation, per-turn cost/guardrails, idempotency, cancellation | shipped (Python v0.1 scope: contracts + memory + sqlite + chat-http); v0.2 follow-up scope tracked in spec §10 | 0.2 (full stack: postgres + redis history + slack adapter + real streaming + cross-process lock + tokeniser) | both | `agentforge-chat`, `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-http`, optional `agentforge-chat-slack` |
 
 ### Pipeline
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
-| **feat-015** | Pipeline & deterministic tasks (`Pipeline`, `Task` ABC, parallel/sequential execution) | shipped (Python) | 0.2 | both | `agentforge` |
+| **feat-015** | Pipeline & deterministic tasks (`Pipeline`, `Task` ABC, parallel/sequential execution) | shipped (Python) | 0.1 | both | `agentforge` |
 
 ### Developer experience
 
 | ID | Title | Status | Target | Languages | Module(s) |
 |---|---|---|---|---|---|
 | **feat-016** | Testing framework — `agentforge.testing` namespace (MockLLMClient + FakeTool + agent_factory + pytest fixtures + record_llm/replay + conformance re-exports) + `agentforge-testing` package (GoldenSetRunner + assert_snapshot + analyze_recording) | shipped (Python) | 0.1 | both | `agentforge`, `agentforge-testing` |
-| **feat-017** | CLI runtime — `agentforge run` (+ `--replay`), `agentforge eval`, `agentforge debug`, `agentforge db {migrate,backup,restore,purge,query}`, `agentforge health` (preflight) | shipped (Python) | 0.1 (run), 0.2 (rest) | both | `agentforge` (CLI), `agentforge-core` (`MemoryStore.delete` ABC addition) |
+| **feat-017** | CLI runtime — `agentforge run` (+ `--replay`), `agentforge eval`, `agentforge debug`, `agentforge db {migrate,backup,restore,purge,query}`, `agentforge health` (preflight) | shipped (Python) | 0.1 | both | `agentforge` (CLI), `agentforge-core` (`MemoryStore.delete` ABC addition) |
 | **feat-019** | Developer experience — 16 runbooks + `AGENTS.md` / `CLAUDE.md` / `.cursorrules` rules shipped with every scaffolded agent; `agentforge docs` CLI (list / open / drift-check / serve); three-section managed/custom file format with upgrade-safe custom preservation | shipped (Python) | 0.1 (initial set) | both | `agentforge` (CLI + templates._shared) |
 
 ---

--- a/docs/features/feat-005-persistence-and-memory.md
+++ b/docs/features/feat-005-persistence-and-memory.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — `MemoryStore` + sqlite/postgres/neo4j/surrealdb + `VectorStore` + `GraphStore` + RAG; PRs #5/#7/#8 mis-labelled — see §10) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.2 (sqlite, postgres), 0.3 (surrealdb, neo4j) |
+| **Target version** | 0.1 (all four drivers + VectorStore + GraphStore + RAG — shipped) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-core` (ABC), `agentforge` (InMemory), `agentforge-memory-sqlite`, `agentforge-memory-postgres`, `agentforge-memory-surrealdb`, `agentforge-memory-neo4j` |
 | **Depends on** | feat-001, feat-008 (Finding shape), feat-010 (module system) |

--- a/docs/features/feat-009-observability.md
+++ b/docs/features/feat-009-observability.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — OTel only; vendor backends deferred) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.2 |
+| **Target version** | 0.1 (framework side: OTel root span + hook fan-out + JSON logs — shipped); 0.2 (vendor backends: Langfuse, Phoenix, Evidently, StatsD) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge` (built-in stdlib filter), `agentforge-otel`, `agentforge-langfuse`, `agentforge-phoenix` |
 | **Depends on** | feat-001, feat-007 (run_id) |

--- a/docs/features/feat-011-scaffolding-and-upgrade.md
+++ b/docs/features/feat-011-scaffolding-and-upgrade.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — `new` + 6 templates + `upgrade` + `fork`/`unfork`/`status`) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.1 (`new`), 0.3 (`upgrade`, `fork`) |
+| **Target version** | 0.1 (`new` + 6 templates + `upgrade` + `fork` / `unfork` / `status` — all shipped) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge` (CLI), `agentforge-templates` (template repo) |
 | **Depends on** | feat-010 |

--- a/docs/features/feat-013-mcp-integration.md
+++ b/docs/features/feat-013-mcp-integration.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — consume + expose, stdio + HTTP/SSE) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.2 |
+| **Target version** | 0.1 (contracts + adapter + client + server + bridge — shipped); 0.2 (production HTTP/stdio runner against a real MCP server) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-mcp` |
 | **Depends on** | feat-001, feat-004, feat-010 |

--- a/docs/features/feat-014-a2a-protocol.md
+++ b/docs/features/feat-014-a2a-protocol.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.4 (after stability bar reached on core) |
+| **Target version** | 0.1 (contracts + client + server + bridge — shipped); 0.2 (production runner + A2A discovery / registry + bi-directional streaming) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-a2a` |
 | **Depends on** | feat-001, feat-004, feat-007 (run_id propagation across calls) |

--- a/docs/features/feat-017-cli-runtime.md
+++ b/docs/features/feat-017-cli-runtime.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — `run` + `eval` + `debug` + `db {migrate,backup,restore,purge,query}` + `health`) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.1 (`run`), 0.2 (rest) |
+| **Target version** | 0.1 (`run` + `eval` + `debug` + `db {migrate,backup,restore,purge,query}` + `health` — all shipped) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge` |
 | **Depends on** | feat-001, feat-005, feat-006, feat-010, feat-012 |

--- a/docs/features/feat-018-safety-and-security-guardrails.md
+++ b/docs/features/feat-018-safety-and-security-guardrails.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python — ABCs + 4 built-ins + Agent integration + 4 vendor modules) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.2 |
+| **Target version** | 0.1 (ABCs + 4 built-in basics + 4 vendor sister packages — all shipped) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-core` (ABCs), `agentforge` (basic built-ins), `agentforge-guard-llmguard`, `agentforge-guard-presidio`, `agentforge-guard-nemo`, `agentforge-guard-llamaguard` |
 | **Depends on** | feat-001, feat-004 (Tool capabilities), feat-009 (audit through hooks), feat-010 |

--- a/docs/features/feat-020-chat-agents.md
+++ b/docs/features/feat-020-chat-agents.md
@@ -9,7 +9,7 @@
 | **Status** | shipped (Python v0.2 scope) |
 | **Owner** | kjoshi |
 | **Created** | 2026-05-09 |
-| **Target version** | 0.2 (contracts + memory + sqlite drivers + chat-http server), 0.3 (postgres + redis drivers + Slack reference adapter) |
+| **Target version** | 0.1 (contracts + memory + sqlite drivers + chat-http server — shipped); 0.2 (postgres + redis drivers + Slack reference adapter + real per-token streaming + cross-process locking + provider-aware tokeniser) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-chat` (core + in-memory + sqlite drivers), `agentforge-chat-history-postgres`, `agentforge-chat-history-redis`, `agentforge-chat-http`, optional channel adapters |
 | **Depends on** | feat-001, feat-003 (streaming capability), feat-005, feat-007 (run_id, budget, idempotency), feat-009 (session-level traces), feat-014 (auth backends reused), feat-018 (per-turn guardrails) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,54 +57,79 @@ of each spec under [`docs/features/`](./features/).
 ## Release sequence
 
 We haven't tagged anything yet. The next release is **v0.1.0**
-(every shipped feature with a `Target version: 0.1` is landed).
-After that, releases follow the natural minor sequence: v0.1 →
-v0.2 → v0.3 → v0.4 → 1.0, two-weekly during 0.x per
-[ADR-0015](./adr/0015-coordinated-release-train.md). Spec
-metadata's `Target version` field is **aspirational** (set
-when the spec was written) and may differ from the tag a
-feature actually lands in — when they diverge, the tag wins.
-The `## Shipped` table above is the durable record.
+(everything in the `## Shipped` table above lands in that
+tag). The release immediately after is **v0.2.0**, which
+contains every Backlog item listed below. After 0.2 the
+natural minor sequence continues — v0.3, v0.4, 1.0 —
+two-weekly during 0.x per
+[ADR-0015](./adr/0015-coordinated-release-train.md).
+Spec metadata's `Target version` field is **aspirational**
+(set when the spec was written) and may differ from the tag
+a feature actually lands in — when they diverge, the tag
+wins. The Shipped table above is the durable record.
 
-## Backlog (canonical numbers)
+## v0.2.0 backlog (everything below ships in 0.2)
 
-These are tracked here so they don't get lost. Full design specs
-already exist under [`docs/features/`](./features/); pick one to
-move into "In flight" when starting. Tag column is the
-**earliest tag it could land in** — actual cadence depends on
-when the work ships.
+All remaining work between v0.1.0 and v0.2.0 is in this list.
+Each item references its canonical spec under
+[`docs/features/`](./features/) or the sub-feat row at the
+bottom. Pick one to move into "In flight" when starting; mark
+`shipped` here on merge.
 
-- **feat-014 follow-ups** (tag: v0.2 or later) — production
-  HTTP runner against a real A2A peer (replaces the
-  `# pragma: no cover` stubs); A2A discovery / registry;
-  bi-directional streaming.
-- **feat-013 follow-up** (tag: v0.2 or later) — production
-  MCP runner against a real server (also replaces
-  `# pragma: no cover` stubs).
-- **feat-020 follow-ups** (tag: v0.2 or v0.3 per spec metadata)
-  — `agentforge-chat-history-postgres`,
-  `agentforge-chat-history-redis`, `agentforge-chat-slack`
-  reference adapter, real per-token streaming through the
-  strategy loop, cross-process per-session locking
-  (Redis-backed), provider-aware tokeniser in `TokenBudget`.
+### feat-013 follow-up — production MCP runner
 
-### feat-009 vendor-package sub-feats (deferred)
+The shipped MCP package scopes its production runner behind
+`MCPClientRunner` / `MCPServerRunner` protocols with
+`# pragma: no cover`. v0.2 replaces those stubs with a real
+runner against stdio + HTTP/SSE MCP servers, gated by a live
+integration test.
 
-feat-009 shipped the framework-side observability (hook fan-out,
-JSON logs, OTel root span via `agentforge-otel`). The four vendor-
-specific dashboard packages from the original spec are deferred —
-they each become a small follow-up:
+### feat-014 follow-ups — production A2A runner + discovery + streaming
 
-- **`agentforge-langfuse`** — Langfuse trace dashboard (LLM-focused).
+Three items:
+
+- **Production HTTP runner against a real A2A peer** —
+  replaces the `# pragma: no cover` stubs in
+  `agentforge_a2a._runner`.
+- **A2A discovery / registry** (spec §9 deferred).
+- **Bi-directional streaming via A2A** (spec §9 deferred).
+
+### feat-020 follow-ups — chat history + adapters + streaming
+
+Six items rolled up:
+
+- **`agentforge-chat-history-postgres`** — asyncpg-backed
+  driver.
+- **`agentforge-chat-history-redis`** — Redis-backed driver
+  with native TTL.
+- **`agentforge-chat-slack`** — reference channel adapter.
+- **Real per-token streaming through the strategy loop** —
+  graduates `ChatSession.stream()` from buffer-then-stream
+  to real per-token streaming once the strategy ABC grows a
+  `stream()` method.
+- **Cross-process per-session locking** (Redis-backed) —
+  replaces the v0.1 `WeakValueDictionary` single-process
+  lock.
+- **Provider-aware tokeniser in `TokenBudget`** — replaces
+  the 4-chars-per-token heuristic.
+
+### feat-009 vendor observability sub-feats
+
+Four small packages, each wrapping its SDK behind the same
+hook contract feat-009 locked in. OTel coverage covers the
+major bases until then.
+
+- **`agentforge-langfuse`** — Langfuse trace dashboard
+  (LLM-focused).
 - **`agentforge-phoenix`** — Phoenix / Arize dashboard.
-- **`agentforge-evidently`** — Evidently AI metrics + drift monitoring.
+- **`agentforge-evidently`** — Evidently AI metrics + drift
+  monitoring.
 - **`agentforge-statsd`** — StatsD metrics emitter.
 
-Each wraps its respective SDK behind the same hook contract feat-009
-locked in. OTel coverage (every collector that ingests OTLP) covers
-the major bases until then.
-
 ### Sub-feat backlog (no canonical number yet)
+
+Each becomes its own short spec when picked up; all
+targeted for v0.2:
 
 - **GraphRAG-style hybrid retrieval** — combines vector retrieval
   with graph expansion (pull top-k vector matches, then traverse

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,18 +54,35 @@ of each spec under [`docs/features/`](./features/).
 
 ---
 
+## Release sequence
+
+We haven't tagged anything yet. The next release is **v0.1.0**
+(every shipped feature with a `Target version: 0.1` is landed).
+After that, releases follow the natural minor sequence: v0.1 →
+v0.2 → v0.3 → v0.4 → 1.0, two-weekly during 0.x per
+[ADR-0015](./adr/0015-coordinated-release-train.md). Spec
+metadata's `Target version` field is **aspirational** (set
+when the spec was written) and may differ from the tag a
+feature actually lands in — when they diverge, the tag wins.
+The `## Shipped` table above is the durable record.
+
 ## Backlog (canonical numbers)
 
 These are tracked here so they don't get lost. Full design specs
 already exist under [`docs/features/`](./features/); pick one to
-move into "In flight" when starting.
+move into "In flight" when starting. Tag column is the
+**earliest tag it could land in** — actual cadence depends on
+when the work ships.
 
-- **feat-014 v0.4.1 follow-ups** — production HTTP runner
-  against a real A2A peer (replaces the
+- **feat-014 follow-ups** (tag: v0.2 or later) — production
+  HTTP runner against a real A2A peer (replaces the
   `# pragma: no cover` stubs); A2A discovery / registry;
   bi-directional streaming.
-- **feat-020 v0.3 follow-ups** —
-  `agentforge-chat-history-postgres`,
+- **feat-013 follow-up** (tag: v0.2 or later) — production
+  MCP runner against a real server (also replaces
+  `# pragma: no cover` stubs).
+- **feat-020 follow-ups** (tag: v0.2 or v0.3 per spec metadata)
+  — `agentforge-chat-history-postgres`,
   `agentforge-chat-history-redis`, `agentforge-chat-slack`
   reference adapter, real per-token streaming through the
   strategy loop, cross-process per-session locking


### PR DESCRIPTION
## Summary

Three pieces of release-engineering scaffolding land here, with a full version-numbering cleanup so the next two tags (v0.1.0 → v0.2.0) are unambiguously scoped.

## What's new

- **Release-notes template** at `.claude/templates/release-notes.md` — modelled on Keep a Changelog v1.1 + the patterns visible in modern OSS releases (ruff / uv / FastAPI / Pydantic). Required sections: Highlights, What's new, Breaking changes, Migration guide (when applicable), Coordinated release-train table (every workspace package + its version per ADR-0015), Cross-language status (Py / TS per ADR-0002), Install/upgrade, Shipped features, Full changelog.
- **Pre-release checklist** at `.claude/checklists/pre-release.md` — end-to-end walk before pushing a tag. Covers version bump across every workspace member, the gate, CHANGELOG rename, release-notes fill, docs sync, state files, tag + publish, post-release.
- **Tagging rule** in `.claude/standards/git.md` — every `vX.Y.Z` tag REQUIRES release notes generated from the template + checklist. `gh release create --notes-file …` is the publish path.
- **`AGENTS.md`** — new "Tagging + releases" subsection links the new files so every contributor / AI assistant reading the project's top doc sees the requirement.

## v0.2.0 backlog reconciliation

Every remaining unshipped item is now explicitly scoped to **v0.2.0**, the immediate next tag after v0.1.0. Already-shipped scope is uniformly labelled `0.1` across docs.

**Release sequence:** v0.1.0 (everything in the Shipped table) → v0.2.0 (the consolidated backlog below) → v0.3.0 (reserved; intentionally empty at v0.1.0 cut) → v0.4.0 (TypeScript reaches parity with Python v0.2 surface per ADR-0002) → 1.0.

**v0.2.0 backlog (everything in this list ships in the next tag):**

- **feat-013 follow-up** — production MCP runner against a real server (replaces `# pragma: no cover` stubs).
- **feat-014 follow-ups** — production HTTP A2A runner; A2A discovery / registry; bi-directional streaming.
- **feat-020 follow-ups** — `agentforge-chat-history-postgres`, `-redis`, `-slack` adapter, real per-token streaming through the strategy loop, cross-process locking, provider-aware tokeniser.
- **feat-009 vendor backends** — `agentforge-langfuse`, `-phoenix`, `-evidently`, `-statsd`.
- **Sub-feat backlog** (no canonical numbers yet) — GraphRAG hybrid retrieval, BM25 + vector hybrid search, `Reranker` ABC, schema migrations.

## Files touched

- `.claude/templates/release-notes.md` (new) — release-notes template.
- `.claude/checklists/pre-release.md` (new) — pre-release checklist.
- `.claude/standards/git.md` — new "Tagging & releases" section + references.
- `AGENTS.md` — new "Tagging + releases" subsection under Workflow.
- `.claude/state/current.md` — next-pick candidates restructured around v0.1.0 release prep + v0.2.0 backlog.
- `docs/features/README.md` — Versioning targets preamble rewritten; per-row Target columns reconciled.
- `docs/features/feat-{005,009,011,013,014,017,018,020}-*.md` — Target version metadata reconciled.
- `docs/roadmap.md` — Backlog section renamed and restructured under v0.2.0.

## Test plan

- [x] `uv run pre-commit run --all-files` green (doc-only; ruff/mypy/bandit skip, pytest + coverage run).
- [x] `grep "Target version" docs/features/feat-*.md | grep -E "0\.3|0\.4"` returns nothing — no stale 0.3 / 0.4 metadata.
- [x] `grep "0\.3" docs/features/README.md` returns only the explicit "reserved for community feedback" line.
- [ ] Live test: this template is used immediately to draft `docs/releases/v0.1.0.md` in the follow-up release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)