### PR TITLE
chore(release): v0.1.0 — Foundation

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,10 +1,10 @@
 ---
 feature: none
 state: in_progress
-branch: chore/release-notes-template-and-version-cleanup
+branch: chore/release-v0.1.0
 started_at: 2026-05-12
 last_milestone_at: 2026-05-12
-last_shipped: feat-014 shipped via PR #27 (merged 2026-05-12)
+last_shipped: v0.1.0 release prep in flight (PR pending)
 blocker: null
 flags_for_user: []
 ---

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1338,3 +1338,20 @@ Tooling notes:
   TimeoutError, so a single except clause catches both.
 
 Ready to push and raise PR #27.
+
+
+## 2026-05-12T18:00 — v0.1.0 release prep
+
+Branch `chore/release-v0.1.0` opens the first tag PR.
+
+- Bumped every workspace package (18 total) from `0.0.0` to
+  `0.1.0`.
+- Filled `docs/releases/v0.1.0.md` from
+  `.claude/templates/release-notes.md` (Codename:
+  Foundation).
+- CHANGELOG.md renamed `[Unreleased]` → `[0.1.0] —
+  2026-05-12` and added fresh empty `[Unreleased]` above.
+- Followed `.claude/checklists/pre-release.md` end-to-end.
+
+Pending: PR merge, then `git tag -a v0.1.0` + push + `gh
+release create v0.1.0 --notes-file docs/releases/v0.1.0.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+### Added
+
+_None yet — v0.2.0 cycle begins here._
+
+### Changed
+
+_None yet._
+
+### Deprecated
+
+_None yet._
+
+### Removed
+
+_None yet._
+
+### Fixed
+
+_None yet._
+
+### Security
+
+_None yet._
+
+---
+
+## [0.1.0] — 2026-05-12
+
+**First tagged release of AgentForge.** Coordinated release
+train per ADR-0015: every workspace package ships at `0.1.0`.
+Full release notes (highlights, train table, cross-language
+status, full shipped-feature mapping, what's-next) at
+[`docs/releases/v0.1.0.md`](docs/releases/v0.1.0.md).
+
 > **Numbering note**: PRs #5, #7, #8 shipped under labels `feat-007`,
 > `feat-009`, `feat-008` respectively, but **all three actually
 > implement portions of canonical feat-005 (Persistence — `MemoryStore`

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,300 @@
+# AgentForge v0.1.0 — Foundation
+
+The first tagged release of AgentForge. v0.1.0 ships the entire
+locked-contract surface, every reasoning loop, persistence,
+findings, evaluators, observability, guardrails, protocols
+(MCP + A2A), pipelines, chat, scaffolding, testing, and the
+operational CLI — across 18 coordinated workspace packages.
+
+---
+
+## Highlights
+
+- **Three-line agent from a fresh scaffold.** `agentforge new
+  smoke --template minimal && cd smoke && agentforge run "Hi"`
+  produces output against a real LLM. Six starter templates
+  (minimal, code-reviewer, patch-bot, docs-qa, triage,
+  research) ship in-wheel.
+- **Locked contracts.** `Agent`, `Tool`, `MemoryStore`,
+  `VectorStore`, `GraphStore`, `LLMClient`, `EmbeddingClient`,
+  `Evaluator`, `Finding`, `FindingRenderer`, `ReasoningStrategy`,
+  `Task`, `ChatHistoryStore`, `HistoryTruncationStrategy`,
+  `AuthPolicy`, `InputValidator` / `OutputValidator` /
+  `ToolCallGate` — every framework ABC is frozen behind ADR-0007.
+  Modules implement them; the runtime never reaches around.
+- **Four reasoning loops, all stable from v0.1.** `ReActLoop`
+  (default), `PlanExecuteLoop`, `TreeOfThoughts`,
+  `MultiAgentSupervisor` — pick by name in `agentforge.yaml`.
+- **Full persistence stack.** SQLite + Postgres + Neo4j +
+  SurrealDB drivers behind `MemoryStore` + `VectorStore` +
+  `GraphStore`, plus an `InMemoryStore` default and RAG
+  primitives.
+- **Operational CLI.** `agentforge run` / `eval` / `debug` /
+  `db {migrate,backup,restore,purge,query}` / `health` /
+  `config {validate,show,schema}` / `list modules` / `add` /
+  `remove` / `swap` module / `new` / `upgrade` / `fork` /
+  `unfork` / `status` / `docs`. Exit codes locked
+  (`0/1/2/3/4/5`).
+
+```python
+from agentforge import Agent
+
+async with Agent(model="bedrock:us.anthropic.claude-sonnet-4-5-20250929") as agent:
+    result = await agent.run("Say hello in three words.")
+    print(result.output)
+```
+
+---
+
+## What's new
+
+### Added
+
+- **`Agent` orchestrator** (`agentforge-core` + `agentforge`)
+  with locked constructor surface (feat-001). `async with`
+  lifecycle; `record_runs=`, `input_validators=`,
+  `output_validators=`, `tool_gates=`, `guardrail_policy=`,
+  `pipeline=` kwargs.
+- **Reasoning strategies** (feat-002): `ReActLoop`,
+  `PlanExecuteLoop`, `TreeOfThoughts`, `MultiAgentSupervisor` —
+  all in `agentforge.strategies`.
+- **LLM + embedding providers** (feat-003): `LLMClient` +
+  `EmbeddingClient` ABCs + `agentforge-bedrock` shipped.
+- **Tools system** (feat-004): `@tool` decorator + four
+  default tools + `FakeTool`.
+- **Persistence** (feat-005): `MemoryStore` ABC + `sqlite`,
+  `postgres`, `neo4j`, `surrealdb` drivers + `VectorStore` +
+  `GraphStore` + RAG primitives.
+- **Evaluators** (feat-006): `Coverage` /
+  `FormatCompliance` / `RegressionVsBaseline` / `Consistency`
+  deterministic graders + `agentforge-eval-geval` with
+  `Correctness` / `Faithfulness` / `Groundedness` /
+  `Hallucination` / `Relevance` / `Helpfulness` LLM judges.
+- **Production rails** (feat-007): `BudgetPolicy`,
+  `RunContext` + `run_id` / `parent_run_id`,
+  `idempotency_key_for`, `RunIdFilter`, `FallbackChain`.
+- **Findings + renderers** (feat-008): `SimpleFinding`,
+  `PatchFinding`, `NarrativeFinding`, `MultiSpanFinding` +
+  `RendererRegistry` + scorecard / patch-applier / markdown /
+  span-table renderers.
+- **Observability** (feat-009): `on_step` / `on_finish` hooks
+  + error isolation + JSON log format + `agentforge-otel`
+  with `OpenTelemetryHook` + framework root span.
+- **Module discovery + full module CLI** (feat-010):
+  entry-point auto-load, `Resolver.list_installed`,
+  `agentforge list / add / remove / swap module`.
+- **Scaffolding** (feat-011): `agentforge new` with six
+  starter templates rendered via Copier; `upgrade` with
+  three-way merge; `fork` / `unfork` / `status`.
+- **Configuration system** (feat-012): `agentforge.yaml`
+  schema, env var interpolation, layered env files,
+  dotted-path overrides, `AGENTFORGE_CONFIG` /
+  `AGENTFORGE_LOG_LEVEL`, module-side schema integration,
+  `agentforge config` CLI.
+- **MCP integration** (feat-013): `agentforge-mcp` package —
+  `MCPServerClient` (stdio + HTTP/SSE), `MCPServer` exposer,
+  `MCPBridge.from_config`.
+- **A2A protocol** (feat-014): `agentforge-a2a` package —
+  `agent_call(target, payload)` client + `A2AServer` +
+  `A2ABridge.from_config`; bearer + mTLS auth; canonical
+  `AuthPolicy` in `agentforge-core`.
+- **Pipeline + Task ABC** (feat-015): `agentforge.pipeline.Pipeline`
+  engine with DAG validation, `asyncio.Semaphore`
+  parallelism, per-task timeouts, continue/fail modes;
+  `PipelineFindingsTool`; `Agent(pipeline=)` wiring.
+- **Testing framework** (feat-016): `agentforge.testing`
+  namespace (`MockLLMClient`, `FakeTool`, `agent_factory`,
+  pytest fixtures, `record_llm`); `agentforge-testing` package
+  (`GoldenSetRunner`, `assert_snapshot`, `analyze_recording`).
+- **CLI runtime** (feat-017): `agentforge run` (+ `--replay`
+  / `--record`), `eval` (JSONL + JUnit), `debug` (REPL),
+  `db {migrate,backup,restore,purge,query}`, `health`.
+  `MemoryStore.delete` on the ABC; `__step` / `__eval` /
+  `__run` / `__pipeline` reserved categories.
+- **Safety guardrails** (feat-018): `InputValidator` /
+  `OutputValidator` / `ToolCallGate` ABCs + `GuardrailEngine`
+  + four built-in basics + four vendor sister packages (LLM
+  Guard, Presidio, NeMo Guardrails, Llama Guard).
+- **Developer experience** (feat-019): three-section
+  managed/custom file format; `inject_shared_scaffold` post-
+  render hook copies `_shared/` into every new scaffold; 16
+  runbooks + `AGENTS.md` + `CLAUDE.md` + `.cursorrules`
+  shipped day-one; `agentforge docs` CLI.
+- **Chat agents** (feat-020 v0.1 scope): `agentforge-chat`
+  package — `ChatSession` + `InMemoryChatHistory` +
+  `SqliteChatHistory` + four truncation strategies
+  (sliding-window / token-budget / summarise-oldest /
+  hybrid); `agentforge-chat-http` package — FastAPI REST +
+  WebSocket + SSE + bearer auth + cross-owner 403 + rate
+  limiting.
+
+### Changed
+
+- **Coordinated release train** per ADR-0015. Every workspace
+  package bumps to `0.1.0` in lockstep.
+- **Release-notes scaffolding** (PR #29) — every future tag
+  uses `.claude/templates/release-notes.md` walked through
+  `.claude/checklists/pre-release.md`.
+- **`Status` field reconciliation** (PR #28) — every shipped
+  canonical spec carries an honest `Status` line.
+
+### Deprecated
+
+- **`agentforge_chat_http.BearerAuthPolicy`** — kept as an
+  alias for the canonical
+  `agentforge_core.contracts.auth.AuthPolicy`. New code should
+  import the canonical name directly. Alias removal slated for
+  v0.3.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing release-blocking; ongoing fix-while-feature work is
+  captured per-PR.
+
+### Security
+
+- Bandit clean across every package; `bandit -c
+  pyproject.toml` runs on every PR.
+- `EnvBearerAuth(token_env_var)` is a v0.1 placeholder
+  shipped in `agentforge` and `agentforge-chat-http`.
+  Production deployments are expected to implement
+  `AuthPolicy` against a real identity provider.
+
+---
+
+## Breaking changes
+
+**None.** v0.1.0 is the first tag; there is no prior public
+surface to break.
+
+---
+
+## Migration guide
+
+Not applicable for the first release.
+
+---
+
+## Coordinated release train
+
+Per ADR-0015, every framework release bumps every in-scope
+workspace package to the same minor version simultaneously.
+The release train cut on **2026-05-12** bumps every in-scope
+package to **0.1.0**:
+
+| Package | Version | Surface change |
+|---|---|---|
+| `agentforge-core` | `0.1.0` | Locked contract surface — every ABC, value type, production-rails primitive, config schema, resolver, testing harness. |
+| `agentforge` | `0.1.0` | Runtime: `Agent`, four reasoning loops, in-memory store, tools system, configuration loader, recording / replay, pipeline runtime, CLI, scaffolding + six templates + 16 runbooks. |
+| `agentforge-bedrock` | `0.1.0` | First-party `LLMClient` against AWS Bedrock. |
+| `agentforge-memory-sqlite` | `0.1.0` | `MemoryStore` + `VectorStore` over SQLite via `aiosqlite`. |
+| `agentforge-memory-postgres` | `0.1.0` | `MemoryStore` + `VectorStore` over Postgres via `asyncpg`. |
+| `agentforge-memory-neo4j` | `0.1.0` | `GraphStore` + `MemoryStore` over Neo4j. |
+| `agentforge-memory-surrealdb` | `0.1.0` | `GraphStore` + `MemoryStore` over SurrealDB. |
+| `agentforge-eval-geval` | `0.1.0` | LLM-judge engine + 6 named graders. |
+| `agentforge-otel` | `0.1.0` | `OpenTelemetryHook` + framework root span. |
+| `agentforge-testing` | `0.1.0` | `GoldenSetRunner`, `assert_snapshot`, `analyze_recording`. |
+| `agentforge-guard-llmguard` | `0.1.0` | LLM Guard vendor wrapper. |
+| `agentforge-guard-presidio` | `0.1.0` | Presidio vendor wrapper. |
+| `agentforge-guard-nemo` | `0.1.0` | NeMo Guardrails vendor wrapper. |
+| `agentforge-guard-llamaguard` | `0.1.0` | Llama Guard vendor wrapper. |
+| `agentforge-mcp` | `0.1.0` | MCP client + server + bridge. Production runner pending live integration test (slated for v0.2). |
+| `agentforge-chat` | `0.1.0` | `ChatSession` + in-memory + SQLite history + four truncation strategies. |
+| `agentforge-chat-http` | `0.1.0` | FastAPI server (REST + WS + SSE + bearer auth). |
+| `agentforge-a2a` | `0.1.0` | A2A client + server + bridge + bearer / mTLS auth. Production runner pending live integration test (slated for v0.2). |
+
+---
+
+## Cross-language status
+
+Per ADR-0002, Python ships first during 0.x; TypeScript catches
+up to parity by v0.4.
+
+- **Python:** released as `0.1.0` on PyPI.
+- **TypeScript:** not yet started. The `typescript/agentforge-ts/`
+  workspace is empty. TS parity to Python's v0.2 surface is
+  slated for v0.4.
+
+---
+
+## Install / upgrade
+
+```bash
+# Hello-world install
+pip install "agentforge[bedrock]==0.1.0"
+
+# Or, from a fresh scaffold
+pip install agentforge==0.1.0
+agentforge new my-agent --template minimal
+cd my-agent
+agentforge run "Hi"
+```
+
+---
+
+## Shipped features
+
+| Spec | What landed in v0.1.0 |
+|---|---|
+| [feat-001](../features/feat-001-core-contracts-and-agent.md) | Locked `Agent` constructor + ABCs + value types + lifecycle. |
+| [feat-002](../features/feat-002-reasoning-strategies.md) | ReAct + Plan-Execute + ToT + Multi-Agent loops in-runtime. |
+| [feat-003](../features/feat-003-llm-provider-abstraction.md) | `LLMClient` + `EmbeddingClient` ABCs + named-provider registry + `agentforge-bedrock`. |
+| [feat-004](../features/feat-004-tools-system.md) | `Tool` ABC + `@tool` decorator + 4 default tools + `FakeTool`. |
+| [feat-005](../features/feat-005-persistence-and-memory.md) | Full persistence stack: 4 drivers + `VectorStore` + `GraphStore` + RAG. |
+| [feat-006](../features/feat-006-evaluators-and-benchmarks.md) | Deterministic graders + `agentforge-eval-geval` with 6 LLM judges. |
+| [feat-007](../features/feat-007-production-rails.md) | `BudgetPolicy` + `RunContext` + idempotency + `FallbackChain`. |
+| [feat-008](../features/feat-008-findings-and-output-shapes.md) | 4 Finding variants + `RendererRegistry` + 4 built-in renderers. |
+| [feat-009](../features/feat-009-observability.md) | Hook fan-out + JSON logs + `agentforge-otel`. Vendor backends slated for v0.2. |
+| [feat-010](../features/feat-010-module-discovery-and-cli.md) | Entry-point scan + full module CLI. |
+| [feat-011](../features/feat-011-scaffolding-and-upgrade.md) | `new` + 6 templates + `upgrade` + `fork` / `unfork` / `status`. |
+| [feat-012](../features/feat-012-configuration-system.md) | Widened root schema + env interpolation + module-side schema + `agentforge config` CLI. |
+| [feat-013](../features/feat-013-mcp-integration.md) | MCP consume + expose. Production runner slated for v0.2. |
+| [feat-014](../features/feat-014-a2a-protocol.md) | A2A client + server + bridge + canonical `AuthPolicy`. Production runner + discovery + streaming slated for v0.2. |
+| [feat-015](../features/feat-015-pipeline-and-tasks.md) | `Pipeline` engine + `Task` ABC + `PipelineFindingsTool` + `Agent(pipeline=)` wiring. |
+| [feat-016](../features/feat-016-testing-framework.md) | `agentforge.testing` namespace + `agentforge-testing` package. |
+| [feat-017](../features/feat-017-cli-runtime.md) | `run` + `eval` + `debug` + `db` + `health` + run-recording protocol. |
+| [feat-018](../features/feat-018-safety-and-security-guardrails.md) | Guardrail ABCs + `GuardrailEngine` + 4 built-ins + 4 vendor wrappers. |
+| [feat-019](../features/feat-019-developer-experience-and-ai-rules.md) | 16 runbooks + `AGENTS.md` / `CLAUDE.md` / `.cursorrules` shipped day-one + `agentforge docs` CLI. |
+| [feat-020](../features/feat-020-chat-agents.md) | `ChatSession` + in-memory / SQLite history + 4 truncation strategies + FastAPI chat-http server. Postgres / Redis / Slack / real per-token streaming / cross-process lock / provider-aware tokeniser slated for v0.2. |
+
+---
+
+## Acknowledgements
+
+Thanks to **kjoshi** — designer, implementer, reviewer across
+all 20 canonical specs. Generated with [Claude
+Code](https://claude.com/claude-code) (Anthropic) as the
+primary AI co-author across every feat-NNN PR per the
+`Co-Authored-By:` commit trailers.
+
+---
+
+## Full changelog
+
+- [`CHANGELOG.md`](../../CHANGELOG.md) — curated notes per
+  release.
+- `git log v0.1.0 --oneline` — every commit in this release
+  (no prior tag to compare against).
+- GitHub Releases page:
+  [`Scaffoldic/agentforge-py/releases/tag/v0.1.0`](https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.1.0).
+
+---
+
+## What's next — v0.2.0 backlog
+
+Tracked in [`docs/roadmap.md`](../roadmap.md). Summary:
+
+- **feat-013** — production MCP runner against a real server.
+- **feat-014** — production A2A runner + discovery / registry
+  + bi-directional streaming.
+- **feat-020** — `chat-history-postgres`, `-redis`, `-slack`
+  adapter, real per-token streaming, cross-process locking,
+  provider-aware tokeniser.
+- **feat-009 vendor backends** — `langfuse`, `phoenix`,
+  `evidently`, `statsd`.
+- **Sub-feat backlog** — GraphRAG hybrid retrieval, BM25 +
+  vector hybrid search, `Reranker` ABC, schema migrations.

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-a2a"
-version = "0.0.0"
+version = "0.1.0"
 description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-bedrock/pyproject.toml
+++ b/packages/agentforge-bedrock/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-bedrock"
-version = "0.0.0"
+version = "0.1.0"
 description = "AWS Bedrock provider for AgentForge — Anthropic, Titan, Cohere on Bedrock"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-chat-http"
-version = "0.0.0"
+version = "0.1.0"
 description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-chat"
-version = "0.0.0"
+version = "0.1.0"
 description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-core"
-version = "0.0.0"
+version = "0.1.0"
 description = "AgentForge core — stable contracts (ABCs, value types) for the agentic framework"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-eval-geval/pyproject.toml
+++ b/packages/agentforge-eval-geval/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-eval-geval"
-version = "0.0.0"
+version = "0.1.0"
 description = "LLM-judge evaluators (G-Eval) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-guard-llamaguard/pyproject.toml
+++ b/packages/agentforge-guard-llamaguard/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-llamaguard"
-version = "0.0.0"
+version = "0.1.0"
 description = "Llama Guard 3 classifier for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-guard-llmguard/pyproject.toml
+++ b/packages/agentforge-guard-llmguard/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-llmguard"
-version = "0.0.0"
+version = "0.1.0"
 description = "LLM Guard scanners for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-guard-nemo/pyproject.toml
+++ b/packages/agentforge-guard-nemo/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-nemo"
-version = "0.0.0"
+version = "0.1.0"
 description = "NeMo Guardrails programmable rails for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-guard-presidio/pyproject.toml
+++ b/packages/agentforge-guard-presidio/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-presidio"
-version = "0.0.0"
+version = "0.1.0"
 description = "Microsoft Presidio PII detector for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-mcp/pyproject.toml
+++ b/packages/agentforge-mcp/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-mcp"
-version = "0.0.0"
+version = "0.1.0"
 description = "Model Context Protocol integration for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-memory-neo4j/pyproject.toml
+++ b/packages/agentforge-memory-neo4j/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-memory-neo4j"
-version = "0.0.0"
+version = "0.1.0"
 description = "Neo4j-backed MemoryStore and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-memory-postgres/pyproject.toml
+++ b/packages/agentforge-memory-postgres/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "agentforge-memory-postgres"
-version = "0.0.0"
+version = "0.1.0"
 description = "Postgres + pgvector-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-memory-sqlite"
-version = "0.0.0"
+version = "0.1.0"
 description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-memory-surrealdb/pyproject.toml
+++ b/packages/agentforge-memory-surrealdb/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "agentforge-memory-surrealdb"
-version = "0.0.0"
+version = "0.1.0"
 description = "SurrealDB-backed MemoryStore, VectorStore, and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-otel/pyproject.toml
+++ b/packages/agentforge-otel/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-otel"
-version = "0.0.0"
+version = "0.1.0"
 description = "OpenTelemetry tracing + metrics emitter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-testing/pyproject.toml
+++ b/packages/agentforge-testing/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-testing"
-version = "0.0.0"
+version = "0.1.0"
 description = "Richer test helpers for AgentForge (golden-set runner, snapshot, recording analysis)"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "agentforge"
-version = "0.0.0"
+version = "0.1.0"
 description = "AgentForge — open-source plug-and-play framework for production AI agents"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ members = [
 
 [[package]]
 name = "agentforge"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge" }
 dependencies = [
     { name = "agentforge-core" },
@@ -53,7 +53,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-a2a"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-a2a" }
 dependencies = [
     { name = "agentforge" },
@@ -74,7 +74,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-bedrock"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-bedrock" }
 dependencies = [
     { name = "agentforge-core" },
@@ -91,7 +91,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge" },
@@ -113,7 +113,7 @@ provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-chat-http"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-chat-http" }
 dependencies = [
     { name = "agentforge" },
@@ -136,7 +136,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-core"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-core" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -153,7 +153,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-eval-geval"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-eval-geval" }
 dependencies = [
     { name = "agentforge-core" },
@@ -168,7 +168,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-guard-llamaguard"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-guard-llamaguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -179,7 +179,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llmguard"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-guard-llmguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -190,7 +190,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-nemo"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-guard-nemo" }
 dependencies = [
     { name = "agentforge-core" },
@@ -201,7 +201,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-presidio"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-guard-presidio" }
 dependencies = [
     { name = "agentforge-core" },
@@ -212,7 +212,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-mcp"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-mcp" }
 dependencies = [
     { name = "agentforge-core" },
@@ -223,7 +223,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-memory-neo4j"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-memory-neo4j" }
 dependencies = [
     { name = "agentforge-core" },
@@ -238,7 +238,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-postgres"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-memory-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -255,7 +255,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-sqlite"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-memory-sqlite" }
 dependencies = [
     { name = "agentforge-core" },
@@ -270,7 +270,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-surrealdb"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-memory-surrealdb" }
 dependencies = [
     { name = "agentforge-core" },
@@ -285,7 +285,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-otel"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-otel" }
 dependencies = [
     { name = "agentforge-core" },
@@ -302,7 +302,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-testing"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "packages/agentforge-testing" }
 dependencies = [
     { name = "agentforge" },


### PR DESCRIPTION
## Summary

First tagged release of AgentForge. Coordinated release train per [ADR-0015](docs/adr/0015-coordinated-release-train.md): every workspace package bumps from `0.0.0` to `0.1.0` in lockstep.

## Release notes

The full release notes are in [`docs/releases/v0.1.0.md`](docs/releases/v0.1.0.md) and will become the GitHub Release body. They cover:

- **Highlights** — three-line agent + locked contracts + four reasoning loops + full persistence stack + operational CLI.
- **What's new** by category (Added / Changed / Deprecated / Removed / Fixed / Security).
- **Coordinated release-train table** — every workspace package at `0.1.0` with a one-line surface summary.
- **Cross-language status** — Python `0.1.0`; TypeScript pending (slated for v0.4 per ADR-0002).
- **Install / upgrade** snippets.
- **Shipped features** — per-spec mapping covering feat-001 through feat-020.
- **What's next — v0.2.0 backlog** — pointer to `docs/roadmap.md`.

## Pre-release checklist

Walked end-to-end per [`.claude/checklists/pre-release.md`](.claude/checklists/pre-release.md):

- ✅ On `main`, clean tree, synced with `origin/main`.
- ✅ Every workspace `pyproject.toml` bumped to `0.1.0` (18 packages).
- ✅ `uv sync` regenerated `uv.lock` against the bumped versions.
- ✅ `uv run pre-commit run --all-files` green (ruff + mypy --strict + bandit + pytest + ≥90 % coverage).
- ✅ `CHANGELOG.md` renamed `[Unreleased]` → `[0.1.0] — 2026-05-12`; fresh empty `[Unreleased]` added.
- ✅ `docs/releases/v0.1.0.md` filled from the template; no placeholder text remains.
- ✅ `docs/features/README.md` + roadmap + every shipped spec's `Status` field reconciled to `shipped (Python — …)` (landed in PR #28).
- ✅ `.claude/state/current.md` + `log.md` updated.

## Post-merge

After this PR squash-merges to `main`:

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "AgentForge v0.1.0 — Foundation"
git push origin v0.1.0
gh release create v0.1.0 --notes-file docs/releases/v0.1.0.md
```

(The pre-release checklist's §8 covers this; I'll drive it once the PR is merged.)

## Files touched

- 18 × `packages/*/pyproject.toml` — version bump `0.0.0` → `0.1.0`.
- `uv.lock` — regenerated.
- `CHANGELOG.md` — `[Unreleased]` rotated.
- `docs/releases/v0.1.0.md` (new) — release notes.
- `.claude/state/current.md`, `log.md` — release state.

## Test plan

- [x] `uv run pre-commit run --all-files` green.
- [x] `grep "^version" packages/*/pyproject.toml | grep -v "0.1.0"` returns nothing.
- [x] `docs/releases/v0.1.0.md` has no `<…>` placeholder text.
- [x] CHANGELOG `[Unreleased]` is empty (ready for v0.2.0 cycle).
- [ ] (post-merge) tag pushed; GitHub Release created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)