### PR TITLE
feat-014 v0.3 follow-up: A2A per-token streaming + unified StreamingChunkKind

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,95 +1,82 @@
 ---
-feature: feat-020 v0.2 follow-up
+feature: feat-014 v0.3 follow-up
 state: in_review
-branch: chore/feat-020-v0.2-followup-postgres-redis-slack-streaming-lock-tokeniser
-started_at: 2026-05-12
-last_milestone_at: 2026-05-12
-last_shipped: feat-014 v0.2 production A2A runner + discovery + streaming shipped via PR #33 (merged 2026-05-12)
+branch: chore/feat-014-v0.3-a2a-per-token-streaming-chunk-kind-unification
+started_at: 2026-05-13
+last_milestone_at: 2026-05-13
+last_shipped: feat-020 v0.2 follow-up shipped via PR #34 (merged 2026-05-13) — postgres + redis chat-history + slack adapter + ReasoningStrategy.stream() + RedisSessionLock + provider-aware tokeniser
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-[`feat-020 — Chat agents`](../../docs/features/feat-020-chat-agents.md)
-v0.2 follow-up: closes the six v0.1 deferred items in one PR
-per user-chosen "full v0.2 spec" scope. Postgres + redis chat-
-history packages, slack reference adapter,
-`ReasoningStrategy.stream()` ABC + `Agent.stream(task)` +
-`ChatSession` per-token graduation, `SessionLock` Protocol +
-`RedisSessionLock`, provider-aware tokeniser
-(`tiktoken_tokeniser` / `anthropic_tokeniser`). Live CI job
-extended with Postgres + Redis services.
+[`feat-014 — A2A protocol`](../../docs/features/feat-014-a2a-protocol.md)
+v0.3 follow-up: closes the two remaining v0.2-deferred items
+(per-token A2A streaming + chunk-kind unification) in one PR
+per user-chosen "Full v0.3 bundle" scope. The per-run hook
+kwarg on `Agent.run` was **obviated** by the streaming
+refactor (no remaining caller) and dropped from scope.
 
 ## Last shipped
 
-[`feat-014 v0.2 follow-up`](../../docs/features/feat-014-a2a-protocol.md)
-shipped via PR #33 (merged 2026-05-12). Closes the three
-items v0.1 deferred in one bundle:
+[`feat-020 — Chat agents (v0.2 follow-up)`](../../docs/features/feat-020-chat-agents.md)
+shipped via PR #34 (merged 2026-05-13). Closes the six items
+v0.1 deferred in one bundle:
 
