### PR TITLE
feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,68 +1,58 @@
 ---
-feature: feat-021 v0.2 follow-up — vendor reranker sister packages
+feature: feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle
 state: in_review
-branch: chore/feat-021-vendor-rerankers-cohere-voyage-mixedbread
+branch: chore/feat-002-009-021-streaming-otel-spans-a2a-tracecontext-retriever-wiring
 started_at: 2026-05-14
 last_milestone_at: 2026-05-14
-last_shipped: feat-021 v0.2 follow-up (retrieval: YAML block + build_retriever_from_config) shipped via PR #38 (merged 2026-05-14)
+last_shipped: feat-021 vendor reranker sister packages shipped via PR #39 (merged 2026-05-14)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-[`feat-021 — Reranker`](../../docs/features/feat-021-reranker.md)
-v0.2 follow-up — vendor reranker sister packages bundled
-into one PR per user-chosen scope. All three follow the
-sentence-transformers package template (Runner Protocol +
-production wrapper + in-memory fake in `src/`).
+Bundled v0.3 polish PR closing five surfaces in one go per
+user-chosen "Full bundle as described" scope:
 
-- **`agentforge-reranker-cohere`** — Cohere Rerank API.
-  Default model `rerank-english-v3.0`.
-- **`agentforge-reranker-voyage`** — Voyage AI Rerank API.
-  Default model `rerank-2`.
-- **`agentforge-reranker-mixedbread`** — Mixedbread AI
-  Rerank API. Default model
-  `mixedbread-ai/mxbai-rerank-large-v1`.
-
-Each vendor SDK is an optional `[<vendor>]` extra; bare
-install keeps the package importable for tests with the
-fake runner. Live tests scoped to developer machines
-(skipped on missing API-key env var).
+- **feat-002** — `ReActLoop.stream()` per-iteration override.
+- **feat-009 v0.3** — child OTel spans
+  (`strategy.iteration` / `llm.call` / `tool.<name>` /
+  `evaluator.<name>`), A2A W3C TraceContext propagation,
+  content-based PII redaction.
+- **feat-021** — `Agent(retriever=...)` auto-wired from
+  `build_agent_from_config`.
 
 ## Last shipped
 
-[`feat-021 v0.2 follow-up`](../../docs/features/feat-021-reranker.md)
-`retrieval:` YAML block + `build_retriever_from_config()`
-shipped via PR #38 (merged 2026-05-14).
+feat-021 vendor reranker sister packages
+(`agentforge-reranker-cohere`, `-voyage`, `-mixedbread`)
+shipped via PR #39 (merged 2026-05-14).
 
 ### Previously
 
