### PR TITLE
chore(a2a): production runner + discovery + bi-directional streaming (feat-014 v0.2 follow-up)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,20 +1,23 @@
 ---
-feature: feat-013 v0.2 follow-up
-state: in_progress
-branch: chore/feat-013-production-mcp-runner
+feature: feat-014 v0.2 follow-up
+state: in_review
+branch: chore/feat-014-production-runner-discovery-streaming
 started_at: 2026-05-12
 last_milestone_at: 2026-05-12
-last_shipped: feat-013 v0.2 production MCP runner (PR pending)
+last_shipped: feat-013 v0.2 production MCP runner shipped via PR #32 (merged 2026-05-12)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-[`feat-013 — MCP integration`](../../docs/features/feat-013-mcp-integration.md)
-v0.2 follow-up: production `_SDKClientRunner` +
-`_SDKServerRunner` against the upstream `mcp` SDK; gated by
-the framework's first `@pytest.mark.live` integration test.
+[`feat-014 — A2A protocol`](../../docs/features/feat-014-a2a-protocol.md)
+v0.2 follow-up: production HTTP runner (httpx + uvicorn),
+A2A discovery (`/a2a/v1/info` + `discover_peer` +
+`A2ABridge.discover_all`), and bi-directional streaming
+(`POST /a2a/v1/calls/stream` + `agent_call_stream`). Closes
+the three open items v0.1 deferred. Also adds the framework's
+non-gating `live` CI job (≥ 2 packages now ship live tests).
 
 ## Last shipped
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1408,3 +1408,75 @@ Tooling notes:
   production runner (i.e. ≥ 2 live tests justify the job).
 
 Ready to push and raise PR.