-- **Production HTTP runner**: `_HTTPXClientRunner` +
-  `_UvicornServerRunner` wrap `httpx.AsyncClient` /
-  `uvicorn.Server`; v0.1's `NotImplementedError` stubs gone.
-  Bodies remain `# pragma: no cover`; coverage proven by the
-  new `@pytest.mark.live` suite.
-- **A2A discovery**: `GET /a2a/v1/info` returns the full
-  `A2APeerInfo` shape (description + JSON-Schema input
-  shapes per endpoint). `discover_peer(peer)` +
-  `A2ABridge.discover_all()` + `bridge.peer_info` cache.
-  Client-side only — no central registry.
-- **Bi-directional streaming**: `POST /a2a/v1/calls/stream`
-  returns SSE `A2AChunk` frames; `agent_call_stream(...)`
-  yields them. Step-level granularity for v0.2 (one chunk per
-  agent `Step` plus terminal `done` / `error`).
-- **Non-gating `live` CI job** running `pytest -m live`
-  across packages with `tests/integration/test_*_live.py`
-  (mcp + a2a; threshold was ≥ 2).
-
-Deferred to v0.3 (recorded in spec §10):
-
-- Real per-token LLM streaming via `ReasoningStrategy.stream()`
-  (lands with feat-020's strategy-level streaming follow-up).
-- Per-run hook kwarg on `Agent.run` (cleanup of the
-  streaming server's transient `agent._on_step.append(...)`).
-- Unifying `A2AChunkKind` with `ChatChunkKind` under a
-  framework-wide `StreamingChunk`.
-- Hardening the `live` CI job to gate merge.
+- **`agentforge-chat-history-postgres`** — asyncpg-backed
+  driver with dual-table schema + composite index +
+  TTL/encryption_at_rest/full_text_search capabilities.
+- **`agentforge-chat-history-redis`** — redis-py async-backed
+  driver with native TTL + sorted-set turn indexing.
+- **`agentforge-chat-slack`** — Slack reference adapter
+  batching `chat.update` calls every `batch_window_s` seconds.
+- **Per-token streaming foundation** —
+  `ReasoningStrategy.stream()` non-abstract default +
+  `Agent.stream(task)` async iterator + `StreamingEvent`
+  value type + `ChatSession._stream_per_token` graduation.
+  Now unblocking feat-014 v0.3 (active above).
+- **Cross-process locking** — `SessionLock` Protocol +
+  `RedisSessionLock` with `SET NX PX` + UUID fencing + Lua
+  unlock.
+- **Provider-aware tokeniser** — `tiktoken_tokeniser` +
+  `anthropic_tokeniser` + `TokenBudget(tokeniser=...)`.
 
 ### Previously
 
-[`feat-020 — Chat agents (v0.2 scope)`](../../docs/features/feat-020-chat-agents.md)
-shipped in PR #26 (merged 2026-05-12).
+- feat-013 v0.2 — production MCP runner (PR #32).
+- feat-014 v0.2 — production A2A runner + discovery +
+  streaming (PR #33).
 
 ## Next pick candidates
 
-v0.1.0 is tagged + published. We're now mid-v0.2.0 cycle.
-Sequence continues v0.3 → v0.4 → 1.0 per
-[ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
+We're mid-v0.2.0 cycle. Sequence continues v0.3 → v0.4 → 1.0
+per [ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
 
-**v0.2.0 remaining backlog:**
+**Remaining backlog:**
 
-- **feat-020 follow-ups** —
-  `agentforge-chat-history-postgres`,
-  `agentforge-chat-history-redis`, `agentforge-chat-slack`
-  adapter, real per-token streaming through the strategy
-  loop (also unblocks A2A per-token streaming), cross-process
-  locking, provider-aware tokeniser.
 - **feat-009 vendor backends** — `agentforge-langfuse`,
   `-phoenix`, `-evidently`, `-statsd`.
 - **Sub-feat backlog** (no canonical numbers yet) — GraphRAG
   hybrid retrieval, BM25 + vector hybrid search, `Reranker`
   ABC, schema migrations.
+- **Strategy-level streaming overrides** — concrete
+  `ReasoningStrategy.stream` impls on `ReActLoop` etc. (now
+  that the contract is locked across chat + A2A).
 
 **Already shipped on the v0.1 → v0.2 line:**
 
 - feat-013 v0.2 — production MCP runner (PR #32).
 - feat-014 v0.2 — production A2A runner + discovery +
   streaming (PR #33).
+- feat-020 v0.2 — postgres + redis history + slack adapter +
+  streaming + cross-process lock + tokeniser (PR #34).
+- feat-014 v0.3 — A2A per-token streaming + unified
+  `StreamingChunkKind` (in review).
 
 After v0.2.0 lands, v0.3.0 is reserved for the next round of
-community / ecosystem feedback (intentionally empty at v0.1.0
-cut). v0.4.0 brings TypeScript to parity with the Python
-v0.2 surface per
+community / ecosystem feedback. v0.4.0 brings TypeScript to
+parity with the Python v0.2 surface per
 [ADR-0002](../../docs/adr/0002-multi-language-python-typescript.md).
 
 Spec `Target version` metadata is aspirational and predates

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1560,3 +1560,64 @@ Tooling notes:
   would lazily create the lock at __aenter__ time.
 
 Ready to push and raise PR.
+
+---
+
+## 2026-05-13 — feat-014 v0.3 follow-up shipped
+
+Closed the two remaining v0.2-deferred items in a single PR
+per user-chosen "Full v0.3 bundle" scope: per-token A2A
+streaming + chunk-kind unification. The per-run hook kwarg
+on `Agent.run` was **obviated** by the streaming refactor
+(no caller remaining) and dropped from scope, not deferred.
+
+Chunks (each gated through `uv run pre-commit run
+--all-files` before commit):
+
+- chunk 1 (`a3ed2d7`): `StreamingChunkKind = Literal[text,
+  thinking, step, tool_call, tool_result, done, error]`
+  in `agentforge_core.values.chat`; `ChatChunkKind` and
+  `A2AChunkKind` aliased to it. `step` kept in the union
+  for strategies that want step-level granularity. Tests
+  assert `typing.get_args` shape and that A2AChunk accepts
+  the newly-unified kinds.
+- chunk 2 (`09674b5`): `A2AServer._stream_call` rewritten
+  to drive `Agent.stream(task)`. Drops
+  `_STEP_KIND_TO_CHUNK_KIND`, `_chunk_kind_for`, the
+  `asyncio.Queue` + backgrounded `_run_agent` coroutine,
+  and the `agent._on_step.append/remove` dance. Strategy's
+  terminal `done` is swallowed; server emits its own
+  canonical `done` with `output` + `cost_usd` + `run_id`.
+  Tests now exercise a `stream()`-overriding
+  `_PerTokenStrategy` (text × 3 + done) plus a
+  `_SilentStrategy` (default stream → one canonical done).
+- chunk 3 (`b3724a4`): live integration test
+  `_PerTokenStrategy` overrides `stream()` to yield three
+  `text` tokens + a `tool_call` + a `tool_result` + a
+  terminal `done`. `test_stream_round_trip` asserts the
+  canonical chunk sequence end-to-end against a real
+  uvicorn server + `_HTTPXClientRunner`. All three live
+  tests pass locally.
+- chunk 4 (about-to-commit): spec §10 v0.3 follow-up
+  subsection + per-chunk table + deviations (`step_hook=`
+  kwarg obviated; v0.2 step-level shape requires opt-in
+  override; `step` kind preserved); §11 runbook refresh
+  with per-token usage + a "How do I expose per-token
+  streaming on my strategy?" snippet; roadmap flipped;
+  CHANGELOG `[Unreleased] / Added + Changed` populated.
+
+Tooling notes:
+
+- `AgentState` has no `output` field — `Agent._extract_output`
+  picks the last non-system step's content. Stream-overriding
+  strategies must `state.steps.append(Step(...))` before the
+  terminal `done` so the canonical chunk carries the assembled
+  output.
+- `Agent.stream` already swallows the strategy's terminal
+  `done` and emits its own with the full RunResult shape; A2A
+  server mirrors that, swallowing the strategy's done a second
+  time and emitting the canonical wire frame.
+- Plain `X = Y` aliases preferred over `X: TypeAlias = Y`
+  (ruff UP040 wants `type X = Y`, but PEP 695's
+  `TypeAliasType` doesn't compose well with Pydantic literal
+  validation — plain assignment threads the literal through).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-014 v0.3 — A2A per-token streaming.**
+  `A2AServer._stream_call` now drives `Agent.stream(task)`
+  (shipped in feat-020 v0.2) and forwards each
+  `StreamingEvent` as one `A2AChunk` SSE frame. Strategies
+  that override `ReasoningStrategy.stream` get true
+  per-token granularity end-to-end; strategies that don't
+  fall through to the default ABC stream and emit one
+  canonical `done`. The strategy's terminal `done` is
+  swallowed; the server emits its own canonical `done` with
+  `output` + `cost_usd` + `run_id`. The v0.2 transient
+  `agent._on_step.append/remove` hack is gone.
+- **feat-014 v0.3 — unified `StreamingChunkKind`.**
+  Framework-wide closed vocabulary (`text` / `thinking` /
+  `step` / `tool_call` / `tool_result` / `done` / `error`)
+  in `agentforge_core.values.chat`. `ChatChunkKind` and
+  `A2AChunkKind` are now aliases of it. `text` and
+  `thinking` are newly valid on the A2A wire.
 - **feat-013 v0.2 — production MCP runner.** Replaced the
   `# pragma: no cover` stubs in `agentforge-mcp` with real
   implementations against the upstream `mcp` Python SDK.
@@ -102,6 +119,18 @@ release tag bumps every workspace member to the same minor version.
 
 ### Changed
 
+- **feat-014 v0.3 — `A2AChunkKind` aliased to
+  `StreamingChunkKind`.** Sourced from
+  `agentforge_core.values.chat` (re-exported from
+  `agentforge_a2a.values` for backward compat). Existing
+  imports keep working; new code should prefer
+  `StreamingChunkKind`.
+- **feat-014 v0.3 — A2A streaming chunk shape.** A2A
+  clients that consumed v0.2's
+  `step` / `tool_call` / `tool_result` chunks from a default
+  strategy now receive a single `done` instead — override
+  `ReasoningStrategy.stream` on the strategy to restore
+  per-step granularity (or migrate to per-token text).
 - **CI: new non-gating `live` job.** Runs
   `pytest -m live` against every package shipping a
   `tests/integration/test_*_live.py` suite (mcp + a2a as of

--- a/docs/features/feat-014-a2a-protocol.md
+++ b/docs/features/feat-014-a2a-protocol.md
@@ -301,6 +301,56 @@ the framework's second live suite after feat-013.
 - Hardening the `live` CI job to gate merge.
 - TS port.
 
+### v0.3 follow-up — per-token streaming + chunk-kind unification
+
+Shipped on the v0.1 → v0.3 line. Closes the per-token
+streaming + chunk-kind unification items v0.2 deferred. The
+per-run hook kwarg on `Agent.run` is **obviated** by the
+streaming refactor — the v0.2 hack it would have cleaned up
+is gone.
+
+| Chunk | What landed |
+|---|---|
+| 1 | Framework-wide `StreamingChunkKind` (`text` / `thinking` / `step` / `tool_call` / `tool_result` / `done` / `error`) lives in `agentforge_core.values.chat`. `ChatChunkKind` and `A2AChunkKind` are aliased to it so chat and A2A share one closed vocabulary. The `step` kind stays in the union for strategies that emit step-level events. |
+| 2 | `A2AServer._stream_call` drives `Agent.stream(task)` and forwards each `StreamingEvent` as an `A2AChunk` SSE frame. The strategy's terminal `done` is swallowed; the server emits its own canonical `done` with `output` + `cost_usd` + `run_id`. The v0.2 `asyncio.Queue` + backgrounded `_run_agent` + `agent._on_step.append/remove` dance is removed wholesale. Budget-cap swap stays inline. |
+| 3 | Live integration test `_PerTokenStrategy` overrides `ReasoningStrategy.stream` to yield three `text` tokens + a `tool_call` + a `tool_result` + a terminal `done`; `test_stream_round_trip` asserts the canonical sequence end-to-end against a real `uvicorn.Server` + `_HTTPXClientRunner`. |
+| 4 | Docs + Runbook + roadmap + CHANGELOG + state. |
+
+### v0.3 deviations from the v0.2 design
+
+- **Per-run `step_hook=` kwarg on `Agent.run` obviated, not
+  shipped.** The v0.2 streaming server's transient
+  `agent._on_step.append/remove` hack is gone now that
+  `_stream_call` drives `agent.stream()` directly. The
+  cleanup the kwarg would have unlocked has no remaining
+  caller, so we don't add API surface speculatively.
+- **`step` kind preserved in `StreamingChunkKind`.** It's no
+  longer emitted by the default streaming server (which now
+  forwards typed events from the strategy), but stays in the
+  union so strategies that want step-level granularity can
+  yield `StreamingEvent(kind="step", ...)` explicitly.
+- **v0.2 `step` / `tool_call` / `tool_result` shape requires
+  an opt-in `stream()` override.** Strategies that don't
+  override `ReasoningStrategy.stream` now emit a single
+  canonical `done` over A2A — same graduation behaviour as
+  `ChatSession`. This is a breaking change for A2A clients
+  that relied on the v0.2 per-step shape from a default
+  strategy; documented here so callers either override
+  `stream()` on their strategy or migrate to consuming the
+  canonical `done` alone.
+- **`A2AChunkKind` is now `agentforge_core`-owned.** The
+  alias still lives at `agentforge_a2a.values` for backward
+  compat, but the canonical definition is
+  `agentforge_core.values.chat.StreamingChunkKind`.
+
+### Out-of-scope (deferred to v0.4+)
+
+- Central A2A registry service.
+- Hardening the `live` CI job to gate merge.
+- TS port.
+- Overriding `ReasoningStrategy.stream` on built-in
+  strategies (`ReActLoop`, etc.) — case-by-case.
+
 ## 11. Runbook
 
 ### How do I consume another agent?
@@ -423,7 +473,7 @@ When you have multiple peers wired through `A2ABridge`,
 `await bridge.discover_all()` probes them all and caches the
 results on `bridge.peer_info`.
 
-### How do I stream a long-running agent call? (v0.2)
+### How do I stream a long-running agent call? (v0.3)
 
 ```python
 from agentforge_a2a import agent_call_stream
@@ -435,20 +485,55 @@ async for chunk in agent_call_stream(
     timeout_s=60.0,
     budget_usd=0.25,
 ):
-    if chunk.kind in {"step", "tool_call", "tool_result"}:
-        print(chunk.kind, chunk.step)
+    if chunk.kind == "text":
+        print(chunk.content, end="", flush=True)
+    elif chunk.kind in {"thinking", "step", "tool_call", "tool_result"}:
+        print(f"\n[{chunk.kind}] {chunk.content}")
     elif chunk.kind == "done":
-        print("done →", chunk.content)
+        print("\ndone →", chunk.content)
     elif chunk.kind == "error":
         # agent_call_stream raises A2AAuthError / A2ACallError
         # on error frames — this branch is for completeness.
         raise RuntimeError(chunk.content)
 ```
 
-Step-level granularity for v0.2: one chunk per agent `Step`
-(mapped from `Step.kind`) plus a final `done`. Real per-token
-streaming through the strategy ABC lands in v0.3 alongside
-feat-020's strategy-level streaming follow-up.
+v0.3 ships true per-token streaming via
+`ReasoningStrategy.stream()`. Each event the strategy yields
+becomes one SSE frame on the wire; the server emits its own
+canonical `done` with `output` + `cost_usd` + `run_id` after
+the strategy completes.
+
+Strategies that **don't** override `ReasoningStrategy.stream`
+fall through to the default ABC implementation and emit a
+single `done` event — same graduation behaviour as
+`ChatSession`. Override `stream()` on your strategy to get
+per-token granularity.
+
+### How do I expose per-token streaming on my strategy? (v0.3)
+
+```python
+from collections.abc import AsyncIterator
+
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.chat import StreamingEvent
+from agentforge_core.values.state import AgentState, Step
+
+
+class MyTokenStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        # Unary callers still call run(); append a final step
+        # so Agent._extract_output picks up the answer.
+        state.steps.append(Step(iteration=0, kind="synthesize", content="final"))
+        return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        async for token in self._llm_stream(state.task):
+            yield StreamingEvent(kind="text", content=token)
+        state.steps.append(Step(iteration=0, kind="synthesize", content="final"))
+        # Always yield a terminal `done`; Agent.stream swallows it
+        # and emits its own canonical done with the full RunResult.
+        yield StreamingEvent(kind="done", content={"run_id": state.run_id})
+```
 
 ### How do I run the live A2A tests?
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,16 +114,32 @@ follow-up"). Three items all landed in one PR:
   `agent_call_stream(...)` yields them. Step-level
   granularity for v0.2.
 
-What remains for v0.3:
+**v0.3 follow-up: per-token streaming + chunk-kind
+unification** — shipped on the v0.1 → v0.3 line (spec §10
+"v0.3 follow-up"):
 
-- Real per-token LLM streaming via `ReasoningStrategy.stream()`
-  (lands alongside feat-020's strategy-level streaming
-  follow-up).
-- Per-run hook kwarg on `Agent.run` (cleanup of the streaming
-  server's transient `agent._on_step.append(...)` dance).
+- **Per-token A2A streaming** —
+  `A2AServer._stream_call` now drives `Agent.stream(task)`
+  and forwards each `StreamingEvent` as an `A2AChunk`. The
+  v0.2 hook-append/remove dance is gone; per-token text is
+  available end-to-end when the strategy overrides
+  `ReasoningStrategy.stream`.
+- **Unified `StreamingChunkKind`** — one closed vocabulary
+  (`text` / `thinking` / `step` / `tool_call` /
+  `tool_result` / `done` / `error`) lives in
+  `agentforge_core.values.chat`. `ChatChunkKind` +
+  `A2AChunkKind` are aliases.
+
+The per-run hook kwarg on `Agent.run` was **obviated** by
+this refactor (no remaining caller) and dropped from scope.
+
+What remains for v0.4+:
+
 - Central A2A registry service (still out of v0.x scope).
-- Unifying `A2AChunkKind` with `ChatChunkKind` under a
-  framework-wide `StreamingChunk`.
+- Hardening the `live` CI job to gate merge.
+- Overriding `ReasoningStrategy.stream` on built-in
+  strategies (`ReActLoop`, etc.).
+- TS port.
 
 ### feat-020 follow-ups — chat history + adapters + streaming
 
@@ -146,10 +162,10 @@ What remains for v0.3:
 - **Provider-aware tokeniser** — `tiktoken_tokeniser` +
   `anthropic_tokeniser` wired into `TokenBudget`.
 
-Remaining for v0.3:
+Remaining for v0.3+:
 
 - A2A per-token streaming using `ReasoningStrategy.stream()`
-  (separate feat-014 follow-up).
+  — **shipped** in feat-014 v0.3 follow-up.
 - Concrete `stream()` overrides on `ReActLoop`.
 - Multi-cluster Redlock for `RedisSessionLock`.
 - Sentence-window streaming output guardrails.

--- a/packages/agentforge-a2a/src/agentforge_a2a/server.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/server.py
@@ -30,28 +30,27 @@ Lifecycle:
      shape stays tolerant of any `Finding` Protocol-compatible
      object.
 
-Streaming installs a one-off `on_step` hook on the agent for
-the duration of a single call so each `Step` arrives as a
-chunk; the final frame carries the cost + output. The hook is
-removed in a `finally` block. A cleaner per-run hook surface
-on `Agent.run` is a v0.3 cleanup.
+Streaming (v0.3) drives `Agent.stream(task)` and forwards each
+`StreamingEvent` emitted by the strategy as one `A2AChunk` SSE
+frame. The strategy's terminal `done` event is swallowed; the
+server emits its own canonical `done` chunk carrying
+`output` + `cost_usd` + `run_id`. The v0.2 transient
+`agent._on_step` hook dance is gone — events arrive
+pre-typed from the strategy generator.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import logging
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import uvicorn
-from agentforge.agent import Agent, StepHook
-from agentforge.recording import _finding_payload, _step_payload
+from agentforge.agent import Agent
+from agentforge.recording import _finding_payload
 from agentforge_core.contracts.auth import AuthPolicy
 from agentforge_core.production.budget import BudgetPolicy
-from agentforge_core.values.state import Step
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -60,7 +59,6 @@ from pydantic import BaseModel, ConfigDict
 from agentforge_a2a._runner import A2AServerRunner
 from agentforge_a2a.values import (
     A2AChunk,
-    A2AChunkKind,
     A2AEndpointConfig,
     A2AEndpointDescriptor,
     A2APeerInfo,
@@ -76,22 +74,11 @@ TaskBuilder = Callable[[str, dict[str, Any]], str]
 """Maps (endpoint_name, payload) -> the task string the agent
 receives. Default: JSON-encode the payload."""
 
-_STEP_KIND_TO_CHUNK_KIND: dict[str, A2AChunkKind] = {
-    "think": "step",
-    "act": "tool_call",
-    "observe": "tool_result",
-}
-
 
 def _default_task_builder(endpoint: str, payload: dict[str, Any]) -> str:
     """Concatenates endpoint name + JSON payload for the agent."""
     body = json.dumps(payload, sort_keys=True)
     return f"a2a.{endpoint}: {body}"
-
-
-def _chunk_kind_for(step_kind: str) -> A2AChunkKind:
-    """Map an agent `Step.kind` to a wire-format `A2AChunkKind`."""
-    return _STEP_KIND_TO_CHUNK_KIND.get(step_kind, "step")
 
 
 def _sse_frame(chunk: A2AChunk) -> bytes:
@@ -216,11 +203,12 @@ class A2AServer:
     async def _stream_call(self, body: CallRequest, request: Request) -> AsyncIterator[bytes]:
         """SSE generator for `POST /a2a/v1/calls/stream`.
 
-        Each `Step` produced by the inner `Agent.run` is pushed
-        onto an `asyncio.Queue` by a one-off `on_step` hook and
-        flushed to the wire as a `data:` frame. The final frame
-        is either ``kind="done"`` carrying the result or
-        ``kind="error"`` carrying the failure reason.
+        Drives `Agent.stream(task)` and forwards each
+        ``StreamingEvent`` as one ``A2AChunk`` ``data:`` frame.
+        The strategy's terminal ``done`` event is swallowed; this
+        method emits the canonical ``done`` chunk carrying
+        ``output`` + ``cost_usd`` + ``run_id``. Strategy errors
+        surface as a terminal ``kind="error"`` frame.
         """
         parent_run_id = request.headers.get("X-AgentForge-Run-Id")
         if body.endpoint not in self._endpoints:
@@ -236,63 +224,61 @@ class A2AServer:
             )
             return
 
-        queue: asyncio.Queue[A2AChunk | None] = asyncio.Queue()
+        task_str = self._task_builder(body.endpoint, body.payload)
+        budget_cap = self._read_budget_header(request)
+        original_budget = self._agent._budget
+        if budget_cap is not None:
+            self._agent._budget = BudgetPolicy(
+                usd=min(original_budget.usd, budget_cap),
+                max_tokens=original_budget.max_tokens,
+                max_iterations=original_budget.max_iterations,
+                error_streak_limit=original_budget.error_streak_limit,
+            )
 
-        async def _hook(step: Step) -> None:
-            await queue.put(
+        done_content: dict[str, Any] | None = None
+        try:
+            async for event in self._agent.stream(task_str):
+                if event.kind == "done":
+                    raw = event.content if isinstance(event.content, dict) else {}
+                    done_content = {
+                        "output": _coerce_jsonable(raw.get("output")),
+                        "cost_usd": float(raw.get("cost_usd", 0.0) or 0.0),
+                        "run_id": str(raw.get("run_id", "")),
+                    }
+                    continue
+                yield _sse_frame(
+                    A2AChunk(
+                        kind=event.kind,
+                        content=event.content,
+                        metadata=dict(event.metadata),
+                        parent_run_id=parent_run_id,
+                    )
+                )
+        except Exception as exc:
+            yield _sse_frame(
                 A2AChunk(
-                    kind=_chunk_kind_for(step.kind),
-                    step=_step_payload(step),
+                    kind="error",
+                    content={
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                    },
                     parent_run_id=parent_run_id,
                 )
             )
-
-        hook: StepHook = _hook
-        self._agent._on_step.append(hook)
-
-        async def _run_agent() -> None:
-            try:
-                result = await self._run_with_budget_cap(body, request)
-                await queue.put(
-                    A2AChunk(
-                        kind="done",
-                        content={
-                            "output": _coerce_jsonable(result.output),
-                            "cost_usd": float(result.cost_usd),
-                            "run_id": result.run_id,
-                        },
-                        run_id=result.run_id,
-                        parent_run_id=parent_run_id,
-                    )
-                )
-            except Exception as exc:
-                await queue.put(
-                    A2AChunk(
-                        kind="error",
-                        content={
-                            "error": type(exc).__name__,
-                            "message": str(exc),
-                        },
-                        parent_run_id=parent_run_id,
-                    )
-                )
-            finally:
-                await queue.put(None)
-
-        task = asyncio.create_task(_run_agent())
-        try:
-            while True:
-                chunk = await queue.get()
-                if chunk is None:
-                    break
-                yield _sse_frame(chunk)
+            return
         finally:
-            with contextlib.suppress(ValueError):
-                self._agent._on_step.remove(hook)
-            if not task.done():
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await task
+            if budget_cap is not None:
+                self._agent._budget = original_budget
+
+        final = done_content or {"output": None, "cost_usd": 0.0, "run_id": ""}
+        yield _sse_frame(
+            A2AChunk(
+                kind="done",
+                content=final,
+                run_id=final["run_id"] or None,
+                parent_run_id=parent_run_id,
+            )
+        )
 
     async def _run_with_budget_cap(self, body: CallRequest, request: Request) -> Any:
         """Run the agent honouring the per-call ``X-AgentForge-Budget-Usd``

--- a/packages/agentforge-a2a/src/agentforge_a2a/values.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/values.py
@@ -19,14 +19,21 @@ v0.2 follow-up adds the discovery + streaming wire shapes:
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
+from agentforge_core.values.chat import StreamingChunkKind
 from pydantic import BaseModel, ConfigDict, Field
 
-A2AChunkKind = Literal["step", "tool_call", "tool_result", "done", "error"]
+A2AChunkKind = StreamingChunkKind
 """Kinds of frames streamed over `POST /a2a/v1/calls/stream`.
 
-- ``step`` — generic agent step (think + others).
+Aliased to the framework-wide ``StreamingChunkKind`` so chat and A2A
+share one wire vocabulary (feat-014 v0.3). Common kinds:
+
+- ``text`` — per-token text chunk emitted by strategies that override
+  ``ReasoningStrategy.stream()``.
+- ``thinking`` — model-internal reasoning token (when surfaced).
+- ``step`` — generic agent step boundary (think / observe envelope).
 - ``tool_call`` — agent invoked a tool.
 - ``tool_result`` — observation from a tool call.
 - ``done`` — terminal frame carrying the final output + cost.

--- a/packages/agentforge-a2a/tests/integration/test_a2a_live.py
+++ b/packages/agentforge-a2a/tests/integration/test_a2a_live.py
@@ -1,11 +1,13 @@
-"""Live A2A integration test (feat-014 v0.2).
+"""Live A2A integration test (feat-014 v0.3).
 
 Spawns a real `uvicorn.Server` on a random localhost port,
 points a real `_HTTPXClientRunner` at it, and round-trips:
 
 1. `agent_call(...)` — unary `POST /a2a/v1/calls`.
 2. `discover_peer(...)` — `GET /a2a/v1/info`.
-3. `agent_call_stream(...)` — SSE `POST /a2a/v1/calls/stream`.
+3. `agent_call_stream(...)` — SSE `POST /a2a/v1/calls/stream`
+   exercising per-token streaming via a strategy that overrides
+   `ReasoningStrategy.stream()`.
 
 Gated by `@pytest.mark.live` so the default unit gate skips it.
 Run explicitly with:
@@ -39,6 +41,7 @@ from agentforge_core.contracts.auth import AuthPolicy
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.values.auth import Principal
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import (
     LLMResponse,
     Message,
@@ -48,15 +51,32 @@ from agentforge_core.values.messages import (
 from agentforge_core.values.state import AgentState, Step
 
 
-class _ThreeStepStrategy(ReasoningStrategy):
+class _PerTokenStrategy(ReasoningStrategy):
+    """Overrides both `run` (for unary callers) and `stream` (for
+    per-token A2A streaming). The streamed sequence is three text
+    tokens, a tool call, a tool result, and a terminal done — the
+    canonical demonstration of the v0.3 per-token contract."""
+
     async def run(self, state: AgentState) -> AgentState:
         runtime = state.metadata.get(RUNTIME_KEY)
         if runtime is not None:
             runtime.budget.commit(0.0)
-        state.steps.append(Step(iteration=0, kind="think", content="thinking"))
-        state.steps.append(Step(iteration=1, kind="act", content="calling-tool"))
-        state.steps.append(Step(iteration=2, kind="observe", content="observed"))
+        state.steps.append(Step(iteration=0, kind="synthesize", content="Hello, world!"))
         return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        for tok in ("Hello, ", "world", "!"):
+            yield StreamingEvent(kind="text", content=tok)
+        yield StreamingEvent(kind="tool_call", content={"name": "noop", "arguments": {}})
+        yield StreamingEvent(kind="tool_result", content={"output": "ok"})
+        state.steps.append(Step(iteration=0, kind="synthesize", content="Hello, world!"))
+        yield StreamingEvent(
+            kind="done",
+            content={"run_id": state.run_id, "cost_usd": 0.0, "output": "Hello, world!"},
+        )
 
 
 class _FakeLLM(LLMClient):
@@ -94,7 +114,7 @@ class _StaticBearerAuth(AuthPolicy):
 
 
 def _build_agent() -> Agent:
-    return Agent(model=_FakeLLM(), strategy=_ThreeStepStrategy())
+    return Agent(model=_FakeLLM(), strategy=_PerTokenStrategy())
 
 
 def _build_server(*, token: str = "live-tok") -> A2AServer:
@@ -232,10 +252,24 @@ async def test_stream_round_trip() -> None:
                 )
             ]
             kinds = [c.kind for c in chunks]
-            assert kinds[-1] == "done"
-            # three steps + done; mapping: think→step, act→tool_call,
-            # observe→tool_result.
-            assert kinds[:3] == ["step", "tool_call", "tool_result"]
-            assert chunks[-1].run_id is not None
+            # v0.3 per-token contract: three `text` tokens, then one
+            # `tool_call` and one `tool_result`, then the canonical
+            # `done` emitted by the server (carrying the assembled
+            # output + cost + run_id).
+            assert kinds == [
+                "text",
+                "text",
+                "text",
+                "tool_call",
+                "tool_result",
+                "done",
+            ]
+            text_tokens = [c.content for c in chunks if c.kind == "text"]
+            assert text_tokens == ["Hello, ", "world", "!"]
+            done = chunks[-1]
+            assert done.run_id is not None
+            assert isinstance(done.content, dict)
+            assert done.content["output"] == "Hello, world!"
+            assert done.content["cost_usd"] == 0.0
     finally:
         await runner.close()

--- a/packages/agentforge-a2a/tests/unit/test_a2a_streaming_server.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_streaming_server.py
@@ -1,8 +1,17 @@
-"""Unit tests for `POST /a2a/v1/calls/stream` (feat-014 v0.2)."""
+"""Unit tests for `POST /a2a/v1/calls/stream` (feat-014 v0.3).
+
+v0.3 swaps the server from a one-off `_on_step` hook to driving
+``Agent.stream(task)`` and forwarding each ``StreamingEvent`` as
+an ``A2AChunk`` frame. Strategies that override
+``ReasoningStrategy.stream`` emit per-token text; strategies that
+don't fall through to the default base-class ``stream`` and emit
+a single ``done``.
+"""
 
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
@@ -12,6 +21,7 @@ from agentforge.runtime import RUNTIME_KEY
 from agentforge_a2a import A2AServer
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import (
     LLMResponse,
     Message,
@@ -22,16 +32,44 @@ from agentforge_core.values.state import AgentState, Step
 from fastapi.testclient import TestClient
 
 
-class _ThreeStepStrategy(ReasoningStrategy):
-    """Appends three deterministic steps then finishes."""
+class _PerTokenStrategy(ReasoningStrategy):
+    """Overrides `stream()` to emit three text tokens then done.
+
+    Demonstrates the v0.3 per-token contract: the strategy itself
+    decides chunk granularity; the A2A server forwards events as
+    SSE frames without inspecting agent steps.
+    """
 
     async def run(self, state: AgentState) -> AgentState:
         runtime = state.metadata.get(RUNTIME_KEY)
         if runtime is not None:
             runtime.budget.commit(0.0)
-        state.steps.append(Step(iteration=0, kind="think", content="thinking"))
-        state.steps.append(Step(iteration=1, kind="act", content="calling_tool", tool_call=None))
-        state.steps.append(Step(iteration=2, kind="observe", content="tool_obs"))
+        return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
+        for tok in ("Hello, ", "world", "!"):
+            yield StreamingEvent(kind="text", content=tok)
+        # Agent._extract_output reads the last non-system step's
+        # content; append one so the canonical `done` chunk carries
+        # the assembled text.
+        state.steps.append(Step(iteration=0, kind="synthesize", content="Hello, world!"))
+        yield StreamingEvent(
+            kind="done",
+            content={"run_id": state.run_id, "cost_usd": 0.0, "output": "Hello, world!"},
+        )
+
+
+class _SilentStrategy(ReasoningStrategy):
+    """Doesn't override `stream`; falls through to the default
+    base-class implementation that yields one terminal `done`."""
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.0)
         return state
 
 
@@ -71,7 +109,7 @@ def _agent(strategy: ReasoningStrategy) -> Agent:
 def server(monkeypatch: pytest.MonkeyPatch) -> A2AServer:
     monkeypatch.setenv("A2A_TOKENS", "good")
     return A2AServer(
-        agent=_agent(_ThreeStepStrategy()),
+        agent=_agent(_PerTokenStrategy()),
         auth=EnvBearerAuth("A2A_TOKENS"),
         endpoints=["verify"],
     )
@@ -94,7 +132,7 @@ def _parse_sse(body: bytes) -> list[dict[str, Any]]:
     ]
 
 
-def test_stream_emits_step_chunks_then_done(client: TestClient) -> None:
+def test_stream_emits_per_token_text_then_done(client: TestClient) -> None:
     r = client.post(
         "/a2a/v1/calls/stream",
         json={"endpoint": "verify", "payload": {}},
@@ -104,11 +142,33 @@ def test_stream_emits_step_chunks_then_done(client: TestClient) -> None:
     assert r.headers["content-type"].startswith("text/event-stream")
     chunks = _parse_sse(r.content)
     kinds = [c["kind"] for c in chunks]
-    # 3 steps mapped to step/tool_call/tool_result, then done.
-    assert kinds == ["step", "tool_call", "tool_result", "done"]
+    assert kinds == ["text", "text", "text", "done"]
+    text_chunks = [c["content"] for c in chunks if c["kind"] == "text"]
+    assert text_chunks == ["Hello, ", "world", "!"]
     done = chunks[-1]
-    assert done["run_id"] is not None
-    assert "output" in done["content"]
+    assert done["run_id"]
+    assert done["content"]["output"] == "Hello, world!"
+    assert done["content"]["cost_usd"] == 0.0
+
+
+def test_stream_default_strategy_emits_only_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strategies that don't override `stream()` fall through to the
+    default base-class implementation, which yields one terminal
+    `done`. The A2A server swallows the strategy's done and emits
+    its own canonical one."""
+    monkeypatch.setenv("A2A_TOKENS", "good")
+    silent = A2AServer(
+        agent=_agent(_SilentStrategy()),
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["verify"],
+    )
+    r = TestClient(silent.app).post(
+        "/a2a/v1/calls/stream",
+        json={"endpoint": "verify", "payload": {}},
+        headers=_auth(),
+    )
+    chunks = _parse_sse(r.content)
+    assert [c["kind"] for c in chunks] == ["done"]
 
 
 def test_stream_missing_bearer_returns_401(client: TestClient) -> None:
@@ -159,17 +219,22 @@ def test_stream_strategy_error_surfaces_as_error_chunk(
     assert chunks[-1]["content"]["error"] in {"RuntimeError", "AgentRunError"}
 
 
-def test_stream_budget_header_caps_run(
+def test_stream_budget_header_caps_and_restores(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Budget cap is honoured for the streamed call and the original
+    budget is restored when the stream finishes. v0.3 also asserts
+    the server does NOT mutate `agent._on_step` (the v0.2 hook
+    dance is gone)."""
     monkeypatch.setenv("A2A_TOKENS", "good")
-    agent = _agent(_ThreeStepStrategy())
+    agent = _agent(_PerTokenStrategy())
     server = A2AServer(
         agent=agent,
         auth=EnvBearerAuth("A2A_TOKENS"),
         endpoints=["verify"],
     )
     original_budget_usd = agent._budget.usd
+    hooks_before = list(agent._on_step)
     client = TestClient(server.app)
     r = client.post(
         "/a2a/v1/calls/stream",
@@ -177,7 +242,5 @@ def test_stream_budget_header_caps_run(
         headers={**_auth(), "X-AgentForge-Budget-Usd": "0.001"},
     )
     assert r.status_code == 200
-    # Budget is restored after the call returns.
     assert agent._budget.usd == original_budget_usd
-    # Hook list is empty again — no leak across calls.
-    assert agent._on_step == []
+    assert agent._on_step == hooks_before

--- a/packages/agentforge-a2a/tests/unit/test_a2a_streaming_values.py
+++ b/packages/agentforge-a2a/tests/unit/test_a2a_streaming_values.py
@@ -17,6 +17,14 @@ def test_a2a_chunk_is_frozen_and_validates_kind() -> None:
         chunk.kind = "done"  # type: ignore[misc]
 
 
+def test_a2a_chunk_accepts_unified_streaming_kinds() -> None:
+    """v0.3 unifies A2AChunkKind with StreamingChunkKind, so per-token
+    `text` / `thinking` kinds are now valid on the A2A wire."""
+    for kind in ("text", "thinking", "step", "tool_call", "tool_result", "done", "error"):
+        chunk = A2AChunk(kind=kind, content="x" if kind in {"text", "thinking"} else {"x": 1})
+        assert chunk.kind == kind
+
+
 def test_a2a_chunk_rejects_unknown_kind() -> None:
     with pytest.raises(ValidationError):
         A2AChunk(kind="bogus")  # type: ignore[arg-type]

--- a/packages/agentforge-core/src/agentforge_core/values/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/values/__init__.py
@@ -15,6 +15,7 @@ from agentforge_core.values.chat import (
     ChatRole,
     ChatTurn,
     SessionInfo,
+    StreamingChunkKind,
     StreamingEvent,
 )
 from agentforge_core.values.claim import Claim
@@ -89,6 +90,7 @@ __all__ = [
     "StopReason",
     "StreamChunk",
     "StreamChunkKind",
+    "StreamingChunkKind",
     "StreamingEvent",
     "TemplateFile",
     "TokenUsage",

--- a/packages/agentforge-core/src/agentforge_core/values/chat.py
+++ b/packages/agentforge-core/src/agentforge_core/values/chat.py
@@ -16,10 +16,29 @@ from agentforge_core.values.messages import ToolCall
 ChatRole = Literal["user", "assistant", "system", "tool"]
 """Closed enum of chat turn roles."""
 
-ChatChunkKind = Literal["text", "tool_call", "tool_result", "thinking", "done", "error"]
-"""Closed enum of streaming chunk kinds. Adding a new kind requires a
-minor version bump per ADR-0007. Receivers must ignore unknown kinds
-on the wire — forward-compat for future additions."""
+StreamingChunkKind = Literal[
+    "text",
+    "thinking",
+    "step",
+    "tool_call",
+    "tool_result",
+    "done",
+    "error",
+]
+"""Closed enum of streaming chunk kinds shared across chat (token-level)
+and A2A (step + token-level) wire formats. Adding a new kind requires a
+minor version bump per ADR-0007. Receivers must ignore unknown kinds on
+the wire — forward-compat for future additions.
+
+The ``step`` kind is reserved for strategies that emit step-level
+events alongside (or instead of) per-token text. Chat receivers
+typically ignore it; A2A clients render it as a generic step boundary.
+"""
+
+ChatChunkKind = StreamingChunkKind
+"""Backward-compatible alias retained for callers that imported the
+chat-shaped name in feat-020 v0.1 / v0.2. Prefer ``StreamingChunkKind``
+in new code."""
 
 
 class ChatTurn(BaseModel):

--- a/packages/agentforge-core/tests/unit/test_chat_values.py
+++ b/packages/agentforge-core/tests/unit/test_chat_values.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+import typing
+
 import pytest
-from agentforge_core.values.chat import ChatChunk, ChatResponse, ChatTurn, SessionInfo
+from agentforge_core.values.chat import (
+    ChatChunk,
+    ChatChunkKind,
+    ChatResponse,
+    ChatTurn,
+    SessionInfo,
+    StreamingChunkKind,
+)
 from pydantic import ValidationError
 
 
@@ -43,3 +52,12 @@ def test_chat_response_round_trip() -> None:
     blob = r.model_dump_json()
     restored = ChatResponse.model_validate_json(blob)
     assert restored == r
+
+
+def test_streaming_chunk_kind_unified_alias() -> None:
+    """feat-014 v0.3 unifies ChatChunkKind with the framework-wide
+    StreamingChunkKind. Both names must resolve to the same Literal
+    union covering text/thinking/step/tool_call/tool_result/done/error."""
+    expected = {"text", "thinking", "step", "tool_call", "tool_result", "done", "error"}
+    assert set(typing.get_args(StreamingChunkKind)) == expected
+    assert set(typing.get_args(ChatChunkKind)) == expected


### PR DESCRIPTION
## Summary

- A2A streaming server now drives `Agent.stream(task)` (shipped in feat-020 v0.2) and forwards each `StreamingEvent` as an `A2AChunk` SSE frame. The v0.2 `agent._on_step.append/remove` hack + `asyncio.Queue` + backgrounded `_run_agent` dance are gone.
- Framework-wide `StreamingChunkKind` (`text` / `thinking` / `step` / `tool_call` / `tool_result` / `done` / `error`) lives in `agentforge_core.values.chat`. `ChatChunkKind` + `A2AChunkKind` are aliases.
- The per-run `step_hook=` kwarg on `Agent.run` listed in v0.2's deferred items is **obviated** by the streaming refactor (no remaining caller) and dropped from scope — documented as a deviation, not deferred.

## Chunks

1. `a3ed2d7` — Unify chunk kinds under `StreamingChunkKind`; alias `ChatChunkKind` + `A2AChunkKind`; tests assert the seven literals.
2. `09674b5` — `A2AServer._stream_call` drives `agent.stream(task)`; strategy's terminal `done` swallowed; server emits canonical `done`. Unit suite exercises both `_PerTokenStrategy` and `_SilentStrategy` (default ABC stream).
3. `b3724a4` — Live integration test `_PerTokenStrategy` overrides `stream()` to yield `text` × 3 + `tool_call` + `tool_result` + `done`; `test_stream_round_trip` asserts the canonical sequence end-to-end.
4. `0f02fcc` — Spec §10 v0.3 follow-up + §11 Runbook refresh + roadmap + CHANGELOG + state.

## Test plan

- [x] `uv run pre-commit run --all-files` green at every chunk (ruff + mypy --strict + bandit + pytest unit + ≥ 90% coverage on touched packages)
- [x] `uv run pytest -m live packages/agentforge-a2a/tests/integration/` — 3 live tests pass (unary, discover, per-token stream)
- [x] No regression in `agentforge-chat` tests on the `ChatChunkKind` alias rename

## Out of scope (deferred to v0.4+)

- Central A2A registry service
- Hardening the `live` CI job to gate merge
- Overriding `ReasoningStrategy.stream` on built-in strategies (`ReActLoop`, etc.) — case-by-case
- TS port

🤖 Generated with [Claude Code](https://claude.com/claude-code)