-- feat-021 — Reranker ABC + SentenceTransformers default
-  + Retriever integration (PR #37, 2026-05-13).
+- feat-021 v0.2 follow-up — `retrieval:` YAML block +
+  `build_retriever_from_config` (PR #38).
+- feat-021 — Reranker ABC + sentence-transformers default
+  + Retriever integration (PR #37).
 - feat-009 v0.2 — Langfuse + Phoenix + Evidently + StatsD
-  vendor observability backends (PR #36, 2026-05-13).
+  vendor observability backends (PR #36).
 - feat-014 v0.3 — A2A per-token streaming + unified
-  `StreamingChunkKind` (PR #35, 2026-05-13).
+  `StreamingChunkKind` (PR #35).
 - feat-020 v0.2 — postgres + redis history + slack adapter
-  + per-token streaming foundation (PR #34, 2026-05-13).
+  + per-token streaming foundation (PR #34).
 
 ## Next pick candidates
 
-We're mid-v0.2.0 cycle. Sequence continues v0.3 → v0.4 → 1.0
-per [ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
-
-**Remaining backlog:**
+Remaining v0.2 backlog:
 
 - **Sub-feat backlog (still un-numbered)** — GraphRAG
   hybrid retrieval, BM25 + vector hybrid search, schema
   migrations.
-- **Strategy-level streaming overrides** — concrete
-  `ReasoningStrategy.stream` impls on `ReActLoop` etc.
-- **feat-009 v0.3 polish** — child OTel spans, A2A trace
-  propagation, content-based PII redaction.
-- **`Agent(retriever=...)` constructor kwarg** — bumped to
-  v0.3 if usage patterns warrant.
+- **ToT + MultiAgent `stream()` overrides** — feat-002
+  follow-up; each strategy's iteration shape is different.
+- **`strategy.iteration` spans on ToT + MultiAgent** —
+  feat-009 v0.3.x; needs a small extract-method refactor.
+- **Plan-Execute `stream()` override** — feat-002 follow-up.
 
 **Already shipped on the v0.1 → v0.2 line:**
 
@@ -79,7 +69,9 @@ per [ADR-0015](../../docs/adr/0015-coordinated-release-train.md).
 - feat-021 v0.2 follow-up — `retrieval:` YAML block +
   builder (PR #38).
 - feat-021 v0.2 follow-up — vendor reranker sister
-  packages (in review).
+  packages (PR #39).
+- feat-002 + feat-009 v0.3 polish + feat-021 follow-up
+  bundle (in review).
 
 ## Reading order on session resume
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1902,3 +1902,72 @@ Tooling notes:
 - Ruff PLR2004 (magic-number-comparison) fires on test
   assertions like `len(results) == 2`. Auto-fixed with
   `# noqa: PLR2004` on first pre-commit pass.
+
+---
+
+## 2026-05-14 — feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle shipped
+
+Big bundled PR closing the three remaining v0.2 cycle items
+in one go per user-chosen "Full bundle as described" scope.
+
+Chunks (each gated through `uv run pre-commit run
+--all-files` before commit):
+
+- chunk 1 (`d096b80`): ReActLoop.stream() per-iteration
+  override. Mirrors run()'s loop structure but yields a
+  `step` StreamingEvent each time state.steps is appended.
+  Terminal `done` event (carrying run_id + cost_usd) is
+  swallowed by Agent.stream which emits its own canonical
+  done with full RunResult shape.
+- chunk 2 (`ebf7af3`): child OTel spans. Single-point
+  instrumentation in StrategyBase._call_llm (llm.call span)
+  + StrategyBase._dispatch_tool (tool.<name> span) covers
+  every strategy. strategy.iteration spans added to
+  ReActLoop (run + stream) and PlanExecuteLoop;
+  ToT + MultiAgent deferred (their nested loop structure
+  needs extract-method refactor). evaluator.<name> span
+  added to Agent._run_evaluators. End-to-end test asserts
+  full span tree via InMemorySpanExporter.
+- chunk 3 (`d8419c1`): A2A W3C TraceContext propagation.
+  Client _build_headers calls TraceContextTextMapPropagator
+  .inject(headers) after existing run-id / budget headers.
+  Server _handle_call + _stream_call extract the
+  traceparent and open an `a2a.call` span with the extracted
+  context as parent. Streaming path uses manual
+  __enter__/__exit__ because async generators don't compose
+  with `with` blocks. 3 unit tests cover injection
+  (with/without span) + cross-process trace_id stitching.
+- chunk 4 (`e347c35`): content-based PII redaction +
+  Agent retriever wiring. OpenTelemetryHook gains
+  redact_value_patterns kwarg; patterns compile once, scan
+  stringified values after the key-based pass.
+  build_agent_from_config now calls
+  build_retriever_from_config and threads the result into
+  Agent(retriever=...). The kwarg + RuntimeContext storage
+  were already wired in feat-021 — only the builder hook
+  was missing.
+- chunk 5 (about-to-commit): docs across three specs
+  (feat-002 §"Implementation status" gets a v0.3 polish
+  subsection, feat-009 §11 flips three deferred items to
+  shipped, feat-021 §11 flips the
+  Agent(retriever=...) deviation), CHANGELOG entry,
+  state files.
+
+Tooling notes:
+
+- `with tracer.start_as_current_span(...):` requires the
+  body of the wrapped loop to be indented one level deeper.
+  For ToT's nested loop structure (depth × parents ×
+  candidates) this would mean cascading indent shifts of
+  ~50 lines; deferred to a v0.3.x patch that does the
+  extract-method refactor properly.
+- `async generator + context manager` don't compose cleanly
+  (`with`-block exit fires before the generator is
+  exhausted on the caller side). For `_stream_call` in the
+  a2a server, we use manual `__enter__()` / `__exit__()`
+  to keep the span open across yields.
+- ruff PT006 (parametrize names must be tuple) fires on
+  the comma-separated string form. Use the tuple form
+  `("field", "bad_value")` instead.
+- ruff RUF012 fires on `class _NoAuth: headers: dict = {}`
+  — mutable default at class level. Move to `__init__`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-002 + feat-009 v0.3 polish + feat-021 follow-up
+  bundle.** Closes the three remaining v0.2 cycle items in
+  one PR:
+  - **feat-002 — ReActLoop.stream() override.** Built-in
+    ReActLoop now emits a `step` StreamingEvent per
+    iteration (think/act/observe). Drops the "out-of-the-
+    box agents only emit a terminal done" gap. Plan-Execute
+    / ToT / MultiAgent overrides deferred to v0.3.x.
+  - **feat-009 v0.3 — child OTel spans.** `strategy.iteration`
+    in ReActLoop + PlanExecute, `llm.call` + `tool.<name>`
+    in StrategyBase (single point per category), and
+    `evaluator.<name>` in `Agent._run_evaluators`. The full
+    span tree now matches feat-009 spec §4.3.
+  - **feat-009 v0.3 — A2A trace propagation.** W3C
+    TraceContext (`traceparent` + `tracestate`) injected on
+    the A2A client and extracted on the A2A server. Multi-
+    agent calls now stitch into one end-to-end trace.
+  - **feat-009 v0.3 — content-based PII redaction.**
+    `OpenTelemetryHook(redact_value_patterns=...)` opt-in
+    regex scan over stringified values. Key-based
+    redaction wins precedence; default `None` is identical
+    to v0.1 behaviour.
+  - **feat-021 — Agent(retriever=...) wiring.**
+    `build_agent_from_config()` now calls
+    `build_retriever_from_config()` and threads the result.
+    YAML `retrieval:` block end-to-end.
+
 - **feat-021 v0.2 follow-up — vendor reranker sister
   packages.** Three managed-API rerankers ship in one
   bundle, all following the

--- a/docs/features/feat-002-reasoning-strategies.md
+++ b/docs/features/feat-002-reasoning-strategies.md
@@ -426,6 +426,26 @@ the resolver from feat-001; e.g. `Agent(strategy="multi-agent")`.
 
 TypeScript port pending.
 
+### v0.3 polish — ReActLoop.stream() override
+
+Shipped on the v0.1 → v0.2 line. ReActLoop now overrides
+`ReasoningStrategy.stream()` (added in feat-020 v0.2) to
+emit a `step` `StreamingEvent` each time
+`state.steps` is appended. Out-of-the-box agents using the
+default strategy now emit per-iteration streaming without
+users having to write a custom strategy.
+
+- `agent.stream(task)` routes through the new override and
+  yields `[step × N, done]` where the canonical `done` is
+  emitted by `Agent.stream` (carries full RunResult shape).
+- Driving `strategy.stream(state)` directly (e.g. unit
+  tests) sees the strategy-level `done` with just
+  `run_id` + `cost_usd`.
+
+Plan-Execute, ToT, and Multi-Agent stream() overrides
+deferred to v0.3.x (case-by-case; each strategy's iteration
+shape is meaningfully different from ReActLoop's).
+
 ---
 
 ## Runbook

--- a/docs/features/feat-009-observability.md
+++ b/docs/features/feat-009-observability.md
@@ -401,12 +401,41 @@ in `src/`).
 
 ### Out-of-scope (deferred to v0.3+)
 
-- Child OTel spans (strategy.iteration, llm.call,
-  tool.<name>, evaluator.<name>).
-- A2A trace propagation via OTel context.
-- Content-based PII redaction (regex over arg values).
+- ~~Child OTel spans (strategy.iteration, llm.call,
+  tool.<name>, evaluator.<name>).~~ **Shipped in the v0.3
+  polish bundle** — see the subsection below.
+- ~~A2A trace propagation via OTel context.~~ **Shipped in
+  the v0.3 polish bundle.**
+- ~~Content-based PII redaction (regex over arg values).~~
+  **Shipped in the v0.3 polish bundle.**
 - Evidently real-time drift dashboards via Cloud.
 - TypeScript port.
+
+### v0.3 polish — child spans + A2A propagation + content redaction
+
+Shipped on the v0.1 → v0.2 line. Closes the three feat-009
+items v0.2 deferred. Bundled with feat-002's ReActLoop.stream
+override and feat-021's retriever-wiring follow-up.
+
+| Chunk | Commit | What landed |
+|---|---|---|
+| 2 | `ebf7af3` | Child OTel spans across the framework. `llm.call` wrapped in `StrategyBase._call_llm` (single point — every strategy inherits). `tool.<name>` wrapped in `StrategyBase._dispatch_tool` (same). `strategy.iteration` spans in ReActLoop (run + stream) and PlanExecuteLoop. `evaluator.<name>` spans in `Agent._run_evaluators`. End-to-end test in `agentforge-otel/tests/unit/test_hook.py` asserts the full span tree (root + strategy.iteration × N + llm.call × M + tool.<name> × P). |
+| 3 | `d8419c1` | W3C TraceContext propagation. Client side injects `traceparent` (+ `tracestate`) via `TraceContextTextMapPropagator().inject()` after the existing run-id / budget headers (no-op when no active span). Server side extracts the same on both `_handle_call` and `_stream_call` and opens an `a2a.call` span with the extracted context as parent — the callee's `agent.run` becomes a child. Tests in `agentforge-a2a/tests/unit/test_trace_propagation.py` cover inject + extract + cross-process trace_id stitching. |
+| 4 | `e347c35` | Content-based PII redaction. `OpenTelemetryHook.__init__` gains optional `redact_value_patterns: tuple[str, ...]` kwarg; patterns compile once, scan stringified value text. Key-based redaction still wins precedence. Default `None` keeps v0.1 behaviour identical. |
+
+### v0.3 polish deviations
+
+- **`strategy.iteration` spans on ToT + MultiAgent deferred**
+  to a v0.3.x patch. Their nested loop structure needs a
+  modest refactor (extract-method to keep indent legible
+  inside the `with tracer.start_as_current_span(...)` block).
+  ReActLoop + PlanExecute are the two most-used strategies
+  and ship with spans now.
+- **`a2a.call` span on the streaming path uses manual
+  `__enter__` / `__exit__`** since `_stream_call` is an async
+  generator (a `with` block doesn't compose cleanly with
+  `yield`). The behaviour matches a context-managed
+  invocation.
 
 ---
 

--- a/docs/features/feat-021-reranker.md
+++ b/docs/features/feat-021-reranker.md
@@ -393,12 +393,15 @@ vendor backend precedent.
 
 ### v0.2 follow-up deviations
 
-- **`Agent.__init__` does NOT gain a `retriever=` kwarg.**
-  `build_retriever_from_config()` returns a sibling
-  construct; callers wire it into their tools or strategy.
-  Reasoning: retrieval is a tool-level concern per ADR-0007
-  — agent-owned retrievers conflate two layers. May
-  reconsider in v0.3 if usage patterns warrant.
+- ~~**`Agent.__init__` does NOT gain a `retriever=` kwarg.**~~
+  **Resolved in the v0.3 polish bundle.** Agent already
+  accepted `retriever=` and stored it on
+  `RuntimeContext.retriever`; the missing piece was
+  `build_agent_from_config()` calling
+  `build_retriever_from_config()` and threading the result.
+  Now config-driven retrieval is wired end-to-end —
+  strategies / tools that ask for `get_runtime(state).retriever`
+  get the YAML-built instance.
 - **Legacy `modules.retriever` block stays valid.** The
   single-entry form is kept for v0.2 backward compat with a
   deprecation notice on the docstring. The new `retrieval:`

--- a/packages/agentforge-a2a/src/agentforge_a2a/client.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/client.py
@@ -286,7 +286,30 @@ def _build_headers(auth: ClientAuth, budget_usd: float | None) -> dict[str, str]
         headers["X-AgentForge-Run-Id"] = ctx.run_id
     if budget_usd is not None:
         headers["X-AgentForge-Budget-Usd"] = f"{budget_usd:.6f}"
+    # feat-009 v0.3 polish: W3C TraceContext propagation. The
+    # propagator is a no-op when no active OTel span is bound,
+    # so this is safe to call unconditionally.
+    _trace_propagator().inject(headers)
     return headers
+
+
+def _trace_propagator() -> Any:
+    """Lazily import OTel's W3C TraceContext propagator.
+
+    Cached at module level via ``_PROPAGATOR_CACHE`` so the import
+    only runs once. OpenTelemetry is a required dependency of
+    `agentforge-core`, so this import is always safe.
+    """
+    if _PROPAGATOR_CACHE[0] is None:
+        from opentelemetry.trace.propagation.tracecontext import (  # noqa: PLC0415
+            TraceContextTextMapPropagator,
+        )
+
+        _PROPAGATOR_CACHE[0] = TraceContextTextMapPropagator()
+    return _PROPAGATOR_CACHE[0]
+
+
+_PROPAGATOR_CACHE: list[Any] = [None]
 
 
 def _raise_for_error_body(peer_name: str, raw: dict[str, Any]) -> None:

--- a/packages/agentforge-a2a/src/agentforge_a2a/server.py
+++ b/packages/agentforge-a2a/src/agentforge_a2a/server.py
@@ -50,10 +50,14 @@ import uvicorn
 from agentforge.agent import Agent
 from agentforge.recording import _finding_payload
 from agentforge_core.contracts.auth import AuthPolicy
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.production.budget import BudgetPolicy
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from opentelemetry.trace.propagation.tracecontext import (
+    TraceContextTextMapPropagator,
+)
 from pydantic import BaseModel, ConfigDict
 
 from agentforge_a2a._runner import A2AServerRunner
@@ -189,7 +193,22 @@ class A2AServer:
                 detail=f"unknown endpoint: {body.endpoint!r}",
             )
         parent_run_id = request.headers.get("X-AgentForge-Run-Id")
-        result = await self._run_with_budget_cap(body, request)
+        # feat-009 v0.3 polish: W3C TraceContext propagation. Extract
+        # the caller's span context from `traceparent` (no-op when
+        # missing) and use it as the parent for the inner work so the
+        # `a2a.call` span — and its child `agent.run` — stitches into
+        # the caller's trace.
+        extracted_ctx = TraceContextTextMapPropagator().extract(dict(request.headers))
+        tracer = get_tracer()
+        with tracer.start_as_current_span(
+            "a2a.call",
+            context=extracted_ctx,
+            attributes={
+                "agentforge.a2a.endpoint": body.endpoint,
+                "agentforge.a2a.parent_run_id": parent_run_id or "",
+            },
+        ):
+            result = await self._run_with_budget_cap(body, request)
         response = A2AResponse(
             output=result.output,
             findings=tuple(_finding_payload(f) for f in getattr(result, "findings", ())),
@@ -224,6 +243,19 @@ class A2AServer:
             )
             return
 
+        # feat-009 v0.3 polish: W3C TraceContext propagation.
+        extracted_ctx = TraceContextTextMapPropagator().extract(dict(request.headers))
+        tracer = get_tracer()
+        a2a_span_cm = tracer.start_as_current_span(
+            "a2a.call",
+            context=extracted_ctx,
+            attributes={
+                "agentforge.a2a.endpoint": body.endpoint,
+                "agentforge.a2a.parent_run_id": parent_run_id or "",
+                "agentforge.a2a.streaming": True,
+            },
+        )
+
         task_str = self._task_builder(body.endpoint, body.payload)
         budget_cap = self._read_budget_header(request)
         original_budget = self._agent._budget
@@ -236,6 +268,7 @@ class A2AServer:
             )
 
         done_content: dict[str, Any] | None = None
+        a2a_span_cm.__enter__()
         try:
             async for event in self._agent.stream(task_str):
                 if event.kind == "done":
@@ -269,6 +302,7 @@ class A2AServer:
         finally:
             if budget_cap is not None:
                 self._agent._budget = original_budget
+            a2a_span_cm.__exit__(None, None, None)
 
         final = done_content or {"output": None, "cost_usd": 0.0, "run_id": ""}
         yield _sse_frame(

--- a/packages/agentforge-a2a/tests/unit/test_trace_propagation.py
+++ b/packages/agentforge-a2a/tests/unit/test_trace_propagation.py
@@ -1,0 +1,143 @@
+"""Unit tests for A2A W3C TraceContext propagation (feat-009 v0.3 polish).
+
+Covers the client-side injection (`traceparent` header derived from
+the active span) and the server-side extraction (the `a2a.call`
+span stitches into the caller's trace).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from agentforge import EnvBearerAuth
+from agentforge.agent import Agent
+from agentforge_a2a import A2AServer
+from agentforge_a2a.client import _build_headers
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.messages import (
+    LLMResponse,
+    Message,
+    TokenUsage,
+    ToolSpec,
+)
+from agentforge_core.values.state import AgentState
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider() -> None:
+    """Reset OTel's process-global provider so each test starts fresh."""
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+
+
+def _install_inmemory_provider() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+class _NoAuth:
+    """ClientAuth duck-type for `_build_headers` (no Bearer header)."""
+
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+def test_build_headers_injects_traceparent_when_span_active() -> None:
+    _install_inmemory_provider()
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("caller"):
+        headers = _build_headers(_NoAuth(), budget_usd=None)  # type: ignore[arg-type]
+    assert "traceparent" in headers
+    # W3C traceparent format: `00-<trace_id>-<span_id>-<flags>`
+    parts = headers["traceparent"].split("-")
+    assert len(parts) == 4
+    assert parts[0] == "00"
+
+
+def test_build_headers_omits_traceparent_when_no_span() -> None:
+    _install_inmemory_provider()
+    headers = _build_headers(_NoAuth(), budget_usd=None)  # type: ignore[arg-type]
+    # No active span → propagator emits nothing.
+    assert "traceparent" not in headers
+
+
+class _NoopStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        return state
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="x",
+            provider="x",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def test_server_stitches_into_callers_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    exporter = _install_inmemory_provider()
+    monkeypatch.setenv("A2A_TOKENS", "ok")
+    agent = Agent(model=_FakeLLM(), strategy=_NoopStrategy())
+    server = A2AServer(
+        agent=agent,
+        auth=EnvBearerAuth("A2A_TOKENS"),
+        endpoints=["echo"],
+    )
+
+    # Caller-side trace: open a span, build a traceparent, fire the request.
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("caller-span") as caller_span:
+        caller_trace_id = caller_span.get_span_context().trace_id
+        headers = _build_headers(_NoAuth(), budget_usd=None)  # type: ignore[arg-type]
+
+    headers["Authorization"] = "Bearer ok"
+
+    with TestClient(server.app) as http:
+        r = http.post(
+            "/a2a/v1/calls",
+            json={"endpoint": "echo", "payload": {}},
+            headers=headers,
+        )
+    assert r.status_code == 200
+
+    finished = exporter.get_finished_spans()
+    a2a_spans = [s for s in finished if s.name == "a2a.call"]
+    assert len(a2a_spans) == 1
+    # The server-side a2a.call span shares the caller's trace_id.
+    assert a2a_spans[0].context.trace_id == caller_trace_id
+
+
+def _silence(logger_name: str) -> None:
+    logging.getLogger(logger_name).setLevel(logging.CRITICAL)
+
+
+def _suppress_a2a_logs() -> Any:
+    _silence("agentforge_a2a.server")
+    _silence("agentforge.observability")
+    return None

--- a/packages/agentforge-otel/src/agentforge_otel/hook.py
+++ b/packages/agentforge-otel/src/agentforge_otel/hook.py
@@ -21,6 +21,7 @@ call args as span attributes.
 from __future__ import annotations
 
 import logging
+import re
 import threading
 from typing import Any
 
@@ -65,6 +66,7 @@ class OpenTelemetryHook:
         service_name: str = "agentforge",
         sample_rate: float = 1.0,
         redact_fields: tuple[str, ...] | None = None,
+        redact_value_patterns: tuple[str, ...] | None = None,
     ) -> None:
         if not 0.0 <= sample_rate <= 1.0:
             raise ValueError(f"sample_rate must be in [0, 1]; got {sample_rate}")
@@ -76,6 +78,15 @@ class OpenTelemetryHook:
         self._sample_rate = sample_rate
         self._redact_fields = tuple(
             f.lower() for f in (redact_fields if redact_fields is not None else _DEFAULT_REDACT)
+        )
+        # feat-009 v0.3 polish: content-based PII redaction. Patterns
+        # are compiled once at construction so per-step redaction
+        # stays cheap. Default None — content-based redaction is
+        # opt-in.
+        self._redact_value_patterns: tuple[re.Pattern[str], ...] = (
+            tuple(re.compile(p) for p in redact_value_patterns)
+            if redact_value_patterns is not None
+            else ()
         )
         _ensure_provider(
             service_name=service_name,
@@ -90,6 +101,10 @@ class OpenTelemetryHook:
     @property
     def redact_fields(self) -> tuple[str, ...]:
         return self._redact_fields
+
+    @property
+    def redact_value_patterns(self) -> tuple[re.Pattern[str], ...]:
+        return self._redact_value_patterns
 
     def __call__(self, payload: Step | RunResult) -> None:
         """Hook entry point — dispatches on payload type."""
@@ -147,18 +162,41 @@ class OpenTelemetryHook:
     # ------------------------------------------------------------------
 
     def _redact(self, args: dict[str, Any]) -> str:
-        """Stringify a dict for span attribution, masking sensitive keys.
+        """Stringify a dict for span attribution, masking sensitive
+        keys *and* values matching configured regex patterns.
+
+        Two redaction passes:
+        1. Key-based: case-insensitive substring match on the field
+           name against `redact_fields` (e.g. ``api_key``,
+           ``password``). The whole value gets masked.
+        2. Content-based (feat-009 v0.3 polish): for string values
+           that survived the key check, run each pattern in
+           `redact_value_patterns` against the stringified value;
+           any match masks the whole value.
 
         Span attributes accept primitives + lists thereof; we render
-        the dict to a compact `k=v` form rather than fight the schema.
+        the dict to a compact ``k=v`` form rather than fight the
+        schema.
         """
         parts: list[str] = []
         for key, value in args.items():
             if any(token in key.lower() for token in self._redact_fields):
                 parts.append(f"{key}=<redacted>")
-            else:
-                parts.append(f"{key}={value!r}")
+                continue
+            if self._value_matches_pattern(value):
+                parts.append(f"{key}=<redacted>")
+                continue
+            parts.append(f"{key}={value!r}")
         return ", ".join(parts)
+
+    def _value_matches_pattern(self, value: Any) -> bool:
+        """True if any configured regex pattern matches the value
+        text. Non-string values are stringified first so payloads
+        like ``42``, ``True``, or nested dicts are still scanned."""
+        if not self._redact_value_patterns:
+            return False
+        text = value if isinstance(value, str) else str(value)
+        return any(p.search(text) for p in self._redact_value_patterns)
 
 
 def _ensure_provider(

--- a/packages/agentforge-otel/tests/unit/test_hook.py
+++ b/packages/agentforge-otel/tests/unit/test_hook.py
@@ -312,3 +312,57 @@ async def test_child_span_tree_via_react_loop():
     llm_attrs = dict(by_name["llm.call"][0].attributes or {})
     assert llm_attrs["agentforge.llm.provider"] == "fake"
     assert llm_attrs["agentforge.llm.tokens_in"] == 5
+
+
+# --- content-based PII redaction (feat-009 v0.3 polish) --------
+
+
+def test_redact_value_patterns_masks_matching_values() -> None:
+    """Values matching any regex in `redact_value_patterns` get
+    replaced wholesale — even when the key isn't in
+    `redact_fields`."""
+    h = OpenTelemetryHook(
+        service_name="test",
+        endpoint="http://localhost:4317",
+        redact_value_patterns=(
+            r"\b\d{3}-\d{2}-\d{4}\b",  # US SSN
+            r"\b\d{16}\b",  # Credit-card-like 16-digit run
+            r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",  # email
+        ),
+    )
+    rendered = h._redact(
+        {
+            "ssn": "123-45-6789",
+            "card": "4111111111111111",
+            "email": "alice@example.com",
+            "innocent": "hello world",
+            "count": 7,
+        }
+    )
+    assert "ssn=<redacted>" in rendered
+    assert "card=<redacted>" in rendered
+    assert "email=<redacted>" in rendered
+    # Plain integers + harmless strings pass through.
+    assert "innocent='hello world'" in rendered
+    assert "count=7" in rendered
+
+
+def test_redact_value_patterns_default_none_is_passthrough() -> None:
+    """Without `redact_value_patterns`, behaviour is identical to
+    v0.1 (key-only redaction)."""
+    h = OpenTelemetryHook(service_name="test", endpoint="http://localhost:4317")
+    assert h.redact_value_patterns == ()
+    rendered = h._redact({"email": "alice@example.com", "api_key": "shh"})
+    assert "email='alice@example.com'" in rendered
+    assert "api_key=<redacted>" in rendered
+
+
+def test_redact_key_match_takes_precedence_over_value_match() -> None:
+    h = OpenTelemetryHook(
+        service_name="test",
+        endpoint="http://localhost:4317",
+        redact_value_patterns=(r"unused-pattern",),
+    )
+    rendered = h._redact({"api_key": "abc"})
+    # Key matches first; we never even check the value patterns.
+    assert "api_key=<redacted>" in rendered

--- a/packages/agentforge-otel/tests/unit/test_hook.py
+++ b/packages/agentforge-otel/tests/unit/test_hook.py
@@ -231,3 +231,84 @@ async def test_end_to_end_root_span_from_agent_run():
     # The step hook annotated the span with an event.
     step_events = [e for e in run_spans[0].events if e.name == "agent.step"]
     assert len(step_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_child_span_tree_via_react_loop():
+    """Drive an Agent with the built-in ReActLoop strategy and a
+    scripted FakeLLM that triggers one tool_call. Assert the full
+    OTel span tree lands:
+      agent.run
+        ├── strategy.iteration (iter 0)
+        │   ├── llm.call
+        │   └── tool.<name>
+        └── strategy.iteration (iter 1)
+            └── llm.call
+    """
+    from agentforge._testing import FakeLLMClient  # noqa: PLC0415
+    from agentforge.strategies.react import ReActLoop  # noqa: PLC0415
+    from agentforge_core.contracts.tool import Tool  # noqa: PLC0415
+    from agentforge_core.values.messages import LLMResponse, TokenUsage  # noqa: PLC0415
+    from pydantic import BaseModel  # noqa: PLC0415
+
+    exporter = _install_inmemory_provider()
+
+    class _SearchArgs(BaseModel):
+        query: str
+
+    class _SearchTool(Tool):
+        name = "search"
+        description = "echoes the query"
+        input_schema = _SearchArgs
+
+        async def run(self, query: str) -> str:
+            return f"got {query!r}"
+
+    fake = FakeLLMClient(
+        responses=[
+            LLMResponse(
+                content="I'll search.",
+                stop_reason="tool_use",
+                tool_calls=(ToolCall(id="t-1", name="search", arguments={"query": "x"}),),
+                usage=TokenUsage(input_tokens=5, output_tokens=3),
+                cost_usd=0.0,
+                model="fake",
+                provider="fake",
+            ),
+            LLMResponse(
+                content="done",
+                stop_reason="end_turn",
+                usage=TokenUsage(input_tokens=4, output_tokens=2),
+                cost_usd=0.0,
+                model="fake",
+                provider="fake",
+            ),
+        ],
+    )
+    otel = OpenTelemetryHook(service_name="test", endpoint="http://localhost:4317")
+    async with Agent(
+        model=fake,
+        tools=[_SearchTool()],
+        strategy=ReActLoop(),
+        on_step=otel,
+        on_finish=otel,
+    ) as agent:
+        await agent.run("find x")
+
+    finished = exporter.get_finished_spans()
+    by_name: dict[str, list] = {}
+    for s in finished:
+        by_name.setdefault(s.name, []).append(s)
+
+    # Root span
+    assert len(by_name["agent.run"]) == 1
+    # Two iterations: one with the tool_call, one terminating
+    assert len(by_name["strategy.iteration"]) == 2
+    # Two LLM calls (one per iteration)
+    assert len(by_name["llm.call"]) == 2
+    # One tool execution
+    assert len(by_name["tool.search"]) == 1
+    # llm.call spans carry provider + token attributes
+    llm_attrs = dict(by_name["llm.call"][0].attributes or {})
+    assert llm_attrs["agentforge.llm.provider"] == "fake"
+    assert llm_attrs["agentforge.llm.tokens_in"] == 5

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -645,7 +645,25 @@ class Agent:
                     remaining,
                 )
                 continue
-            eval_result = await evaluator.evaluate(result, context)
+            tracer = get_tracer()
+            started_ms = time.monotonic()
+            with tracer.start_as_current_span(
+                f"evaluator.{evaluator.name}",
+                attributes={
+                    "agentforge.evaluator.name": evaluator.name,
+                    "agentforge.evaluator.cost_estimate_usd": est,
+                },
+            ) as ev_span:
+                eval_result = await evaluator.evaluate(result, context)
+                ev_span.set_attribute("agentforge.evaluator.score", float(eval_result.score))
+                ev_span.set_attribute(
+                    "agentforge.evaluator.cost_usd",
+                    float(getattr(eval_result, "cost_usd", 0.0)),
+                )
+                ev_span.set_attribute(
+                    "agentforge.evaluator.duration_ms",
+                    int((time.monotonic() - started_ms) * 1000),
+                )
             out.append(eval_result)
         return tuple(out)
 

--- a/packages/agentforge/src/agentforge/cli/_build.py
+++ b/packages/agentforge/src/agentforge/cli/_build.py
@@ -76,6 +76,7 @@ async def build_agent_from_config(
         await _maybe_init_schema(memory)
     evaluators = build_evaluators_from_config(config)
     pipeline = build_pipeline_from_config(config)
+    retriever = build_retriever_from_config(config)
     llm = _resolve_llm(config)
     strategy = config.agent.strategy if isinstance(config.agent.strategy, str) else None
 
@@ -84,6 +85,7 @@ async def build_agent_from_config(
         memory=memory if memory is not None else InMemoryStore(),
         evaluators=evaluators,
         strategy=strategy,
+        retriever=retriever,
         system_prompt=config.agent.system_prompt,
         budget_usd=config.agent.budget.usd,
         max_iterations=config.agent.max_iterations,

--- a/packages/agentforge/src/agentforge/strategies/_base.py
+++ b/packages/agentforge/src/agentforge/strategies/_base.py
@@ -35,6 +35,7 @@ from typing import Any
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.contracts.tool import Tool
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.values.messages import LLMResponse, Message, ToolSpec
 from agentforge_core.values.state import AgentState, Step, StepKind
 from pydantic import ValidationError
@@ -150,8 +151,25 @@ class StrategyBase(ReasoningStrategy):
         runtime = get_runtime(state)
         llm: LLMClient = runtime.llm
 
+        tracer = get_tracer()
         started_ms = time.monotonic()
-        response = await llm.call(system=system, messages=messages, tools=tools)
+        with tracer.start_as_current_span(
+            "llm.call",
+            attributes={
+                "agentforge.iteration": iteration,
+                "agentforge.llm.has_tools": tools is not None and len(tools) > 0,
+            },
+        ) as llm_span:
+            response = await llm.call(system=system, messages=messages, tools=tools)
+            llm_span.set_attribute("agentforge.llm.provider", response.provider)
+            llm_span.set_attribute("agentforge.llm.model", response.model)
+            llm_span.set_attribute("agentforge.llm.tokens_in", response.usage.input_tokens)
+            llm_span.set_attribute("agentforge.llm.tokens_out", response.usage.output_tokens)
+            llm_span.set_attribute("agentforge.llm.cost_usd", float(response.cost_usd))
+            llm_span.set_attribute(
+                "agentforge.llm.stop_reason",
+                str(response.stop_reason),
+            )
         duration_ms = int((time.monotonic() - started_ms) * 1000)
 
         # Record cost on the shared BudgetPolicy.
@@ -215,13 +233,30 @@ class StrategyBase(ReasoningStrategy):
         except ValidationError as exc:
             return f"Error: invalid arguments for {tool_name!r}: {exc}"
         kwargs = validated.model_dump()
-        try:
-            if timeout_s is None:
-                raw = await tool.run(**kwargs)
-            else:
-                raw = await asyncio.wait_for(tool.run(**kwargs), timeout=timeout_s)
-        except TimeoutError:
-            return f"Error: tool {tool_name!r} exceeded timeout_s={timeout_s}."
-        except Exception as exc:
-            return f"Error: {type(exc).__name__}: {exc}"
+
+        tracer = get_tracer()
+        started_ms = time.monotonic()
+        with tracer.start_as_current_span(
+            f"tool.{tool_name}",
+            attributes={
+                "agentforge.tool.name": tool_name,
+                "agentforge.tool.timeout_s": (float(timeout_s) if timeout_s is not None else -1.0),
+            },
+        ) as tool_span:
+            try:
+                if timeout_s is None:
+                    raw = await tool.run(**kwargs)
+                else:
+                    raw = await asyncio.wait_for(tool.run(**kwargs), timeout=timeout_s)
+            except TimeoutError:
+                tool_span.set_attribute("agentforge.tool.error", "TimeoutError")
+                return f"Error: tool {tool_name!r} exceeded timeout_s={timeout_s}."
+            except Exception as exc:
+                tool_span.set_attribute("agentforge.tool.error", type(exc).__name__)
+                return f"Error: {type(exc).__name__}: {exc}"
+            finally:
+                tool_span.set_attribute(
+                    "agentforge.tool.duration_ms",
+                    int((time.monotonic() - started_ms) * 1000),
+                )
         return raw if isinstance(raw, str) else str(raw)

--- a/packages/agentforge/src/agentforge/strategies/plan_execute.py
+++ b/packages/agentforge/src/agentforge/strategies/plan_execute.py
@@ -30,6 +30,7 @@ import time
 from typing import Any
 
 from agentforge_core.contracts.tool import Tool
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
 from pydantic import ValidationError
@@ -102,48 +103,56 @@ class PlanExecuteLoop(StrategyBase):
         get_runtime(state)
         replans = 0
         plan_messages: list[Message] = [Message(role="user", content=state.task)]
+        tracer = get_tracer()
 
         while True:
-            # PHASE 1 — Plan (with retry on parse / validation failure)
-            plan = await self._build_plan(state, plan_messages, replans_done=replans)
-            self._record_step(
-                state,
-                iteration=0,
-                kind="plan",
-                content={"steps": [step.model_dump() for step in plan.steps]},
-            )
-
-            # PHASE 2 — Execute
-            try:
-                observations = await self._execute_plan(state, plan)
-                break
-            except _StepFailure as failure:
-                if not self._replan_on_failure or replans >= self._max_replans:
-                    # Surface the failure as a final observation; don't crash.
-                    observations = failure.observations_so_far
-                    self._record_step(
-                        state,
-                        iteration=len(plan.steps),
-                        kind="observe",
-                        content=(
-                            f"Plan execution failed at step {failure.failed_step.id!r}: "
-                            f"{failure.error}. No further re-plan attempts."
-                        ),
-                    )
-                    break
-                replans += 1
-                # Feed the failure context back so the LLM can revise the plan.
-                plan_messages.append(Message(role="assistant", content=plan.model_dump_json()))
-                plan_messages.append(
-                    Message(
-                        role="user",
-                        content=(
-                            f"The plan failed at step {failure.failed_step.id!r} "
-                            f"({failure.failed_step.description!r}): {failure.error}. "
-                            f"Please re-plan."
-                        ),
-                    )
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": replans,
+                    "agentforge.strategy": "plan_execute",
+                },
+            ):
+                # PHASE 1 — Plan (with retry on parse / validation failure)
+                plan = await self._build_plan(state, plan_messages, replans_done=replans)
+                self._record_step(
+                    state,
+                    iteration=0,
+                    kind="plan",
+                    content={"steps": [step.model_dump() for step in plan.steps]},
                 )
+
+                # PHASE 2 — Execute
+                try:
+                    observations = await self._execute_plan(state, plan)
+                    break
+                except _StepFailure as failure:
+                    if not self._replan_on_failure or replans >= self._max_replans:
+                        # Surface the failure as a final observation; don't crash.
+                        observations = failure.observations_so_far
+                        self._record_step(
+                            state,
+                            iteration=len(plan.steps),
+                            kind="observe",
+                            content=(
+                                f"Plan execution failed at step {failure.failed_step.id!r}: "
+                                f"{failure.error}. No further re-plan attempts."
+                            ),
+                        )
+                        break
+                    replans += 1
+                    # Feed the failure context back so the LLM can revise the plan.
+                    plan_messages.append(Message(role="assistant", content=plan.model_dump_json()))
+                    plan_messages.append(
+                        Message(
+                            role="user",
+                            content=(
+                                f"The plan failed at step {failure.failed_step.id!r} "
+                                f"({failure.failed_step.description!r}): {failure.error}. "
+                                f"Please re-plan."
+                            ),
+                        )
+                    )
 
         # PHASE 3 — Synthesize
         synth_messages: list[Message] = [

--- a/packages/agentforge/src/agentforge/strategies/react.py
+++ b/packages/agentforge/src/agentforge/strategies/react.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 
 from agentforge_core.contracts.tool import Tool
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState, Step
@@ -56,64 +57,72 @@ class ReActLoop(StrategyBase):
         tool_specs = [tool.to_spec() for tool in runtime.tools] if runtime.tools else None
         messages: list[Message] = [Message(role="user", content=state.task)]
         iteration = 0
+        tracer = get_tracer()
 
         while True:
-            self._check_guardrails(state)
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": iteration,
+                    "agentforge.strategy": "react",
+                },
+            ):
+                self._check_guardrails(state)
 
-            response = await self._call_llm(
-                state,
-                iteration=iteration,
-                system=system_prompt,
-                messages=messages,
-                tools=tool_specs,
-                kind="think",
-            )
-
-            # Modern termination: no tool calls means the LLM is done.
-            if not response.tool_calls:
-                break
-
-            # Record the assistant's turn for the next iteration's context.
-            messages.append(Message(role="assistant", content=response.content))
-
-            # Dispatch every tool call the LLM emitted.
-            for tool_call in response.tool_calls:
-                self._record_step(
+                response = await self._call_llm(
                     state,
                     iteration=iteration,
-                    kind="act",
-                    content={
-                        "tool": tool_call.name,
-                        "arguments": tool_call.arguments,
-                    },
-                    tool_call=tool_call,
+                    system=system_prompt,
+                    messages=messages,
+                    tools=tool_specs,
+                    kind="think",
                 )
 
-                tool = _find_tool(runtime.tools, tool_call.name)
-                observation = await self._dispatch_tool(
-                    tool, tool_call.name, dict(tool_call.arguments)
-                )
-                if observation.startswith("Error:"):
-                    runtime.budget.record_error()
-                else:
-                    runtime.budget.record_success()
+                # Modern termination: no tool calls means the LLM is done.
+                if not response.tool_calls:
+                    break
 
-                self._record_step(
-                    state,
-                    iteration=iteration,
-                    kind="observe",
-                    content=observation,
-                    tool_call=tool_call,
-                )
-                messages.append(
-                    Message(
-                        role="tool",
-                        content=observation,
-                        tool_call_id=tool_call.id,
+                # Record the assistant's turn for the next iteration's context.
+                messages.append(Message(role="assistant", content=response.content))
+
+                # Dispatch every tool call the LLM emitted.
+                for tool_call in response.tool_calls:
+                    self._record_step(
+                        state,
+                        iteration=iteration,
+                        kind="act",
+                        content={
+                            "tool": tool_call.name,
+                            "arguments": tool_call.arguments,
+                        },
+                        tool_call=tool_call,
                     )
-                )
 
-            iteration += 1
+                    tool = _find_tool(runtime.tools, tool_call.name)
+                    observation = await self._dispatch_tool(
+                        tool, tool_call.name, dict(tool_call.arguments)
+                    )
+                    if observation.startswith("Error:"):
+                        runtime.budget.record_error()
+                    else:
+                        runtime.budget.record_success()
+
+                    self._record_step(
+                        state,
+                        iteration=iteration,
+                        kind="observe",
+                        content=observation,
+                        tool_call=tool_call,
+                    )
+                    messages.append(
+                        Message(
+                            role="tool",
+                            content=observation,
+                            tool_call_id=tool_call.id,
+                        )
+                    )
+
+                iteration += 1
 
         return state
 
@@ -138,71 +147,79 @@ class ReActLoop(StrategyBase):
         messages: list[Message] = [Message(role="user", content=state.task)]
         iteration = 0
         before = len(state.steps)
+        tracer = get_tracer()
 
         while True:
-            self._check_guardrails(state)
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": iteration,
+                    "agentforge.strategy": "react",
+                },
+            ):
+                self._check_guardrails(state)
 
-            response = await self._call_llm(
-                state,
-                iteration=iteration,
-                system=system_prompt,
-                messages=messages,
-                tools=tool_specs,
-                kind="think",
-            )
-            for ev in _events_for_new_steps(state.steps, before):
-                yield ev
-            before = len(state.steps)
-
-            if not response.tool_calls:
-                break
-
-            messages.append(Message(role="assistant", content=response.content))
-
-            for tool_call in response.tool_calls:
-                self._record_step(
+                response = await self._call_llm(
                     state,
                     iteration=iteration,
-                    kind="act",
-                    content={
-                        "tool": tool_call.name,
-                        "arguments": tool_call.arguments,
-                    },
-                    tool_call=tool_call,
+                    system=system_prompt,
+                    messages=messages,
+                    tools=tool_specs,
+                    kind="think",
                 )
                 for ev in _events_for_new_steps(state.steps, before):
                     yield ev
                 before = len(state.steps)
 
-                tool = _find_tool(runtime.tools, tool_call.name)
-                observation = await self._dispatch_tool(
-                    tool, tool_call.name, dict(tool_call.arguments)
-                )
-                if observation.startswith("Error:"):
-                    runtime.budget.record_error()
-                else:
-                    runtime.budget.record_success()
+                if not response.tool_calls:
+                    break
 
-                self._record_step(
-                    state,
-                    iteration=iteration,
-                    kind="observe",
-                    content=observation,
-                    tool_call=tool_call,
-                )
-                for ev in _events_for_new_steps(state.steps, before):
-                    yield ev
-                before = len(state.steps)
+                messages.append(Message(role="assistant", content=response.content))
 
-                messages.append(
-                    Message(
-                        role="tool",
-                        content=observation,
-                        tool_call_id=tool_call.id,
+                for tool_call in response.tool_calls:
+                    self._record_step(
+                        state,
+                        iteration=iteration,
+                        kind="act",
+                        content={
+                            "tool": tool_call.name,
+                            "arguments": tool_call.arguments,
+                        },
+                        tool_call=tool_call,
                     )
-                )
+                    for ev in _events_for_new_steps(state.steps, before):
+                        yield ev
+                    before = len(state.steps)
 
-            iteration += 1
+                    tool = _find_tool(runtime.tools, tool_call.name)
+                    observation = await self._dispatch_tool(
+                        tool, tool_call.name, dict(tool_call.arguments)
+                    )
+                    if observation.startswith("Error:"):
+                        runtime.budget.record_error()
+                    else:
+                        runtime.budget.record_success()
+
+                    self._record_step(
+                        state,
+                        iteration=iteration,
+                        kind="observe",
+                        content=observation,
+                        tool_call=tool_call,
+                    )
+                    for ev in _events_for_new_steps(state.steps, before):
+                        yield ev
+                    before = len(state.steps)
+
+                    messages.append(
+                        Message(
+                            role="tool",
+                            content=observation,
+                            tool_call_id=tool_call.id,
+                        )
+                    )
+
+                iteration += 1
 
         yield StreamingEvent(
             kind="done",

--- a/packages/agentforge/src/agentforge/strategies/react.py
+++ b/packages/agentforge/src/agentforge/strategies/react.py
@@ -14,9 +14,12 @@ observations (counted toward `error_streak_limit`).
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+
 from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
-from agentforge_core.values.state import AgentState
+from agentforge_core.values.state import AgentState, Step
 
 from agentforge.resolver_register import register_strategy
 from agentforge.strategies._base import StrategyBase, get_runtime
@@ -113,6 +116,118 @@ class ReActLoop(StrategyBase):
             iteration += 1
 
         return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        """Per-iteration streaming override (feat-002 v0.3 polish).
+
+        Mirrors :meth:`run` but yields a ``step`` `StreamingEvent`
+        each time a step is appended to ``state.steps``. The terminal
+        ``done`` event is yielded so ``Agent.stream`` can swallow it
+        and emit its own canonical one carrying the full RunResult
+        shape.
+
+        Strategies that bypass `Agent.stream()` (e.g. unit tests) see
+        the strategy-level done with ``run_id`` + ``cost_usd``.
+        """
+        runtime = get_runtime(state)
+        if self._max_iterations_override is not None:
+            runtime.budget.max_iterations = self._max_iterations_override
+
+        system_prompt = runtime.system_prompt or DEFAULT_SYSTEM_PROMPT
+        tool_specs = [tool.to_spec() for tool in runtime.tools] if runtime.tools else None
+        messages: list[Message] = [Message(role="user", content=state.task)]
+        iteration = 0
+        before = len(state.steps)
+
+        while True:
+            self._check_guardrails(state)
+
+            response = await self._call_llm(
+                state,
+                iteration=iteration,
+                system=system_prompt,
+                messages=messages,
+                tools=tool_specs,
+                kind="think",
+            )
+            for ev in _events_for_new_steps(state.steps, before):
+                yield ev
+            before = len(state.steps)
+
+            if not response.tool_calls:
+                break
+
+            messages.append(Message(role="assistant", content=response.content))
+
+            for tool_call in response.tool_calls:
+                self._record_step(
+                    state,
+                    iteration=iteration,
+                    kind="act",
+                    content={
+                        "tool": tool_call.name,
+                        "arguments": tool_call.arguments,
+                    },
+                    tool_call=tool_call,
+                )
+                for ev in _events_for_new_steps(state.steps, before):
+                    yield ev
+                before = len(state.steps)
+
+                tool = _find_tool(runtime.tools, tool_call.name)
+                observation = await self._dispatch_tool(
+                    tool, tool_call.name, dict(tool_call.arguments)
+                )
+                if observation.startswith("Error:"):
+                    runtime.budget.record_error()
+                else:
+                    runtime.budget.record_success()
+
+                self._record_step(
+                    state,
+                    iteration=iteration,
+                    kind="observe",
+                    content=observation,
+                    tool_call=tool_call,
+                )
+                for ev in _events_for_new_steps(state.steps, before):
+                    yield ev
+                before = len(state.steps)
+
+                messages.append(
+                    Message(
+                        role="tool",
+                        content=observation,
+                        tool_call_id=tool_call.id,
+                    )
+                )
+
+            iteration += 1
+
+        yield StreamingEvent(
+            kind="done",
+            content={
+                "run_id": state.run_id,
+                "cost_usd": float(runtime.budget.spent_usd),
+            },
+        )
+
+
+def _events_for_new_steps(steps: list[Step], before: int) -> list[StreamingEvent]:
+    """Build ``step`` `StreamingEvent`s for every step appended since
+    the ``before`` index. Keeps the streaming-side rendering of state
+    deltas separate from the strategy's recording semantics."""
+    return [
+        StreamingEvent(
+            kind="step",
+            content=step.content,
+            metadata={
+                "iteration": step.iteration,
+                "kind": step.kind,
+            },
+        )
+        for step in steps[before:]
+    ]
 
 
 def _find_tool(tools: tuple[Tool, ...], name: str) -> Tool | None:

--- a/packages/agentforge/tests/unit/test_react_stream.py
+++ b/packages/agentforge/tests/unit/test_react_stream.py
@@ -1,0 +1,128 @@
+"""Unit tests for `ReActLoop.stream()` (feat-002 v0.3 polish).
+
+Exercises the per-iteration streaming override:
+
+- LLM emits one tool_call → strategy emits think/act/observe step
+  events, plus another think on the next iteration when the LLM
+  terminates → terminal `done` event from the strategy.
+- `Agent.stream(task)` routes through the strategy's `stream()` and
+  swallows its terminal done, emitting the canonical RunResult done.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent
+from agentforge._testing import FakeLLMClient
+from agentforge.strategies.react import ReActLoop
+from agentforge_core.contracts.tool import Tool
+from agentforge_core.values.messages import (
+    LLMResponse,
+    TokenUsage,
+    ToolCall,
+)
+from pydantic import BaseModel
+
+
+class _SearchArgs(BaseModel):
+    query: str
+
+
+class _FakeSearchTool(Tool):
+    name = "search"
+    description = "echoes the query back"
+    input_schema = _SearchArgs
+
+    async def run(self, query: str) -> str:
+        return f"results for {query!r}"
+
+
+def _llm_response(
+    *,
+    content: str,
+    stop_reason: str = "end_turn",
+    tool_calls: tuple[ToolCall, ...] = (),
+    cost: float = 0.0,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        tool_calls=tool_calls,
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_per_step_then_canonical_done() -> None:
+    """Two-iteration ReAct: think → act → observe (iter 0) → think (iter 1, terminates).
+
+    Expected stream from Agent.stream(task): five `step` events plus
+    the canonical `done` event emitted by Agent.stream itself.
+    """
+    fake = FakeLLMClient(
+        responses=[
+            _llm_response(
+                content="I'll search.",
+                stop_reason="tool_use",
+                tool_calls=(ToolCall(id="t-1", name="search", arguments={"query": "x"}),),
+            ),
+            _llm_response(content="found it", stop_reason="end_turn"),
+        ],
+    )
+    agent = Agent(model=fake, tools=[_FakeSearchTool()], strategy=ReActLoop())
+
+    events = [event async for event in agent.stream("find x")]
+    kinds = [e.kind for e in events]
+
+    # 3 steps on iter-0 (think + act + observe) + 1 step on iter-1 (think) + done.
+    assert kinds == ["step", "step", "step", "step", "done"]
+
+    # Every step event carries iteration + kind metadata.
+    step_events = [e for e in events if e.kind == "step"]
+    iterations = [e.metadata["iteration"] for e in step_events]
+    step_kinds = [e.metadata["kind"] for e in step_events]
+    assert iterations == [0, 0, 0, 1]
+    assert step_kinds == ["think", "act", "observe", "think"]
+
+    # The final done is the agent-canonical one (carries the full RunResult shape).
+    done = events[-1]
+    assert isinstance(done.content, dict)
+    assert "run_id" in done.content
+    assert "output" in done.content
+    assert "finish_reason" in done.content
+
+
+@pytest.mark.asyncio
+async def test_strategy_stream_yields_strategy_level_done_when_driven_directly() -> None:
+    """When a caller drives `strategy.stream(state)` directly (bypassing
+    Agent.stream), the strategy's own `done` event surfaces — it carries
+    just `run_id` + `cost_usd`, not the full RunResult."""
+    from agentforge._testing import FakeTool  # noqa: PLC0415
+    from agentforge.runtime import RUNTIME_KEY, RuntimeContext  # noqa: PLC0415
+    from agentforge_core.production.budget import BudgetPolicy  # noqa: PLC0415
+    from agentforge_core.values.state import AgentState  # noqa: PLC0415
+
+    fake = FakeLLMClient(responses=[_llm_response(content="done")])
+    state = AgentState(
+        run_id="r-1",
+        task="t",
+        metadata={
+            RUNTIME_KEY: RuntimeContext(
+                llm=fake,
+                tools=(FakeTool(),),
+                memory=None,  # type: ignore[arg-type]
+                budget=BudgetPolicy(usd=1.0),
+            ),
+        },
+    )
+    strategy = ReActLoop()
+
+    events = [event async for event in strategy.stream(state)]
+
+    assert events[-1].kind == "done"
+    assert isinstance(events[-1].content, dict)
+    # Strategy-level done is minimal.
+    assert set(events[-1].content.keys()) == {"run_id", "cost_usd"}

--- a/tests/integration/test_retrieval_yaml.py
+++ b/tests/integration/test_retrieval_yaml.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 from agentforge import InMemoryVectorStore
-from agentforge.cli._build import build_retriever_from_config
+from agentforge.cli._build import build_agent_from_config, build_retriever_from_config
 from agentforge_core.config import load_config
 from agentforge_core.contracts.embedding import EmbeddingClient
 from agentforge_core.contracts.reranker import Reranker
@@ -112,6 +112,8 @@ class _ReverseReranker(Reranker):
 
 
 _INTEGRATION_YAML = """
+agent:
+  strategy: react
 retrieval:
   vector_store:
     driver: integration-store
@@ -165,3 +167,24 @@ async def test_yaml_to_retriever_end_to_end(registered: None, tmp_path: Path) ->
     assert query == "alpha query"
     assert n_candidates == 6  # top_k=2 * over_fetch_factor=3
     assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_build_agent_from_config_threads_retriever(registered: None, tmp_path: Path) -> None:
+    """feat-021 follow-up: `build_agent_from_config` now threads the
+    Retriever returned by `build_retriever_from_config` into the
+    Agent constructor (Agent already accepts `retriever=` and stores
+    it on `RuntimeContext.retriever`)."""
+    del registered
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text(_INTEGRATION_YAML)
+
+    cfg = load_config(yaml_path)
+    agent = await build_agent_from_config(cfg)
+    try:
+        # Agent constructed with the YAML's retrieval: block has the
+        # retriever threaded in via build_agent_from_config.
+        assert agent._retriever is not None
+        assert isinstance(agent._retriever.reranker, _ReverseReranker)
+    finally:
+        await agent.close()


### PR DESCRIPTION
## Summary

Closes the three remaining v0.2 cycle items in one bundled PR per the user-chosen "Full bundle as described" scope. Five surfaces across three feat specs:

- **feat-002** — `ReActLoop.stream()` per-iteration override. Built-in ReActLoop now emits a `step` `StreamingEvent` each iteration; out-of-the-box agents using the default strategy get per-step streaming without custom-strategy code.
- **feat-009 v0.3 polish** — three sub-items:
  - **Child OTel spans** (`strategy.iteration`, `llm.call`, `tool.<name>`, `evaluator.<name>`) as proper children of the root `agent.run` span. Single-point instrumentation in `StrategyBase._call_llm` + `_dispatch_tool` covers every strategy.
  - **A2A W3C TraceContext propagation** — multi-agent calls stitch into one end-to-end trace. Client injects `traceparent`; server extracts and opens an `a2a.call` span with the extracted context as parent.
  - **Content-based PII redaction** — `OpenTelemetryHook(redact_value_patterns=...)` opt-in regex scan over stringified values.
- **feat-021 follow-up** — `Agent(retriever=...)` auto-wired from `build_agent_from_config`. The kwarg + `RuntimeContext` storage existed; only the builder hook was missing.

## Chunks

1. `d096b80` — ReActLoop.stream() override + 2 unit tests
2. `ebf7af3` — Child OTel spans across the framework + end-to-end exporter test
3. `d8419c1` — A2A W3C TraceContext propagation + 3 unit tests (inject + extract + cross-process stitch)
4. `e347c35` — Content-based redaction + Agent retriever wiring + 4 unit tests
5. `dd16014` — Spec updates across feat-002/009/021 + CHANGELOG + state

## Test plan

- [x] `uv run pre-commit run --all-files` green at every chunk (ruff + mypy --strict + bandit + pytest unit + ≥ 90% coverage on touched packages)
- [x] `agentforge-otel` exporter test asserts the full span tree (agent.run → strategy.iteration × 2 → llm.call × 2 → tool.search × 1)
- [x] A2A test: caller-side `traceparent` produces a server-side `a2a.call` span sharing the caller's `trace_id`
- [x] Retrieval integration test: YAML `retrieval:` block → `build_agent_from_config` → `agent._retriever` is set

## Out of scope (deferred to v0.3.x)

- `strategy.iteration` spans on ToT + MultiAgent (their nested loop structure needs an extract-method refactor)
- `stream()` overrides on PlanExecute / ToT / MultiAgent (case-by-case, separate PRs)
- TypeScript port

🤖 Generated with [Claude Code](https://claude.com/claude-code)