+
+
+## 2026-05-12T22:00 — feat-014 v0.2 production A2A runner + discovery + streaming
+
+Branch `chore/feat-014-production-runner-discovery-streaming`
+opens the next v0.2 cycle PR. Closes three v0.1 deferred items
+in one bundle. Eight chunks:
+
+- chunk 1 (`149dbac`): `_HTTPXClientRunner` real body wrapping
+  `httpx.AsyncClient` (lazy client; HTTP 401/403 → `A2AAuthError`,
+  ≥ 400 → `A2ACallError`). `_UvicornServerRunner` real body
+  wrapping `uvicorn.Server` (lazy build in `serve()`; `stop()`
+  sets `should_exit`). `A2AClientRunner` Protocol gains `get(...)`
+  + `post_stream(...) -> AsyncIterator[dict]`. Fake mirrors the
+  new surface.
+- chunk 2 (`397999e`): Discovery — `A2APeerInfo` +
+  `A2AEndpointDescriptor` frozen values. `/a2a/v1/info` returns
+  full rich shape with description + JSON-Schema input shapes.
+  `discover_peer(peer)` helper + `A2ABridge.discover_all()` +
+  `bridge.peer_info` cache. Info URL derived from
+  `peer.url.swap("/calls" → "/info")`.
+- chunk 3 (`39cdeaf`): Streaming wire format — `A2AChunk` +
+  `A2AChunkKind` (step / tool_call / tool_result / done / error).
+- chunk 4 (`5aa57bf`): Streaming server `POST /a2a/v1/calls/stream`
+  returns SSE `data:` frames. Installs a one-off `on_step` hook
+  on the agent; each `Step` → `A2AChunk`. Background `agent.run`
+  task pushes terminal `done` / `error` + sentinel. 404 emits a
+  single `error` chunk (stream stays "always SSE once
+  authenticated").
+- chunk 5 (`d633033`): Streaming client `agent_call_stream(...)`
+  yields `A2AChunk`. Budget reserve on entry, commit on `done`,
+  release in `finally`. Error frames raise A2AAuthError /
+  A2ACallError; transport errors funnel through
+  `_wrap_stream_errors` helper.
+- chunk 6 (`10b0d1b`): Live integration tests (3) under
+  `packages/agentforge-a2a/tests/integration/test_a2a_live.py`.
+  Each spins up a real `uvicorn.Server` on a random free port +
+  real `_HTTPXClientRunner`; round-trips unary / discover /
+  stream; tears down. Helpers (deterministic strategy, static
+  bearer, `_spawn_server` context manager) live in the test file
+  — no extra importable module + no `__init__.py` collision with
+  agentforge-mcp's integration dir. Side adjustments:
+  `A2AResponse` drops `strict=True` (JSON round-trip
+  list↔tuple coercion); pyproject filterwarnings ignores
+  `websockets.legacy` / `uvicorn.protocols.websockets`
+  DeprecationWarnings.
+- chunk 7 (`a810583`): New `live` job in
+  `.github/workflows/ci.yml`. Runs `pytest -m live` against
+  every package shipping a `tests/integration/test_*_live.py`
+  suite (mcp + a2a as of v0.2). Ubuntu + macOS matrix on
+  Python 3.13. `continue-on-error: true` — branch protection
+  still gates on the main `test` job. Threshold for adding the
+  job was ≥ 2 packages with live tests.
+- chunk 8 (about-to-commit): spec §10 v0.2 follow-up addendum;
+  three new runbook sections (discover, stream, run live);
+  roadmap entry flipped to shipped; CHANGELOG `[Unreleased] /
+  Added + Changed` populated.
+
+Tooling notes:
+
+- uvicorn's `install_signal_handlers` needs the main thread;
+  pytest-asyncio's worker loop may not be on the main thread.
+  Live tests no-op the method on the `Server` instance so
+  startup proceeds to the socket bind.
+- `lifespan="off"` skips FastAPI's lifespan event setup for
+  the test server.
+- The `_free_port` helper picks a port via a transient
+  socket.bind on `127.0.0.1:0`; cross-platform; the small race
+  window between close + uvicorn bind has held green on
+  developer machine.
+
+Ready to push and raise PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,34 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: uv run pytest --cov --cov-report=xml --cov-fail-under=90 -q -m "not live"
 
+  live:
+    # feat-014 v0.2: live integration tests for every package that
+    # ships a `tests/integration/test_*_live.py` suite. Runs on every
+    # PR and push to main, but does NOT gate merge — branch protection
+    # stays on the `test` job. We tighten this once the live suite
+    # stabilises across more packages.
+    name: Live (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    if: success() || failure()
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
+      - name: Sync dependencies
+        run: uv sync --all-extras --dev
+      - name: Pytest live (every package shipping integration/)
+        run: uv run pytest -q -m live packages/agentforge-mcp/tests/integration packages/agentforge-a2a/tests/integration
+
   coverage-ratchet:
     name: Coverage ratchet vs main
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,47 @@ release tag bumps every workspace member to the same minor version.
 - **`live` pytest marker description** broadened to "tests
   that hit real LLM providers or spawn real protocol
   servers" (feat-013's live test is the first one shipping).
+- **feat-014 v0.2 — production A2A runner.**
+  `_HTTPXClientRunner` and `_UvicornServerRunner` now wrap
+  `httpx.AsyncClient` + `uvicorn.Server` respectively;
+  v0.1's `# pragma: no cover` `NotImplementedError` stubs are
+  replaced with real lifecycle (`close()` on the client,
+  `stop()` on the server). Bodies stay under
+  `# pragma: no cover`; coverage of the real transport lives
+  in the new live integration suite.
+- **feat-014 v0.2 — A2A discovery.** `GET /a2a/v1/info`
+  returns the full `A2APeerInfo` shape (version, server_name,
+  list of `A2AEndpointDescriptor` with description +
+  JSON-Schema input shapes). New
+  `agentforge_a2a.discover_peer(peer)` helper +
+  `A2ABridge.discover_all()` + `bridge.peer_info` cache.
+  Discovery is client-side: no central registry.
+- **feat-014 v0.2 — A2A bi-directional streaming.** Server
+  exposes `POST /a2a/v1/calls/stream` as Server-Sent-Events
+  (`text/event-stream`). Client helper `agent_call_stream(...)`
+  yields `A2AChunk` frames as they arrive. Step-level
+  granularity for v0.2 (one chunk per agent `Step` plus a
+  terminal `done` / `error`); real per-token LLM streaming
+  blocks on `ReasoningStrategy.stream()` and is deferred to
+  v0.3.
+- **Three new live integration tests** under
+  `packages/agentforge-a2a/tests/integration/` covering the
+  unary, discovery, and streaming round-trips against a real
+  uvicorn server on a random localhost port.
 
 ### Changed
 
-_None yet._
+- **CI: new non-gating `live` job.** Runs
+  `pytest -m live` against every package shipping a
+  `tests/integration/test_*_live.py` suite (mcp + a2a as of
+  v0.2). Ubuntu + macOS matrix on Python 3.13.
+  `continue-on-error: true` — branch protection still gates
+  on the main `test` job. Tightening to gate-on-merge once
+  the live suite stabilises is tracked as a v0.3 follow-up.
+- **`A2AResponse.findings` model config drops `strict=True`.**
+  JSON round-trip coerces tuple↔list; client-side
+  `model_validate(response.json())` needs the default lax
+  sequence handling. The wire format is unchanged.
 
 ### Deprecated
 

--- a/docs/features/feat-014-a2a-protocol.md
+++ b/docs/features/feat-014-a2a-protocol.md
@@ -240,10 +240,65 @@ auth contract into a canonical core ABC.
 
 ### Open items
 
-- Production runner against a real A2A peer (live
-  integration test).
-- A2A discovery / registry (spec §9).
-- Bi-directional streaming (spec §9).
+- Real per-token streaming through the strategy ABC (deferred
+  to v0.3 alongside feat-020's strategy-level streaming
+  follow-up). v0.2 ships step-level streaming.
+- A central A2A registry service (out of scope for v0.2 —
+  discovery is strictly client-side caching of well-known
+  endpoints).
+- Per-run hook kwarg on `Agent.run` (cleanup of the streaming
+  server's `agent._on_step.append(...)` / remove dance).
+- TS port.
+
+### v0.2 follow-up — production runner + discovery + bi-directional streaming
+
+Shipped on the v0.1 → v0.2 line. Closes the three open items
+that v0.1 deferred: real HTTP transport, peer discovery, and
+streaming. Coverage of the production runner is proven by
+`@pytest.mark.live` integration tests (`tests/integration/`),
+the framework's second live suite after feat-013.
+
+| Chunk | Commit | What landed |
+|---|---|---|
+| 1 | `149dbac` | `_HTTPXClientRunner` real body wrapping `httpx.AsyncClient` (lazy allocation; `verify=ssl_context or True`; HTTP 401/403 → `A2AAuthError`, ≥ 400 → `A2ACallError`); `_UvicornServerRunner` real body wrapping `uvicorn.Server` (lazy build in `serve()`; `stop()` sets `should_exit`). `A2AClientRunner` Protocol gains `get(...)` + `post_stream(...) -> AsyncIterator[dict]`. `FakeA2AClientRunner` mirrors the new surface with `set_get_response` / `set_stream` test knobs. Bodies remain `# pragma: no cover` (covered by chunk 6 live tests). |
+| 2 | `397999e` | Discovery: `A2APeerInfo` + `A2AEndpointDescriptor` frozen values; `GET /a2a/v1/info` now returns the full rich shape (version, server_name, list-of-descriptors with description + JSON-Schema input shapes); `agentforge_a2a.discover_peer(peer)` probes a peer; `A2ABridge.discover_all()` caches results on `bridge.peer_info`. Info URL is derived from the unary calls URL by swapping `/calls` for `/info` so callers configure only one URL per peer. `A2AServer.__init__` accepts `endpoint_descriptors:` + `server_name:`. |
+| 3 | `39cdeaf` | Streaming wire format: `A2AChunk` + `A2AChunkKind` (`step` / `tool_call` / `tool_result` / `done` / `error`). Public re-exports + unit tests against the fake's `responses_stream` knob. |
+| 4 | `5aa57bf` | Streaming server: `POST /a2a/v1/calls/stream` returns `text/event-stream` `data: <json>\n\n` frames. Installs a one-off `on_step` hook on the agent for the duration of one call; each `Step` becomes an `A2AChunk` (mapping `think→step`, `act→tool_call`, `observe→tool_result`); a backgrounded `agent.run(...)` task pushes a final `kind="done"` (or `kind="error"`) frame and a sentinel. The 404 path emits a single `kind="error"` chunk so the contract stays "always SSE once authenticated." Unary `/v1/calls` refactored to share the budget-cap path via `_run_with_budget_cap`. |
+| 5 | `d633033` | Streaming client: `agent_call_stream(target, payload, *, peers, ...) -> AsyncIterator[A2AChunk]`. Same target / peer / header / budget shape as `agent_call`; commits actual cost on the terminal `done` frame and releases the reservation in `finally`. `kind="error"` frames raise `A2AAuthError` / `A2ACallError` based on the embedded `content.error` code. Transport errors funnel through a `_wrap_stream_errors` helper that maps `TimeoutError → A2ATimeout`. |
+| 6 | `10b0d1b` | Live integration tests: `tests/integration/test_a2a_live.py` spins up a real `uvicorn.Server` on a random localhost port, points a real `_HTTPXClientRunner` at it, and round-trips three flows (unary `agent_call`, `discover_peer`, `agent_call_stream`). Helpers (deterministic three-step strategy, `_StaticBearerAuth`, `_spawn_server` async context manager) live in the test file itself — no extra importable module + no `__init__.py` collision with `agentforge-mcp/tests/integration/`. Two small framework adjustments: `A2AResponse` drops `strict=True` (so list↔tuple JSON coercion on `findings` round-trips cleanly), and root `pyproject.toml` ignores `websockets.legacy` / `uvicorn.protocols.websockets` `DeprecationWarning`s (uvicorn imports the legacy module at startup). |
+| 7 | `a810583` | New `live` job in `.github/workflows/ci.yml` running `pytest -m live` against every package shipping a `tests/integration/test_*_live.py` suite (mcp + a2a as of v0.2). Runs on every PR + push but does NOT gate merge (`continue-on-error: true`); branch protection stays on the main `test` job. Threshold for adding the job was ≥ 2 packages with live tests. |
+| 8 | (this PR) | Docs + Runbook + roadmap + CHANGELOG + state. |
+
+### v0.2 deviations from the v0.1 spec
+
+- **Step-level streaming, not per-token.** The streaming
+  endpoint emits one `A2AChunk` per agent `Step` plus a
+  terminal `done`. True per-token LLM streaming blocks on
+  `ReasoningStrategy.stream()` and lands alongside feat-020's
+  strategy-level streaming follow-up in v0.3.
+- **`peer.url` semantics unchanged.** `peer.url` is the full
+  unary calls URL (`https://x/a2a/v1/calls`); the streaming +
+  info URLs are derived by `_stream_url_from_calls_url(...)` /
+  `_info_url_from_calls_url(...)`. Callers still configure one
+  URL per peer.
+- **No central A2A registry server.** Discovery is strictly
+  client-side caching via `A2ABridge.discover_all()`.
+- **Hook installation on `agent._on_step`.** The streaming
+  server appends a one-off hook to the agent's hook list for
+  the duration of a single call and removes it in a `finally`
+  block. A cleaner per-run-hook surface on `Agent.run` is a
+  v0.3 cleanup.
+- **`A2AChunkKind` is distinct from `ChatChunkKind`.** A2A
+  streams agent-level steps; chat streams text. A
+  framework-wide `StreamingChunk` unification is a v0.3 polish.
+
+### Out-of-scope (deferred to v0.3+)
+
+- Real per-token LLM streaming via the strategy ABC.
+- Central A2A registry service.
+- Per-run hook kwarg on `Agent.run`.
+- Unifying `A2AChunkKind` and `ChatChunkKind`.
+- Hardening the `live` CI job to gate merge.
 - TS port.
 
 ## 11. Runbook
@@ -345,6 +400,68 @@ await bridge.start()
 `agentforge config validate` enforces the schema
 automatically — `A2ABridge.config_schema` points at
 `A2AConfig`, so feat-012's module-schema walker picks it up.
+
+### How do I discover what a peer exposes? (v0.2)
+
+```python
+from agentforge_a2a import A2APeer, BearerAuth, discover_peer
+from agentforge_a2a._runner import _HTTPXClientRunner
+
+runner = _HTTPXClientRunner()
+peer = A2APeer(
+    name="fact-checker",
+    url="https://internal.fact-checker.example/a2a/v1/calls",
+    auth=BearerAuth(os.environ["FACT_CHECKER_TOKEN"]),
+    runner=runner,
+)
+info = await discover_peer(peer, timeout_s=10.0)
+for ep in info.endpoints:
+    print(ep.name, "—", ep.description, ep.input_schema)
+```
+
+When you have multiple peers wired through `A2ABridge`,
+`await bridge.discover_all()` probes them all and caches the
+results on `bridge.peer_info`.
+
+### How do I stream a long-running agent call? (v0.2)
+
+```python
+from agentforge_a2a import agent_call_stream
+
+async for chunk in agent_call_stream(
+    "fact-checker:verify",
+    {"claim": "x"},
+    peers={"fact-checker": peer},
+    timeout_s=60.0,
+    budget_usd=0.25,
+):
+    if chunk.kind in {"step", "tool_call", "tool_result"}:
+        print(chunk.kind, chunk.step)
+    elif chunk.kind == "done":
+        print("done →", chunk.content)
+    elif chunk.kind == "error":
+        # agent_call_stream raises A2AAuthError / A2ACallError
+        # on error frames — this branch is for completeness.
+        raise RuntimeError(chunk.content)
+```
+
+Step-level granularity for v0.2: one chunk per agent `Step`
+(mapped from `Step.kind`) plus a final `done`. Real per-token
+streaming through the strategy ABC lands in v0.3 alongside
+feat-020's strategy-level streaming follow-up.
+
+### How do I run the live A2A tests?
+
+```bash
+uv run pytest -m live packages/agentforge-a2a/tests/integration/
+```
+
+Each test spins up a real `uvicorn.Server` on a random
+localhost port, points a real `_HTTPXClientRunner` at it,
+round-trips the three flows (`agent_call` / `discover_peer` /
+`agent_call_stream`), and tears down. The default
+pre-commit + CI gate skips this suite via `-m "not live"`; CI
+runs it in a dedicated non-gating `live` job.
 
 ## 12. References
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,13 +96,34 @@ What remains for v0.2.1:
 
 ### feat-014 follow-ups — production A2A runner + discovery + streaming
 
-Three items:
+**Status: shipped on the v0.1 → v0.2 line** (see spec §10 "v0.2
+follow-up"). Three items all landed in one PR:
 
-- **Production HTTP runner against a real A2A peer** —
-  replaces the `# pragma: no cover` stubs in
-  `agentforge_a2a._runner`.
-- **A2A discovery / registry** (spec §9 deferred).
-- **Bi-directional streaming via A2A** (spec §9 deferred).
+- **Production HTTP runner** — `_HTTPXClientRunner` +
+  `_UvicornServerRunner` now wrap `httpx.AsyncClient` /
+  `uvicorn.Server`; v0.1's `# pragma: no cover` stubs are
+  replaced. Bodies stay under `# pragma: no cover`; coverage
+  proven by `@pytest.mark.live` integration tests.
+- **A2A discovery** — `GET /a2a/v1/info` carries the full
+  endpoint catalogue (description + JSON-Schema input
+  shapes); `agentforge_a2a.discover_peer(peer)` +
+  `A2ABridge.discover_all()` + `bridge.peer_info`. Strictly
+  client-side; no central registry.
+- **Bi-directional streaming** — `POST /a2a/v1/calls/stream`
+  returns SSE `A2AChunk` frames; client helper
+  `agent_call_stream(...)` yields them. Step-level
+  granularity for v0.2.
+
+What remains for v0.3:
+
+- Real per-token LLM streaming via `ReasoningStrategy.stream()`
+  (lands alongside feat-020's strategy-level streaming
+  follow-up).
+- Per-run hook kwarg on `Agent.run` (cleanup of the streaming
+  server's transient `agent._on_step.append(...)` dance).
+- Central A2A registry service (still out of v0.x scope).
+- Unifying `A2AChunkKind` with `ChatChunkKind` under a
+  framework-wide `StreamingChunk`.
 
 ### feat-020 follow-ups — chat history + adapters + streaming
 

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -4,6 +4,7 @@ Public surface:
 
 - `agent_call(target, payload, *, peers, ...)` — outgoing A2A
   client.
+- `discover_peer(peer)` — probe a peer's `/a2a/v1/info`.
 - `A2APeer` — per-peer config + runner.
 - `A2AServer(agent, ..., auth, endpoints)` — FastAPI server
   exposing this agent as an A2A peer.
@@ -12,19 +13,23 @@ Public surface:
 - `BearerAuth` / `MutualTLSAuth` — client-side credential
   builders. (Server-side bearer validation uses the canonical
   `agentforge_core.contracts.auth.AuthPolicy`.)
+- `A2APeerInfo`, `A2AEndpointDescriptor` — discovery wire
+  shapes returned by `/a2a/v1/info`.
 """
 
 from __future__ import annotations
 
 from agentforge_a2a.auth import BearerAuth, ClientAuth, MutualTLSAuth, build_outgoing_auth
 from agentforge_a2a.bridge import A2ABridge
-from agentforge_a2a.client import A2APeer, agent_call
+from agentforge_a2a.client import A2APeer, agent_call, discover_peer
 from agentforge_a2a.config import A2AConfig
 from agentforge_a2a.server import A2AServer
 from agentforge_a2a.values import (
     A2AEndpointConfig,
+    A2AEndpointDescriptor,
     A2AExposeConfig,
     A2APeerConfig,
+    A2APeerInfo,
     A2AResponse,
 )
 
@@ -32,9 +37,11 @@ __all__ = [
     "A2ABridge",
     "A2AConfig",
     "A2AEndpointConfig",
+    "A2AEndpointDescriptor",
     "A2AExposeConfig",
     "A2APeer",
     "A2APeerConfig",
+    "A2APeerInfo",
     "A2AResponse",
     "A2AServer",
     "BearerAuth",
@@ -42,4 +49,5 @@ __all__ = [
     "MutualTLSAuth",
     "agent_call",
     "build_outgoing_auth",
+    "discover_peer",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -25,6 +25,8 @@ from agentforge_a2a.client import A2APeer, agent_call, discover_peer
 from agentforge_a2a.config import A2AConfig
 from agentforge_a2a.server import A2AServer
 from agentforge_a2a.values import (
+    A2AChunk,
+    A2AChunkKind,
     A2AEndpointConfig,
     A2AEndpointDescriptor,
     A2AExposeConfig,
@@ -35,6 +37,8 @@ from agentforge_a2a.values import (
 
 __all__ = [
     "A2ABridge",
+    "A2AChunk",
+    "A2AChunkKind",
     "A2AConfig",
     "A2AEndpointConfig",
     "A2AEndpointDescriptor",

--- a/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from agentforge_a2a.auth import BearerAuth, ClientAuth, MutualTLSAuth, build_outgoing_auth
 from agentforge_a2a.bridge import A2ABridge
-from agentforge_a2a.client import A2APeer, agent_call, discover_peer
+from agentforge_a2a.client import A2APeer, agent_call, agent_call_stream, discover_peer
 from agentforge_a2a.config import A2AConfig
 from agentforge_a2a.server import A2AServer
 from agentforge_a2a.values import (
@@ -52,6 +52,7 @@ __all__ = [
     "ClientAuth",
     "MutualTLSAuth",
     "agent_call",
+    "agent_call_stream",
     "build_outgoing_auth",
     "discover_peer",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/_inmem_runner.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/_inmem_runner.py
@@ -15,6 +15,7 @@ the fakes for their own integration tests.
 from __future__ import annotations
 
 import ssl
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -23,18 +24,28 @@ from typing import Any
 class _Call:
     url: str
     headers: dict[str, str]
-    json: dict[str, Any]
+    json: dict[str, Any] | None
     ssl_context: ssl.SSLContext | None
     timeout_s: float
 
 
 class FakeA2AClientRunner:
-    """Records POSTs and returns a configurable canned response."""
+    """Records POSTs / GETs / streams and returns canned data."""
 
-    def __init__(self, *, response: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        response: dict[str, Any] | None = None,
+        get_response: dict[str, Any] | None = None,
+        responses_stream: list[dict[str, Any]] | None = None,
+    ) -> None:
         self._response: dict[str, Any] = response if response is not None else {}
+        self._get_response: dict[str, Any] | None = get_response
+        self._stream: list[dict[str, Any]] = list(responses_stream or [])
         self._error: Exception | None = None
         self.calls: list[_Call] = []
+        self.get_calls: list[_Call] = []
+        self.stream_calls: list[_Call] = []
         self.closed = False
 
     @classmethod
@@ -44,8 +55,14 @@ class FakeA2AClientRunner:
     def set_response(self, response: dict[str, Any]) -> None:
         self._response = response
 
+    def set_get_response(self, response: dict[str, Any]) -> None:
+        self._get_response = response
+
+    def set_stream(self, chunks: list[dict[str, Any]]) -> None:
+        self._stream = list(chunks)
+
     def set_error(self, error: Exception) -> None:
-        """Next `post()` will raise this error."""
+        """Next `post()` (or `get()` / `post_stream()`) raises this."""
         self._error = error
 
     async def post(
@@ -70,6 +87,53 @@ class FakeA2AClientRunner:
             err, self._error = self._error, None
             raise err
         return dict(self._response)
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        self.get_calls.append(
+            _Call(
+                url=url,
+                headers=dict(headers),
+                json=None,
+                ssl_context=ssl_context,
+                timeout_s=timeout_s,
+            )
+        )
+        if self._error is not None:
+            err, self._error = self._error, None
+            raise err
+        body = self._get_response if self._get_response is not None else self._response
+        return dict(body)
+
+    async def post_stream(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.stream_calls.append(
+            _Call(
+                url=url,
+                headers=dict(headers),
+                json=dict(json),
+                ssl_context=ssl_context,
+                timeout_s=timeout_s,
+            )
+        )
+        if self._error is not None:
+            err, self._error = self._error, None
+            raise err
+        for chunk in self._stream:
+            yield dict(chunk)
 
     async def close(self) -> None:
         self.closed = True

--- a/packages/agentforge-a2a/src/agentforge_a2a/_runner.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/_runner.py
@@ -6,16 +6,23 @@ for the embedded server. Tests inject fakes so the unit suite
 doesn't need a real network socket.
 
 Production runners (`_HTTPXClientRunner`, `_UvicornServerRunner`)
-are scaffolded behind ``# pragma: no cover`` until the
-framework's first live A2A integration test lands. The contract
-surface is fully covered by the fake runners in
-`_inmem_runner.py`.
+are exercised by the `@pytest.mark.live` integration tests in
+`tests/integration/` (feat-014 v0.2 follow-up). Their bodies
+stay under ``# pragma: no cover`` because the unit suite uses
+the fakes in `_inmem_runner.py`; coverage of the real transport
+lives in the live job.
 """
 
 from __future__ import annotations
 
 import ssl
-from typing import Any, Protocol
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    import httpx
+    import uvicorn
+    from fastapi import FastAPI
 
 
 class A2AClientRunner(Protocol):
@@ -33,6 +40,25 @@ class A2AClientRunner(Protocol):
         timeout_s: float,
     ) -> dict[str, Any]: ...
 
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]: ...
+
+    def post_stream(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> AsyncIterator[dict[str, Any]]: ...
+
     async def close(self) -> None: ...
 
 
@@ -46,22 +72,31 @@ class A2AServerRunner(Protocol):
     async def stop(self) -> None: ...
 
 
-class _HTTPXClientRunner:
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
+_SSE_DATA_PREFIX = "data: "
+
+
+class _HTTPXClientRunner:  # pragma: no cover — exercised only with `-m live`
     """Production `A2AClientRunner` — wraps `httpx.AsyncClient`.
 
-    Pragma-no-cover until the first live A2A integration test
-    lands. Unit tests inject `FakeA2AClientRunner` from
-    `_inmem_runner.py`.
+    The client is allocated lazily on the first call so
+    instantiation stays cheap and the constructor stays sync.
+    `close()` shuts the underlying httpx client down.
     """
 
-    def __init__(self) -> None:  # pragma: no cover — live transport
-        raise NotImplementedError(
-            "Production A2A runner not implemented yet. Inject a "
-            "FakeA2AClientRunner in tests, or wait for the live "
-            "integration scaffolding (feat-014 v0.4.1 follow-up)."
-        )
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
 
-    async def post(  # pragma: no cover
+    def _ensure_client(self, ssl_context: ssl.SSLContext | None) -> httpx.AsyncClient:
+        if self._client is None:
+            import httpx  # noqa: PLC0415
+
+            verify: ssl.SSLContext | bool = ssl_context if ssl_context is not None else True
+            self._client = httpx.AsyncClient(verify=verify)
+        return self._client
+
+    async def post(
         self,
         url: str,
         *,
@@ -70,30 +105,135 @@ class _HTTPXClientRunner:
         ssl_context: ssl.SSLContext | None,
         timeout_s: float,
     ) -> dict[str, Any]:
-        raise NotImplementedError
-
-    async def close(self) -> None:  # pragma: no cover
-        raise NotImplementedError
-
-
-class _UvicornServerRunner:
-    """Production `A2AServerRunner` — wraps `uvicorn.Server`.
-
-    Pragma-no-cover until live integration tests land.
-    """
-
-    def __init__(self) -> None:  # pragma: no cover — live transport
-        raise NotImplementedError(
-            "Production A2A server runner not implemented yet. Inject "
-            "FakeA2AServerRunner in tests, or wait for the live "
-            "integration scaffolding (feat-014 v0.4.1 follow-up)."
+        from agentforge_core.production.exceptions import (  # noqa: PLC0415
+            A2AAuthError,
+            A2ACallError,
         )
 
-    async def serve(self) -> None:  # pragma: no cover
-        raise NotImplementedError
+        client = self._ensure_client(ssl_context)
+        response = await client.post(url, headers=headers, json=json, timeout=timeout_s)
+        if response.status_code in (_HTTP_UNAUTHORIZED, _HTTP_FORBIDDEN):
+            raise A2AAuthError(
+                f"a2a peer rejected credentials ({response.status_code}): {response.text!r}"
+            )
+        if response.status_code >= 400:  # noqa: PLR2004
+            raise A2ACallError(f"a2a peer returned HTTP {response.status_code}: {response.text!r}")
+        parsed: dict[str, Any] = response.json()
+        return parsed
 
-    async def stop(self) -> None:  # pragma: no cover
-        raise NotImplementedError
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        from agentforge_core.production.exceptions import (  # noqa: PLC0415
+            A2AAuthError,
+            A2ACallError,
+        )
+
+        client = self._ensure_client(ssl_context)
+        response = await client.get(url, headers=headers, timeout=timeout_s)
+        if response.status_code in (_HTTP_UNAUTHORIZED, _HTTP_FORBIDDEN):
+            raise A2AAuthError(
+                f"a2a peer rejected credentials ({response.status_code}): {response.text!r}"
+            )
+        if response.status_code >= 400:  # noqa: PLR2004
+            raise A2ACallError(f"a2a peer returned HTTP {response.status_code}: {response.text!r}")
+        parsed: dict[str, Any] = response.json()
+        return parsed
+
+    async def post_stream(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        ssl_context: ssl.SSLContext | None,
+        timeout_s: float,
+    ) -> AsyncIterator[dict[str, Any]]:
+        import json as _json  # noqa: PLC0415
+
+        from agentforge_core.production.exceptions import (  # noqa: PLC0415
+            A2AAuthError,
+            A2ACallError,
+        )
+
+        client = self._ensure_client(ssl_context)
+        stream_headers = dict(headers)
+        stream_headers.setdefault("Accept", "text/event-stream")
+        async with client.stream(
+            "POST", url, headers=stream_headers, json=json, timeout=timeout_s
+        ) as response:
+            if response.status_code in (_HTTP_UNAUTHORIZED, _HTTP_FORBIDDEN):
+                await response.aread()
+                raise A2AAuthError(
+                    f"a2a peer rejected credentials ({response.status_code}): {response.text!r}"
+                )
+            if response.status_code >= 400:  # noqa: PLR2004
+                await response.aread()
+                raise A2ACallError(
+                    f"a2a peer returned HTTP {response.status_code}: {response.text!r}"
+                )
+            async for line in response.aiter_lines():
+                if not line or not line.startswith(_SSE_DATA_PREFIX):
+                    continue
+                payload = line[len(_SSE_DATA_PREFIX) :]
+                try:
+                    parsed: dict[str, Any] = _json.loads(payload)
+                except _json.JSONDecodeError as exc:
+                    raise A2ACallError(
+                        f"a2a peer streamed an unparseable SSE frame: {payload!r}"
+                    ) from exc
+                yield parsed
+
+    async def close(self) -> None:
+        if self._client is None:
+            return
+        client, self._client = self._client, None
+        await client.aclose()
+
+
+class _UvicornServerRunner:  # pragma: no cover — exercised only with `-m live`
+    """Production `A2AServerRunner` — wraps `uvicorn.Server`.
+
+    `serve()` blocks until either an external signal sets
+    `should_exit = True` or `stop()` is called from another
+    task. `stop()` is idempotent.
+    """
+
+    def __init__(
+        self,
+        app: FastAPI,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        log_level: str = "info",
+    ) -> None:
+        self._app = app
+        self._host = host
+        self._port = port
+        self._log_level = log_level
+        self._server: uvicorn.Server | None = None
+
+    async def serve(self) -> None:
+        import uvicorn  # noqa: PLC0415
+
+        config = uvicorn.Config(
+            self._app, host=self._host, port=self._port, log_level=self._log_level
+        )
+        self._server = uvicorn.Server(config)
+        try:
+            await self._server.serve()
+        finally:
+            self._server = None
+
+    async def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.should_exit = True
 
 
 __all__ = [

--- a/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/bridge.py
@@ -23,9 +23,10 @@ from agentforge.agent import Agent
 from agentforge_core.contracts.auth import AuthPolicy
 
 from agentforge_a2a._runner import A2AClientRunner, A2AServerRunner
-from agentforge_a2a.client import A2APeer
+from agentforge_a2a.client import A2APeer, discover_peer
 from agentforge_a2a.config import A2AConfig
 from agentforge_a2a.server import A2AServer
+from agentforge_a2a.values import A2APeerInfo
 
 
 class A2ABridge:
@@ -50,6 +51,7 @@ class A2ABridge:
         self._peers = dict(peers)
         self._server = server
         self._serve_task: asyncio.Task[None] | None = None
+        self._peer_info: dict[str, A2APeerInfo] = {}
 
     @property
     def peers(self) -> dict[str, A2APeer]:
@@ -58,6 +60,12 @@ class A2ABridge:
     @property
     def server(self) -> A2AServer | None:
         return self._server
+
+    @property
+    def peer_info(self) -> dict[str, A2APeerInfo]:
+        """Cached `A2APeerInfo` keyed by peer name (populated by
+        `discover_all()` — empty until then)."""
+        return dict(self._peer_info)
 
     @classmethod
     def from_config(
@@ -98,11 +106,25 @@ class A2ABridge:
                 agent=agent,
                 auth=auth,
                 endpoints=[e.name for e in validated.expose.endpoints],
+                endpoint_descriptors=list(validated.expose.endpoints),
                 host=validated.expose.host,
                 port=validated.expose.port,
                 runner=server_runner,
             )
         return cls(peers=peers, server=server)
+
+    async def discover_all(self, *, timeout_s: float = 10.0) -> dict[str, A2APeerInfo]:
+        """Probe every configured peer's `/a2a/v1/info` endpoint
+        and cache the result on `self.peer_info`.
+
+        Re-callable — replaces the cached entry per peer. Caller-
+        driven: never invoked automatically by `start()`.
+        """
+        fresh: dict[str, A2APeerInfo] = {}
+        for name, peer in self._peers.items():
+            fresh[name] = await discover_peer(peer, timeout_s=timeout_s)
+        self._peer_info = fresh
+        return dict(self._peer_info)
 
     async def start(self) -> None:
         """Launch the server (if any) in the background. Idempotent."""

--- a/packages/agentforge-a2a/src/agentforge_a2a/client.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/client.py
@@ -31,7 +31,10 @@ from agentforge_core.production.run_context import current_run
 
 from agentforge_a2a._runner import A2AClientRunner
 from agentforge_a2a.auth import ClientAuth, build_outgoing_auth
-from agentforge_a2a.values import A2APeerConfig, A2AResponse
+from agentforge_a2a.values import A2APeerConfig, A2APeerInfo, A2AResponse
+
+_CALLS_SUFFIX = "/calls"
+_INFO_PATH = "/info"
 
 HTTP_UNAUTHORIZED = 401
 HTTP_FORBIDDEN = 403
@@ -133,6 +136,48 @@ async def agent_call(
     return response
 
 
+async def discover_peer(
+    peer: A2APeer,
+    *,
+    timeout_s: float = 10.0,
+) -> A2APeerInfo:
+    """Probe ``peer``'s ``GET /a2a/v1/info`` endpoint and return
+    the parsed `A2APeerInfo`.
+
+    `peer.url` is the unary calls URL (e.g.
+    ``https://x/a2a/v1/calls``); the info URL is derived by
+    swapping the trailing ``/calls`` for ``/info`` so callers
+    only ever configure one URL per peer.
+    """
+    info_url = _info_url_from_calls_url(peer.url)
+    headers = dict(peer.auth.headers)
+    headers.setdefault("Accept", "application/json")
+    try:
+        raw = await peer.runner.get(
+            info_url,
+            headers=headers,
+            ssl_context=peer.auth.ssl_context,
+            timeout_s=timeout_s,
+        )
+    except (A2AAuthError, A2ACallError, A2ATimeout):
+        raise
+    except TimeoutError as exc:
+        raise A2ATimeout(f"a2a discovery of {peer.name!r} exceeded {timeout_s:.1f}s") from exc
+    except Exception as exc:
+        raise A2ACallError(f"a2a discovery of {peer.name!r} failed: {exc}") from exc
+    _raise_for_error_body(peer.name, raw)
+    return A2APeerInfo.model_validate(raw)
+
+
+def _info_url_from_calls_url(calls_url: str) -> str:
+    if calls_url.endswith(_CALLS_SUFFIX):
+        return calls_url[: -len(_CALLS_SUFFIX)] + _INFO_PATH
+    head, sep, _ = calls_url.rpartition(_CALLS_SUFFIX)
+    if sep:
+        return head + _INFO_PATH
+    return calls_url.rstrip("/") + _INFO_PATH
+
+
 def _parse_target(target: str) -> tuple[str, str]:
     if ":" not in target:
         raise ModuleError(f"a2a target must be '<peer>:<endpoint>', got {target!r}")
@@ -171,4 +216,5 @@ def _raise_for_error_body(peer_name: str, raw: dict[str, Any]) -> None:
 __all__ = [
     "A2APeer",
     "agent_call",
+    "discover_peer",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/client.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/client.py
@@ -17,6 +17,7 @@ stays callable from contexts without a bound budget too.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,10 +32,11 @@ from agentforge_core.production.run_context import current_run
 
 from agentforge_a2a._runner import A2AClientRunner
 from agentforge_a2a.auth import ClientAuth, build_outgoing_auth
-from agentforge_a2a.values import A2APeerConfig, A2APeerInfo, A2AResponse
+from agentforge_a2a.values import A2AChunk, A2APeerConfig, A2APeerInfo, A2AResponse
 
 _CALLS_SUFFIX = "/calls"
 _INFO_PATH = "/info"
+_STREAM_PATH = "/calls/stream"
 
 HTTP_UNAUTHORIZED = 401
 HTTP_FORBIDDEN = 403
@@ -136,6 +138,92 @@ async def agent_call(
     return response
 
 
+async def agent_call_stream(
+    target: str,
+    payload: dict[str, Any],
+    *,
+    peers: dict[str, A2APeer],
+    timeout_s: float = 60.0,
+    budget_usd: float | None = None,
+    budget: BudgetPolicy | None = None,
+) -> AsyncIterator[A2AChunk]:
+    """Streaming counterpart to `agent_call`.
+
+    Opens an SSE channel against ``peer.url + "/stream"`` (the
+    stream endpoint is derived from the unary calls URL) and
+    yields each `A2AChunk` frame as it arrives. The terminal
+    ``kind="done"`` frame commits actual cost against the
+    supplied ``budget``; ``kind="error"`` releases the
+    reservation and raises the matching A2A* exception.
+    """
+    peer_name, endpoint = _parse_target(target)
+    peer = peers.get(peer_name)
+    if peer is None:
+        raise ModuleError(f"unknown a2a peer: {peer_name!r}")
+
+    headers = _build_headers(peer.auth, budget_usd)
+    body = {"endpoint": endpoint, "payload": payload, "budget_usd": budget_usd}
+    stream_url = _stream_url_from_calls_url(peer.url)
+
+    if budget is not None and budget_usd is not None:
+        budget.reserve(budget_usd)
+
+    try:
+        stream = peer.runner.post_stream(
+            stream_url,
+            headers=headers,
+            json=body,
+            ssl_context=peer.auth.ssl_context,
+            timeout_s=timeout_s,
+        )
+        async for raw in _wrap_stream_errors(peer_name, timeout_s, stream):
+            chunk = A2AChunk.model_validate(raw)
+            if chunk.kind == "error":
+                _raise_for_error_chunk(peer_name, chunk)
+            if chunk.kind == "done" and budget is not None:
+                content = chunk.content if isinstance(chunk.content, dict) else {}
+                budget.commit(float(content.get("cost_usd", 0.0)))
+            yield chunk
+    finally:
+        if budget is not None and budget_usd is not None:
+            budget.release_reservation(budget_usd)
+
+
+async def _wrap_stream_errors(
+    peer_name: str,
+    timeout_s: float,
+    stream: AsyncIterator[dict[str, Any]],
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield from ``stream`` while mapping transport errors to A2A*."""
+    try:
+        async for raw in stream:
+            yield raw
+    except (A2AAuthError, A2ACallError, A2ATimeout):
+        raise
+    except TimeoutError as exc:
+        raise A2ATimeout(f"a2a stream to {peer_name!r} exceeded {timeout_s:.1f}s") from exc
+    except Exception as exc:
+        raise A2ACallError(f"a2a stream to {peer_name!r} failed: {exc}") from exc
+
+
+def _raise_for_error_chunk(peer_name: str, chunk: A2AChunk) -> None:
+    content = chunk.content if isinstance(chunk.content, dict) else {}
+    code = str(content.get("error", "")) if content else ""
+    message = str(content.get("message", "")) if content else ""
+    if code in ("unauthorized", "forbidden", "A2AAuthError"):
+        raise A2AAuthError(f"a2a peer {peer_name!r} rejected credentials: {message}")
+    raise A2ACallError(f"a2a peer {peer_name!r} streamed error {code!r}: {message}")
+
+
+def _stream_url_from_calls_url(calls_url: str) -> str:
+    if calls_url.endswith(_CALLS_SUFFIX):
+        return calls_url + "/stream"
+    head, sep, _ = calls_url.rpartition(_CALLS_SUFFIX)
+    if sep:
+        return head + _STREAM_PATH
+    return calls_url.rstrip("/") + _STREAM_PATH
+
+
 async def discover_peer(
     peer: A2APeer,
     *,
@@ -216,5 +304,6 @@ def _raise_for_error_body(peer_name: str, raw: dict[str, Any]) -> None:
 __all__ = [
     "A2APeer",
     "agent_call",
+    "agent_call_stream",
     "discover_peer",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/server.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/server.py
@@ -42,7 +42,12 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, ConfigDict
 
 from agentforge_a2a._runner import A2AServerRunner
-from agentforge_a2a.values import A2AResponse
+from agentforge_a2a.values import (
+    A2AEndpointConfig,
+    A2AEndpointDescriptor,
+    A2APeerInfo,
+    A2AResponse,
+)
 
 _log = logging.getLogger("agentforge_a2a.server")
 _VERSION = "0.1"
@@ -83,6 +88,8 @@ class A2AServer:
         host: str = "0.0.0.0",  # noqa: S104  # nosec B104
         port: int = 8080,
         runner: A2AServerRunner | None = None,
+        endpoint_descriptors: list[A2AEndpointConfig] | None = None,
+        server_name: str = "agentforge",
     ) -> None:
         self._agent = agent
         self._auth = auth
@@ -91,6 +98,8 @@ class A2AServer:
         self._host = host
         self._port = port
         self._runner = runner
+        self._endpoint_descriptors = list(endpoint_descriptors or [])
+        self._server_name = server_name
         self.app = self._build_app()
 
     @property
@@ -112,10 +121,7 @@ class A2AServer:
 
         @app.get("/a2a/v1/info")
         async def info(_p: Any = Depends(require_principal)) -> dict[str, Any]:  # noqa: B008
-            return {
-                "version": _VERSION,
-                "endpoints": list(self._endpoints),
-            }
+            return self._build_info().model_dump(mode="json")
 
         @app.post("/a2a/v1/calls")
         async def call(
@@ -126,6 +132,23 @@ class A2AServer:
             return await self._handle_call(body, request)
 
         return app
+
+    def _build_info(self) -> A2APeerInfo:
+        """Render the discovery payload returned by `/a2a/v1/info`."""
+        by_name = {d.name: d for d in self._endpoint_descriptors}
+        descriptors = [
+            A2AEndpointDescriptor(
+                name=name,
+                description=(by_name[name].description if name in by_name else ""),
+                input_schema=(dict(by_name[name].accepts) if name in by_name else {}),
+            )
+            for name in self._endpoints
+        ]
+        return A2APeerInfo(
+            version=_VERSION,
+            server_name=self._server_name,
+            endpoints=descriptors,
+        )
 
     async def _handle_call(self, body: CallRequest, request: Request) -> dict[str, Any]:
         if body.endpoint not in self._endpoints:

--- a/packages/agentforge-a2a/src/agentforge_a2a/server.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/server.py
@@ -1,9 +1,13 @@
 """`A2AServer` — exposes an `Agent` over the A2A wire format
 (feat-014).
 
-FastAPI app with two endpoints:
+FastAPI app with three endpoints:
 
-- `POST /a2a/v1/calls` — invoke a whitelisted endpoint.
+- `POST /a2a/v1/calls` — invoke a whitelisted endpoint
+  synchronously and return one `A2AResponse`.
+- `POST /a2a/v1/calls/stream` — invoke a whitelisted endpoint
+  and emit a Server-Sent-Events stream of `A2AChunk` frames
+  (v0.2 follow-up).
 - `GET /a2a/v1/info` — return the endpoint catalogue +
   framework version.
 
@@ -12,7 +16,9 @@ Lifecycle:
   1. Bearer auth via the canonical `AuthPolicy` (feat-014
      chunk 1).
   2. Endpoint name validated against the whitelist (404
-     otherwise).
+     otherwise; on the stream endpoint we instead emit a
+     single ``kind="error"`` frame and close the stream so
+     the contract stays "always SSE" once authenticated).
   3. `X-AgentForge-Run-Id` (if present) is recorded on the
      response as `parent_run_id` for the cross-framework chain.
   4. `X-AgentForge-Budget-Usd` (if present + valid) caps the
@@ -23,26 +29,38 @@ Lifecycle:
      `agentforge.recording._finding_payload` so the wire
      shape stays tolerant of any `Finding` Protocol-compatible
      object.
+
+Streaming installs a one-off `on_step` hook on the agent for
+the duration of a single call so each `Step` arrives as a
+chunk; the final frame carries the cost + output. The hook is
+removed in a `finally` block. A cleaner per-run hook surface
+on `Agent.run` is a v0.3 cleanup.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import uvicorn
-from agentforge.agent import Agent
-from agentforge.recording import _finding_payload
+from agentforge.agent import Agent, StepHook
+from agentforge.recording import _finding_payload, _step_payload
 from agentforge_core.contracts.auth import AuthPolicy
 from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.values.state import Step
 from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, ConfigDict
 
 from agentforge_a2a._runner import A2AServerRunner
 from agentforge_a2a.values import (
+    A2AChunk,
+    A2AChunkKind,
     A2AEndpointConfig,
     A2AEndpointDescriptor,
     A2APeerInfo,
@@ -58,11 +76,27 @@ TaskBuilder = Callable[[str, dict[str, Any]], str]
 """Maps (endpoint_name, payload) -> the task string the agent
 receives. Default: JSON-encode the payload."""
 
+_STEP_KIND_TO_CHUNK_KIND: dict[str, A2AChunkKind] = {
+    "think": "step",
+    "act": "tool_call",
+    "observe": "tool_result",
+}
+
 
 def _default_task_builder(endpoint: str, payload: dict[str, Any]) -> str:
     """Concatenates endpoint name + JSON payload for the agent."""
     body = json.dumps(payload, sort_keys=True)
     return f"a2a.{endpoint}: {body}"
+
+
+def _chunk_kind_for(step_kind: str) -> A2AChunkKind:
+    """Map an agent `Step.kind` to a wire-format `A2AChunkKind`."""
+    return _STEP_KIND_TO_CHUNK_KIND.get(step_kind, "step")
+
+
+def _sse_frame(chunk: A2AChunk) -> bytes:
+    """Encode one `A2AChunk` as a single SSE `data:` frame."""
+    return b"data: " + chunk.model_dump_json().encode("utf-8") + b"\n\n"
 
 
 class CallRequest(BaseModel):
@@ -131,6 +165,17 @@ class A2AServer:
         ) -> dict[str, Any]:
             return await self._handle_call(body, request)
 
+        @app.post("/a2a/v1/calls/stream")
+        async def stream_call(
+            body: CallRequest,
+            request: Request,
+            _p: Any = Depends(require_principal),  # noqa: B008
+        ) -> StreamingResponse:
+            return StreamingResponse(
+                self._stream_call(body, request),
+                media_type="text/event-stream",
+            )
+
         return app
 
     def _build_info(self) -> A2APeerInfo:
@@ -157,24 +202,7 @@ class A2AServer:
                 detail=f"unknown endpoint: {body.endpoint!r}",
             )
         parent_run_id = request.headers.get("X-AgentForge-Run-Id")
-        budget_cap = self._read_budget_header(request)
-        if budget_cap is not None:
-            # Apply the cap by temporarily lowering the agent's
-            # budget for this run. We restore after.
-            original_budget = self._agent._budget
-            self._agent._budget = BudgetPolicy(
-                usd=min(original_budget.usd, budget_cap),
-                max_tokens=original_budget.max_tokens,
-                max_iterations=original_budget.max_iterations,
-                error_streak_limit=original_budget.error_streak_limit,
-            )
-            try:
-                result = await self._agent.run(self._task_builder(body.endpoint, body.payload))
-            finally:
-                self._agent._budget = original_budget
-        else:
-            result = await self._agent.run(self._task_builder(body.endpoint, body.payload))
-
+        result = await self._run_with_budget_cap(body, request)
         response = A2AResponse(
             output=result.output,
             findings=tuple(_finding_payload(f) for f in getattr(result, "findings", ())),
@@ -184,6 +212,106 @@ class A2AServer:
         )
         body_dict: dict[str, Any] = json.loads(response.model_dump_json())
         return body_dict
+
+    async def _stream_call(self, body: CallRequest, request: Request) -> AsyncIterator[bytes]:
+        """SSE generator for `POST /a2a/v1/calls/stream`.
+
+        Each `Step` produced by the inner `Agent.run` is pushed
+        onto an `asyncio.Queue` by a one-off `on_step` hook and
+        flushed to the wire as a `data:` frame. The final frame
+        is either ``kind="done"`` carrying the result or
+        ``kind="error"`` carrying the failure reason.
+        """
+        parent_run_id = request.headers.get("X-AgentForge-Run-Id")
+        if body.endpoint not in self._endpoints:
+            yield _sse_frame(
+                A2AChunk(
+                    kind="error",
+                    content={
+                        "error": "unknown_endpoint",
+                        "message": f"unknown endpoint: {body.endpoint!r}",
+                    },
+                    parent_run_id=parent_run_id,
+                )
+            )
+            return
+
+        queue: asyncio.Queue[A2AChunk | None] = asyncio.Queue()
+
+        async def _hook(step: Step) -> None:
+            await queue.put(
+                A2AChunk(
+                    kind=_chunk_kind_for(step.kind),
+                    step=_step_payload(step),
+                    parent_run_id=parent_run_id,
+                )
+            )
+
+        hook: StepHook = _hook
+        self._agent._on_step.append(hook)
+
+        async def _run_agent() -> None:
+            try:
+                result = await self._run_with_budget_cap(body, request)
+                await queue.put(
+                    A2AChunk(
+                        kind="done",
+                        content={
+                            "output": _coerce_jsonable(result.output),
+                            "cost_usd": float(result.cost_usd),
+                            "run_id": result.run_id,
+                        },
+                        run_id=result.run_id,
+                        parent_run_id=parent_run_id,
+                    )
+                )
+            except Exception as exc:
+                await queue.put(
+                    A2AChunk(
+                        kind="error",
+                        content={
+                            "error": type(exc).__name__,
+                            "message": str(exc),
+                        },
+                        parent_run_id=parent_run_id,
+                    )
+                )
+            finally:
+                await queue.put(None)
+
+        task = asyncio.create_task(_run_agent())
+        try:
+            while True:
+                chunk = await queue.get()
+                if chunk is None:
+                    break
+                yield _sse_frame(chunk)
+        finally:
+            with contextlib.suppress(ValueError):
+                self._agent._on_step.remove(hook)
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+
+    async def _run_with_budget_cap(self, body: CallRequest, request: Request) -> Any:
+        """Run the agent honouring the per-call ``X-AgentForge-Budget-Usd``
+        header. Restores the original budget on the way out."""
+        budget_cap = self._read_budget_header(request)
+        task = self._task_builder(body.endpoint, body.payload)
+        if budget_cap is None:
+            return await self._agent.run(task)
+        original_budget = self._agent._budget
+        self._agent._budget = BudgetPolicy(
+            usd=min(original_budget.usd, budget_cap),
+            max_tokens=original_budget.max_tokens,
+            max_iterations=original_budget.max_iterations,
+            error_streak_limit=original_budget.error_streak_limit,
+        )
+        try:
+            return await self._agent.run(task)
+        finally:
+            self._agent._budget = original_budget
 
     @staticmethod
     def _read_budget_header(request: Request) -> float | None:
@@ -213,6 +341,19 @@ class A2AServer:
     async def stop(self) -> None:
         if self._runner is not None:
             await self._runner.stop()
+
+
+def _coerce_jsonable(value: Any) -> Any:
+    """Best-effort JSON-friendly coercion for the streamed
+    ``done`` content. Strings / numbers / bools / None / dicts /
+    lists pass through; everything else becomes ``str(value)``."""
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(k): _coerce_jsonable(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_coerce_jsonable(v) for v in value]
+    return str(value)
 
 
 __all__ = [

--- a/packages/agentforge-a2a/src/agentforge_a2a/values.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/values.py
@@ -6,14 +6,32 @@ are immutable once built.
 
 `A2AResponse` mirrors spec §4.2. The three config models
 (`A2APeerConfig`, `A2AEndpointConfig`, `A2AExposeConfig`) feed
-the YAML side via `A2AConfig` (chunk 5).
+the YAML side via `A2AConfig`.
+
+v0.2 follow-up adds the discovery + streaming wire shapes:
+
+- `A2AEndpointDescriptor` + `A2APeerInfo` — the rich shape
+  returned by `GET /a2a/v1/info` and consumed by
+  `discover_peer(...)`.
+- `A2AChunk` + `A2AChunkKind` — the streaming wire format
+  emitted by `POST /a2a/v1/calls/stream`.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+A2AChunkKind = Literal["step", "tool_call", "tool_result", "done", "error"]
+"""Kinds of frames streamed over `POST /a2a/v1/calls/stream`.
+
+- ``step`` — generic agent step (think + others).
+- ``tool_call`` — agent invoked a tool.
+- ``tool_result`` — observation from a tool call.
+- ``done`` — terminal frame carrying the final output + cost.
+- ``error`` — terminal error frame.
+"""
 
 
 class A2AResponse(BaseModel):
@@ -68,9 +86,47 @@ class A2AExposeConfig(BaseModel):
     endpoints: list[A2AEndpointConfig] = Field(default_factory=list)
 
 
+class A2AEndpointDescriptor(BaseModel):
+    """One endpoint advertised by `GET /a2a/v1/info`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    name: str = Field(min_length=1)
+    description: str = ""
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2APeerInfo(BaseModel):
+    """Discovery payload returned by `GET /a2a/v1/info`."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    version: str
+    server_name: str = ""
+    endpoints: list[A2AEndpointDescriptor] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class A2AChunk(BaseModel):
+    """One frame on the streaming `/a2a/v1/calls/stream` channel."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    kind: A2AChunkKind
+    content: dict[str, Any] | str | None = None
+    step: dict[str, Any] | None = None
+    run_id: str | None = None
+    parent_run_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 __all__ = [
+    "A2AChunk",
+    "A2AChunkKind",
     "A2AEndpointConfig",
+    "A2AEndpointDescriptor",
     "A2AExposeConfig",
     "A2APeerConfig",
+    "A2APeerInfo",
     "A2AResponse",
 ]

--- a/packages/agentforge-a2a/src/agentforge_a2a/values.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/values.py
@@ -38,7 +38,10 @@ class A2AResponse(BaseModel):
     """Response returned by `agent_call(...)` and built by
     `A2AServer.POST /a2a/v1/calls`."""
 
-    model_config = ConfigDict(frozen=True, strict=True)
+    # Not strict: the wire format coerces tuple↔list on JSON round-trip,
+    # so the client-side `model_validate(response.json())` needs the
+    # default lax sequence handling.
+    model_config = ConfigDict(frozen=True)
 
     output: Any
     findings: tuple[dict[str, Any], ...] = ()

--- a/packages/agentforge-a2a/tests/integration/test_a2a_live.py
+++ b/packages/agentforge-a2a/tests/integration/test_a2a_live.py
@@ -1,0 +1,241 @@
+"""Live A2A integration test (feat-014 v0.2).
+
+Spawns a real `uvicorn.Server` on a random localhost port,
+points a real `_HTTPXClientRunner` at it, and round-trips:
+
+1. `agent_call(...)` — unary `POST /a2a/v1/calls`.
+2. `discover_peer(...)` — `GET /a2a/v1/info`.
+3. `agent_call_stream(...)` — SSE `POST /a2a/v1/calls/stream`.
+
+Gated by `@pytest.mark.live` so the default unit gate skips it.
+Run explicitly with:
+
+    uv run pytest -m live packages/agentforge-a2a/tests/integration/
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import pytest
+import uvicorn
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_a2a import (
+    A2APeer,
+    A2AServer,
+    BearerAuth,
+    agent_call,
+    agent_call_stream,
+    discover_peer,
+)
+from agentforge_a2a._runner import _HTTPXClientRunner
+from agentforge_a2a.values import A2AEndpointConfig
+from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.auth import Principal
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+
+
+class _ThreeStepStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content="thinking"))
+        state.steps.append(Step(iteration=1, kind="act", content="calling-tool"))
+        state.steps.append(Step(iteration=2, kind="observe", content="observed"))
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+class _StaticBearerAuth(AuthPolicy):
+    """Accepts exactly one bearer token."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    async def authenticate(self, token: str | None) -> Principal | None:
+        if token != self._token:
+            return None
+        return Principal(id="live-test")
+
+
+def _build_agent() -> Agent:
+    return Agent(model=_FakeLLM(), strategy=_ThreeStepStrategy())
+
+
+def _build_server(*, token: str = "live-tok") -> A2AServer:
+    return A2AServer(
+        agent=_build_agent(),
+        auth=_StaticBearerAuth(token),
+        endpoints=["verify"],
+        endpoint_descriptors=[
+            A2AEndpointConfig(
+                name="verify",
+                description="Live integration verifier",
+                accepts={"type": "object", "properties": {"k": {"type": "string"}}},
+            )
+        ],
+        server_name="live-test",
+    )
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass
+class _SpawnedServer:
+    base_url: str
+    calls_url: str
+
+
+@contextlib.asynccontextmanager
+async def _spawn_server(server: A2AServer) -> AsyncIterator[_SpawnedServer]:
+    port = _free_port()
+    config = uvicorn.Config(
+        server.app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        lifespan="off",
+    )
+    uv_server = uvicorn.Server(config)
+    # uvicorn's default install_signal_handlers() needs the main thread;
+    # the pytest worker loop may not have it. No-op the call so startup
+    # proceeds to the socket bind.
+    uv_server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+    task = asyncio.create_task(uv_server.serve())
+    for _ in range(200):
+        if uv_server.started:
+            break
+        await asyncio.sleep(0.02)
+    if not uv_server.started:
+        uv_server.should_exit = True
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await asyncio.wait_for(task, timeout=5.0)
+        msg = "uvicorn test server failed to start within 4s"
+        raise RuntimeError(msg)
+    await asyncio.sleep(0.05)
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        yield _SpawnedServer(base_url=base_url, calls_url=f"{base_url}/a2a/v1/calls")
+    finally:
+        uv_server.should_exit = True
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await asyncio.wait_for(task, timeout=5.0)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_unary_call_round_trip() -> None:
+    server = _build_server()
+    runner = _HTTPXClientRunner()
+    try:
+        async with _spawn_server(server) as bound:
+            peer = A2APeer(
+                name="live",
+                url=bound.calls_url,
+                auth=BearerAuth("live-tok"),
+                runner=runner,
+            )
+            response = await agent_call(
+                "live:verify",
+                {"k": "v"},
+                peers={"live": peer},
+                timeout_s=10.0,
+            )
+            assert response.run_id
+            assert response.cost_usd >= 0.0
+    finally:
+        await runner.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_discover_round_trip() -> None:
+    server = _build_server()
+    runner = _HTTPXClientRunner()
+    try:
+        async with _spawn_server(server) as bound:
+            peer = A2APeer(
+                name="live",
+                url=bound.calls_url,
+                auth=BearerAuth("live-tok"),
+                runner=runner,
+            )
+            info = await discover_peer(peer, timeout_s=10.0)
+            assert info.server_name == "live-test"
+            assert {e.name for e in info.endpoints} == {"verify"}
+            verify = info.endpoints[0]
+            assert verify.description == "Live integration verifier"
+            assert verify.input_schema["type"] == "object"
+    finally:
+        await runner.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_stream_round_trip() -> None:
+    server = _build_server()
+    runner = _HTTPXClientRunner()
+    try:
+        async with _spawn_server(server) as bound:
+            peer = A2APeer(
+                name="live",
+                url=bound.calls_url,
+                auth=BearerAuth("live-tok"),
+                runner=runner,
+            )
+            chunks = [
+                chunk
+                async for chunk in agent_call_stream(
+                    "live:verify",
+                    {"k": "v"},
+                    peers={"live": peer},
+                    timeout_s=15.0,
+                )
+            ]
+            kinds = [c.kind for c in chunks]
+            assert kinds[-1] == "done"
+            # three steps + done; mapping: think→step, act→tool_call,
+            # observe→tool_result.
+            assert kinds[:3] == ["step", "tool_call", "tool_result"]
+            assert chunks[-1].run_id is not None
+    finally:
+        await runner.close()

--- a/packages/agentforge-a2a/tests/unit/test_a2a_client_stream.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_client_stream.py
@@ -1,0 +1,136 @@
+"""Unit tests for `agent_call_stream` (feat-014 v0.2)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agentforge_a2a import (
+    A2APeer,
+    A2APeerConfig,
+    agent_call_stream,
+)
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.production.exceptions import A2AAuthError, A2ACallError, ModuleError
+
+
+def _peer(runner: FakeA2AClientRunner) -> A2APeer:
+    config = A2APeerConfig(
+        name="alpha",
+        url="https://alpha.example/a2a/v1/calls",
+        auth={"type": "bearer", "token": "tok"},
+    )
+    return A2APeer.from_config(config, runner=runner)
+
+
+def test_stream_yields_step_chunks_then_done() -> None:
+    runner = FakeA2AClientRunner(
+        responses_stream=[
+            {"kind": "step", "step": {"iteration": 0, "kind": "think", "content": "a"}},
+            {"kind": "tool_call", "step": {"iteration": 1, "kind": "act", "content": "b"}},
+            {"kind": "done", "content": {"output": "ok", "cost_usd": 0.0}, "run_id": "r"},
+        ]
+    )
+    peers = {"alpha": _peer(runner)}
+
+    async def _collect() -> list[str]:
+        return [
+            chunk.kind
+            async for chunk in agent_call_stream(
+                "alpha:verify",
+                {"x": 1},
+                peers=peers,
+                budget_usd=0.05,
+            )
+        ]
+
+    kinds = asyncio.run(_collect())
+    assert kinds == ["step", "tool_call", "done"]
+    # Stream URL is derived from peer.url + "/stream".
+    assert runner.stream_calls[0].url == "https://alpha.example/a2a/v1/calls/stream"
+    # Bearer header propagated.
+    assert runner.stream_calls[0].headers["Authorization"] == "Bearer tok"
+    # Budget hint header propagated.
+    assert runner.stream_calls[0].headers["X-AgentForge-Budget-Usd"] == "0.050000"
+
+
+def test_stream_commits_actual_cost_at_done() -> None:
+    runner = FakeA2AClientRunner(
+        responses_stream=[
+            {"kind": "done", "content": {"output": "ok", "cost_usd": 0.0123}, "run_id": "r"},
+        ]
+    )
+    peers = {"alpha": _peer(runner)}
+    budget = BudgetPolicy(usd=1.0, max_tokens=1000, max_iterations=10)
+
+    async def _drain() -> None:
+        async for _ in agent_call_stream(
+            "alpha:verify",
+            {},
+            peers=peers,
+            budget=budget,
+            budget_usd=0.05,
+        ):
+            pass
+
+    asyncio.run(_drain())
+    # Actual cost was committed; reservation was released.
+    assert budget.spent_usd == pytest.approx(0.0123)
+    assert budget.reserved_usd == 0.0
+
+
+def test_stream_error_chunk_raises_call_error() -> None:
+    runner = FakeA2AClientRunner(
+        responses_stream=[
+            {
+                "kind": "error",
+                "content": {"error": "RuntimeError", "message": "boom"},
+            }
+        ]
+    )
+    peers = {"alpha": _peer(runner)}
+    budget = BudgetPolicy(usd=1.0, max_tokens=1000, max_iterations=10)
+
+    async def _drain() -> None:
+        async for _ in agent_call_stream(
+            "alpha:verify",
+            {},
+            peers=peers,
+            budget=budget,
+            budget_usd=0.05,
+        ):
+            pass
+
+    with pytest.raises(A2ACallError, match="boom"):
+        asyncio.run(_drain())
+    # Reservation released on failure.
+    assert budget.reserved_usd == 0.0
+
+
+def test_stream_auth_error_chunk_raises_auth_error() -> None:
+    runner = FakeA2AClientRunner(
+        responses_stream=[
+            {
+                "kind": "error",
+                "content": {"error": "unauthorized", "message": "bad token"},
+            }
+        ]
+    )
+    peers = {"alpha": _peer(runner)}
+
+    async def _drain() -> None:
+        async for _ in agent_call_stream("alpha:verify", {}, peers=peers):
+            pass
+
+    with pytest.raises(A2AAuthError, match="bad token"):
+        asyncio.run(_drain())
+
+
+def test_stream_unknown_peer_raises_module_error() -> None:
+    async def _drain() -> None:
+        async for _ in agent_call_stream("nope:verify", {}, peers={}):
+            pass
+
+    with pytest.raises(ModuleError, match="unknown a2a peer"):
+        asyncio.run(_drain())

--- a/packages/agentforge-a2a/tests/unit/test_a2a_discovery.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_discovery.py
@@ -1,0 +1,173 @@
+"""Unit tests for A2A discovery (feat-014 v0.2 follow-up)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_a2a import (
+    A2ABridge,
+    A2APeer,
+    A2APeerInfo,
+    A2AServer,
+    BearerAuth,
+    discover_peer,
+)
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+from agentforge_a2a.values import A2AEndpointConfig
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+from fastapi.testclient import TestClient
+
+
+class _Strategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content="ok"))
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _peer(runner: FakeA2AClientRunner) -> A2APeer:
+    return A2APeer(
+        name="alpha",
+        url="https://peer.example.com/a2a/v1/calls",
+        auth=BearerAuth("tok"),
+        runner=runner,
+    )
+
+
+def test_discover_peer_parses_info_payload() -> None:
+    runner = FakeA2AClientRunner(
+        get_response={
+            "version": "0.1",
+            "server_name": "alpha",
+            "endpoints": [
+                {"name": "review-pr", "description": "Review", "input_schema": {}},
+                {"name": "verify", "description": "Verify", "input_schema": {"k": 1}},
+            ],
+            "metadata": {},
+        }
+    )
+    info = asyncio.run(discover_peer(_peer(runner)))
+    assert isinstance(info, A2APeerInfo)
+    assert info.version == "0.1"
+    assert info.server_name == "alpha"
+    assert [e.name for e in info.endpoints] == ["review-pr", "verify"]
+    # info URL is derived: /calls -> /info
+    assert runner.get_calls[0].url == "https://peer.example.com/a2a/v1/info"
+    # Bearer header propagated
+    assert runner.get_calls[0].headers["Authorization"] == "Bearer tok"
+
+
+def test_discover_peer_handles_url_without_calls_suffix() -> None:
+    runner = FakeA2AClientRunner(get_response={"version": "0.1"})
+    peer = A2APeer(
+        name="beta",
+        url="https://peer.example.com/api",
+        auth=BearerAuth("tok"),
+        runner=runner,
+    )
+    asyncio.run(discover_peer(peer))
+    assert runner.get_calls[0].url == "https://peer.example.com/api/info"
+
+
+def test_bridge_discover_all_populates_peer_info() -> None:
+    runner_a = FakeA2AClientRunner(
+        get_response={"version": "0.1", "server_name": "a", "endpoints": []}
+    )
+    runner_b = FakeA2AClientRunner(
+        get_response={"version": "0.1", "server_name": "b", "endpoints": []}
+    )
+    peers = {
+        "a": A2APeer(
+            name="a",
+            url="https://a.example.com/a2a/v1/calls",
+            auth=BearerAuth("t"),
+            runner=runner_a,
+        ),
+        "b": A2APeer(
+            name="b",
+            url="https://b.example.com/a2a/v1/calls",
+            auth=BearerAuth("t"),
+            runner=runner_b,
+        ),
+    }
+    bridge = A2ABridge(peers=peers)
+    info_map = asyncio.run(bridge.discover_all())
+    assert set(info_map) == {"a", "b"}
+    assert info_map["a"].server_name == "a"
+    assert info_map["b"].server_name == "b"
+    # peer_info exposes the cache (defensive copy).
+    cached = bridge.peer_info
+    assert set(cached) == {"a", "b"}
+    cached.clear()
+    assert set(bridge.peer_info) == {"a", "b"}
+
+
+def test_info_endpoint_returns_rich_descriptors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    agent = Agent(model=_FakeLLM(), strategy=_Strategy())
+    server = A2AServer(
+        agent=agent,
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["review-pr", "verify"],
+        endpoint_descriptors=[
+            A2AEndpointConfig(
+                name="review-pr",
+                description="Review a PR diff",
+                accepts={"type": "object", "properties": {"diff": {"type": "string"}}},
+            ),
+            A2AEndpointConfig(name="verify", description="Run verifier", accepts={}),
+        ],
+        server_name="alpha-prod",
+    )
+    client = TestClient(server.app)
+    r = client.get("/a2a/v1/info", headers={"Authorization": "Bearer good"})
+    assert r.status_code == 200
+    body: dict[str, Any] = r.json()
+    assert body["server_name"] == "alpha-prod"
+    by_name = {ep["name"]: ep for ep in body["endpoints"]}
+    assert by_name["review-pr"]["description"] == "Review a PR diff"
+    assert by_name["review-pr"]["input_schema"] == {
+        "type": "object",
+        "properties": {"diff": {"type": "string"}},
+    }
+    # An endpoint name with no descriptor still shows up, with empties.
+    assert by_name["verify"]["input_schema"] == {}

--- a/packages/agentforge-a2a/tests/unit/test_a2a_runner.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_runner.py
@@ -1,28 +1,31 @@
-"""Smoke tests for the runner protocols (feat-014 chunk 2)."""
+"""Smoke tests for the runner protocols (feat-014)."""
 
 from __future__ import annotations
 
-import pytest
 from agentforge_a2a._runner import (
     A2AClientRunner,
     A2AServerRunner,
     _HTTPXClientRunner,
     _UvicornServerRunner,
 )
+from fastapi import FastAPI
 
 
-def test_production_client_runner_raises_until_live_test_lands() -> None:
-    with pytest.raises(NotImplementedError, match="not implemented yet"):
-        _HTTPXClientRunner()
+def test_production_client_runner_constructs() -> None:
+    """v0.2 follow-up: constructor is sync + cheap; the httpx
+    client is allocated lazily on the first call."""
+    runner = _HTTPXClientRunner()
+    assert runner is not None
 
 
-def test_production_server_runner_raises_until_live_test_lands() -> None:
-    with pytest.raises(NotImplementedError, match="not implemented yet"):
-        _UvicornServerRunner()
+def test_production_server_runner_constructs() -> None:
+    """v0.2 follow-up: constructor stores config; uvicorn.Server
+    is built inside `serve()`."""
+    runner = _UvicornServerRunner(FastAPI(), host="127.0.0.1", port=0)
+    assert runner is not None
 
 
 def test_protocols_are_importable() -> None:
-    # Smoke: the Protocol classes are importable and runtime-checkable
-    # only structurally — a typed `Any` check is enough.
+    # Smoke: the Protocol classes are importable.
     assert A2AClientRunner is not None
     assert A2AServerRunner is not None

--- a/packages/agentforge-a2a/tests/unit/test_a2a_server.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_server.py
@@ -79,7 +79,11 @@ def test_info_endpoint_lists_whitelist(client: TestClient) -> None:
     assert r.status_code == 200
     body = r.json()
     assert "version" in body
-    assert set(body["endpoints"]) == {"review-pr", "verify"}
+    names = {ep["name"] for ep in body["endpoints"]}
+    assert names == {"review-pr", "verify"}
+    # v0.2 shape: each entry has description + input_schema fields.
+    for ep in body["endpoints"]:
+        assert set(ep.keys()) >= {"name", "description", "input_schema"}
 
 
 def test_missing_bearer_returns_401(client: TestClient) -> None:

--- a/packages/agentforge-a2a/tests/unit/test_a2a_streaming_server.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_streaming_server.py
@@ -1,0 +1,183 @@
+"""Unit tests for `POST /a2a/v1/calls/stream` (feat-014 v0.2)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge.agent import Agent
+from agentforge.runtime import RUNTIME_KEY
+from agentforge_a2a import A2AServer
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState, Step
+from fastapi.testclient import TestClient
+
+
+class _ThreeStepStrategy(ReasoningStrategy):
+    """Appends three deterministic steps then finishes."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        state.steps.append(Step(iteration=0, kind="think", content="thinking"))
+        state.steps.append(Step(iteration=1, kind="act", content="calling_tool", tool_call=None))
+        state.steps.append(Step(iteration=2, kind="observe", content="tool_obs"))
+        return state
+
+
+class _BoomStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        msg = "strategy exploded"
+        raise RuntimeError(msg)
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _agent(strategy: ReasoningStrategy) -> Agent:
+    return Agent(model=_FakeLLM(), strategy=strategy)
+
+
+@pytest.fixture
+def server(monkeypatch: pytest.MonkeyPatch) -> A2AServer:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    return A2AServer(
+        agent=_agent(_ThreeStepStrategy()),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+
+
+@pytest.fixture
+def client(server: A2AServer) -> TestClient:
+    return TestClient(server.app)
+
+
+def _auth(token: str = "good") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _parse_sse(body: bytes) -> list[dict[str, Any]]:
+    return [
+        json.loads(line[len("data: ") :])
+        for line in body.decode("utf-8").splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def test_stream_emits_step_chunks_then_done(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "verify", "payload": {}},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    chunks = _parse_sse(r.content)
+    kinds = [c["kind"] for c in chunks]
+    # 3 steps mapped to step/tool_call/tool_result, then done.
+    assert kinds == ["step", "tool_call", "tool_result", "done"]
+    done = chunks[-1]
+    assert done["run_id"] is not None
+    assert "output" in done["content"]
+
+
+def test_stream_missing_bearer_returns_401(client: TestClient) -> None:
+    r = client.post("/a2a/v1/calls/stream", json={"endpoint": "verify", "payload": {}})
+    assert r.status_code == 401
+
+
+def test_stream_unknown_endpoint_emits_error_chunk(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "nope", "payload": {}},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    chunks = _parse_sse(r.content)
+    assert len(chunks) == 1
+    assert chunks[0]["kind"] == "error"
+    assert chunks[0]["content"]["error"] == "unknown_endpoint"
+
+
+def test_stream_propagates_parent_run_id(client: TestClient) -> None:
+    r = client.post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "verify", "payload": {}},
+        headers={**_auth(), "X-AgentForge-Run-Id": "abc-123"},
+    )
+    chunks = _parse_sse(r.content)
+    assert all(c["parent_run_id"] == "abc-123" for c in chunks)
+
+
+def test_stream_strategy_error_surfaces_as_error_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    boom_server = A2AServer(
+        agent=_agent(_BoomStrategy()),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+    boom_client = TestClient(boom_server.app)
+    r = boom_client.post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "verify", "payload": {}},
+        headers=_auth(),
+    )
+    chunks = _parse_sse(r.content)
+    assert chunks[-1]["kind"] == "error"
+    assert chunks[-1]["content"]["error"] in {"RuntimeError", "AgentRunError"}
+
+
+def test_stream_budget_header_caps_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    agent = _agent(_ThreeStepStrategy())
+    server = A2AServer(
+        agent=agent,
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+    original_budget_usd = agent._budget.usd
+    client = TestClient(server.app)
+    r = client.post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "verify", "payload": {}},
+        headers={**_auth(), "X-AgentForge-Budget-Usd": "0.001"},
+    )
+    assert r.status_code == 200
+    # Budget is restored after the call returns.
+    assert agent._budget.usd == original_budget_usd
+    # Hook list is empty again — no leak across calls.
+    assert agent._on_step == []

--- a/packages/agentforge-a2a/tests/unit/test_a2a_streaming_values.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_streaming_values.py
@@ -1,0 +1,71 @@
+"""Unit tests for the A2A streaming wire format (feat-014 v0.2 follow-up)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agentforge_a2a import A2AChunk
+from agentforge_a2a._inmem_runner import FakeA2AClientRunner
+from pydantic import ValidationError
+
+
+def test_a2a_chunk_is_frozen_and_validates_kind() -> None:
+    chunk = A2AChunk(kind="step", step={"iteration": 0, "kind": "think", "content": "x"})
+    assert chunk.kind == "step"
+    with pytest.raises(ValidationError):
+        chunk.kind = "done"  # type: ignore[misc]
+
+
+def test_a2a_chunk_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError):
+        A2AChunk(kind="bogus")  # type: ignore[arg-type]
+
+
+def test_a2a_chunk_done_carries_content() -> None:
+    chunk = A2AChunk(
+        kind="done", content={"output": "ok", "cost_usd": 0.0}, run_id="r", parent_run_id="p"
+    )
+    assert chunk.content == {"output": "ok", "cost_usd": 0.0}
+    assert chunk.run_id == "r"
+    assert chunk.parent_run_id == "p"
+
+
+def test_fake_runner_post_stream_yields_configured_chunks() -> None:
+    runner = FakeA2AClientRunner(
+        responses_stream=[
+            {"kind": "step", "step": {"iteration": 0, "kind": "think", "content": "a"}},
+            {"kind": "step", "step": {"iteration": 1, "kind": "act", "content": "b"}},
+            {"kind": "done", "content": {"output": "ok"}},
+        ]
+    )
+
+    async def _collect() -> list[dict[str, object]]:
+        return [
+            chunk
+            async for chunk in runner.post_stream(
+                "https://x/a2a/v1/calls/stream",
+                headers={"Authorization": "Bearer t"},
+                json={"endpoint": "verify", "payload": {}, "budget_usd": None},
+                ssl_context=None,
+                timeout_s=5.0,
+            )
+        ]
+
+    chunks = asyncio.run(_collect())
+    assert [c["kind"] for c in chunks] == ["step", "step", "done"]
+    assert runner.stream_calls[0].url == "https://x/a2a/v1/calls/stream"
+
+
+def test_fake_runner_post_stream_raises_configured_error() -> None:
+    runner = FakeA2AClientRunner()
+    runner.set_error(RuntimeError("boom"))
+
+    async def _drain() -> None:
+        async for _ in runner.post_stream(
+            "https://x", headers={}, json={}, ssl_context=None, timeout_s=1.0
+        ):
+            pass
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(_drain())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,11 @@ markers = [
 filterwarnings = [
     "error",
     "ignore::DeprecationWarning:pydantic._internal.*",
+    # feat-014 v0.2 live tests spin up uvicorn, which imports
+    # `websockets.legacy` (deprecated). The deprecation is benign for
+    # our HTTP-only use; demote to non-error so the live job stays green.
+    "ignore::DeprecationWarning:websockets.legacy",
+    "ignore::DeprecationWarning:uvicorn.protocols.websockets.*",
     # feat-017: CLI commands use asyncio.run inside argparse handlers.
     # Combined with test suites that also call asyncio.run (e.g. Copier
     # in new_cmd tests), Python's loop GC sometimes emits an


### PR DESCRIPTION
## Summary

Closes the three open items v0.1's feat-014 deferred — in a
single PR per the user-chosen "Full spec" scope.

- **Production HTTP runner.** `_HTTPXClientRunner` +
  `_UvicornServerRunner` now wrap `httpx.AsyncClient` /
  `uvicorn.Server` (lazy client / server build; auth →
  `A2AAuthError`, ≥400 → `A2ACallError`). Bodies remain
  `# pragma: no cover`; coverage is proven by the
  `@pytest.mark.live` integration suite.
- **A2A discovery.** `GET /a2a/v1/info` carries the full
  endpoint catalogue (description + JSON-Schema input
  shapes). `discover_peer(peer)` + `A2ABridge.discover_all()`
  + `bridge.peer_info` cache. Strictly client-side; info URL
  is derived from `peer.url` so callers configure one URL per
  peer.
- **Bi-directional streaming.** New `POST /a2a/v1/calls/stream`
  returns SSE `A2AChunk` frames; client helper
  `agent_call_stream(...)` yields them. Step-level
  granularity for v0.2 — per-token LLM streaming via
  `ReasoningStrategy.stream()` is deferred to v0.3 alongside
  feat-020's strategy-level follow-up.
- **Non-gating `live` CI job** running `pytest -m live`
  against every package shipping a
  `tests/integration/test_*_live.py` (mcp + a2a). Threshold
  was ≥ 2 packages with live tests; `continue-on-error: true`.

Eight chunks, one per commit:

| # | Sha | What |
|---|---|---|
| 1 | `149dbac` | Production runners + `get` / `post_stream` Protocol methods |
| 2 | `397999e` | `/v1/info` + `A2APeerInfo` + `discover_peer` + `discover_all` |
| 3 | `39cdeaf` | `A2AChunk` + `A2AChunkKind` wire format + fake stream |
| 4 | `5aa57bf` | `POST /v1/calls/stream` SSE endpoint + `on_step` hook |
| 5 | `d633033` | `agent_call_stream(...)` client helper |
| 6 | `10b0d1b` | Three `@pytest.mark.live` integration tests |
| 7 | `a810583` | New non-gating `live` CI job |
| 8 | `6783d54` | Spec §10 v0.2 follow-up + §11 runbook + roadmap + CHANGELOG + state |

Spec, runbook, roadmap, and CHANGELOG updated in chunk 8
(`docs/features/feat-014-a2a-protocol.md` §10 + §11,
`docs/roadmap.md`, `CHANGELOG.md`, `.claude/state/{current,log}.md`).

## Test plan

- [x] `uv run pre-commit run --all-files` green on every chunk
- [x] `uv run pytest -m "not live"` — 70 a2a unit + integration tests pass
- [x] `uv run pytest -m live packages/agentforge-a2a/tests/integration/` — 3 live tests pass against a real uvicorn server on a random localhost port
- [x] `uv run pytest -m live` — 4 live tests pass (mcp + a2a combined)
- [ ] CI `lint-and-type` (ruff format + ruff check + mypy --strict + bandit) green on the PR
- [ ] CI `test` (ubuntu + macos + windows × py3.13: unit + integration + coverage ≥ 90%) green
- [ ] CI new `live` (ubuntu + macos × py3.13) green — non-gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)