### PR TITLE
feat-002 + feat-009 v0.3.x strategy follow-ups bundle

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,35 +1,37 @@
 ---
-feature: feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle
+feature: feat-002 + feat-009 v0.3.x strategy follow-ups bundle
 state: in_review
-branch: chore/feat-002-009-021-streaming-otel-spans-a2a-tracecontext-retriever-wiring
+branch: chore/feat-002-feat-009-strategy-streams-iteration-spans
 started_at: 2026-05-14
 last_milestone_at: 2026-05-14
-last_shipped: feat-021 vendor reranker sister packages shipped via PR #39 (merged 2026-05-14)
+last_shipped: feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle shipped via PR #40 (merged 2026-05-14)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-Bundled v0.3 polish PR closing five surfaces in one go per
-user-chosen "Full bundle as described" scope:
+Bundled strategy follow-ups PR closing two deferred items
+from PR #40 per user-chosen "Strategy follow-ups bundle"
+scope:
 
-- **feat-002** — `ReActLoop.stream()` per-iteration override.
-- **feat-009 v0.3** — child OTel spans
-  (`strategy.iteration` / `llm.call` / `tool.<name>` /
-  `evaluator.<name>`), A2A W3C TraceContext propagation,
-  content-based PII redaction.
-- **feat-021** — `Agent(retriever=...)` auto-wired from
-  `build_agent_from_config`.
+- **feat-009 v0.3.x** — `strategy.iteration` OTel spans on
+  `TreeOfThoughts` + `MultiAgentSupervisor` via extract-method
+  refactor (`_iterate_depth`, `_iterate_round`).
+- **feat-002 v0.3.x** — `stream()` overrides on
+  `PlanExecuteLoop`, `TreeOfThoughts`, and
+  `MultiAgentSupervisor`. ReActLoop's override already
+  shipped in PR #40; the shared `_events_for_new_steps`
+  helper was lifted to `_base.py` for reuse.
 
 ## Last shipped
 
-feat-021 vendor reranker sister packages
-(`agentforge-reranker-cohere`, `-voyage`, `-mixedbread`)
-shipped via PR #39 (merged 2026-05-14).
+feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle
+shipped via PR #40 (merged 2026-05-14).
 
 ### Previously
 
+- feat-021 vendor reranker sister packages (PR #39).
 - feat-021 v0.2 follow-up — `retrieval:` YAML block +
   `build_retriever_from_config` (PR #38).
 - feat-021 — Reranker ABC + sentence-transformers default
@@ -48,11 +50,11 @@ Remaining v0.2 backlog:
 - **Sub-feat backlog (still un-numbered)** — GraphRAG
   hybrid retrieval, BM25 + vector hybrid search, schema
   migrations.
-- **ToT + MultiAgent `stream()` overrides** — feat-002
-  follow-up; each strategy's iteration shape is different.
-- **`strategy.iteration` spans on ToT + MultiAgent** —
-  feat-009 v0.3.x; needs a small extract-method refactor.
-- **Plan-Execute `stream()` override** — feat-002 follow-up.
+- **Evidently real-time drift dashboards via Cloud**
+  (feat-009 v0.3+ open item).
+- **Multi-cluster Redlock for `RedisSessionLock`** and
+  **sentence-window streaming output guardrails** (feat-020
+  v0.3+ open items).
 
 **Already shipped on the v0.1 → v0.2 line:**
 
@@ -71,7 +73,9 @@ Remaining v0.2 backlog:
 - feat-021 v0.2 follow-up — vendor reranker sister
   packages (PR #39).
 - feat-002 + feat-009 v0.3 polish + feat-021 follow-up
-  bundle (in review).
+  bundle (PR #40).
+- feat-002 + feat-009 v0.3.x strategy follow-ups bundle
+  (in review).
 
 ## Reading order on session resume
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -1971,3 +1971,68 @@ Tooling notes:
   `("field", "bad_value")` instead.
 - ruff RUF012 fires on `class _NoAuth: headers: dict = {}`
   — mutable default at class level. Move to `__init__`.
+
+---
+
+## 2026-05-14T11:00 — feat-002 + feat-009 v0.3.x strategy follow-ups bundle in review
+
+Closes the two deferred items from PR #40 in one bundled
+PR per the user's "Strategy follow-ups bundle" choice:
+
+1. `strategy.iteration` OTel spans on TreeOfThoughts +
+   MultiAgentSupervisor (the two deferred at the end of
+   PR #40 — their loop bodies were too large for an
+   in-place `with`-block addition).
+2. `stream()` overrides on PlanExecuteLoop, TreeOfThoughts,
+   and MultiAgentSupervisor — closes the feat-002 v0.3+
+   follow-up that was deferred case-by-case at the spec
+   level.
+
+Branch: `chore/feat-002-feat-009-strategy-streams-iteration-spans`.
+
+Chunked across 6 commits:
+
+- chunk 1 (`57e66ce`): lift `_events_for_new_steps` from
+  `react.py` into `strategies/_base.py` so the three
+  follow-up strategies' `stream()` overrides can reuse it.
+- chunk 2 (`9f7ca68`): ToT `strategy.iteration` via
+  extract-method. New `_iterate_depth(state, by_id,
+  survivors, current_depth) -> list[_Node]` holds the
+  inner depth-iteration body; `run()` (and later
+  `stream()`) wrap the helper call in
+  `tracer.start_as_current_span("strategy.iteration", ...)`.
+  Extended `agentforge-otel/tests/unit/test_hook.py`
+  asserts the span tree.
+- chunk 3 (`5890b8a`): MultiAgent `strategy.iteration` via
+  extract-method. New `_iterate_round(state, runtime,
+  round_idx, prior_results) -> tuple[list[_WorkerResult],
+  bool]` holds the round body; the bool flags both
+  "no valid assignments" and "every worker errored" exits.
+  Same span pattern; extended test asserts.
+- chunk 4 (`3b654cf`): PlanExecuteLoop.stream() override.
+  Mirrors `run()` but yields `_events_for_new_steps` after
+  each phase: plan-build (which records `think` + `plan`),
+  `_execute_plan` (batched think-only or tool steps —
+  yields after the helper returns since `asyncio.gather`
+  packs the batch), then synthesize.
+- chunk 5 (`87b9d9a`): ToT.stream() override. Mirrors
+  `run()` but yields `_events_for_new_steps` after each
+  `_iterate_depth` call (flushing all branch steps for
+  that depth) and again after synthesize.
+- chunk 6 (about-to-commit): MultiAgentSupervisor.stream()
+  override + docs (feat-002 + feat-009 specs) + roadmap
+  cleanup (flips three v0.3+ items that PR #40 actually
+  shipped to ~shipped~) + CHANGELOG entry + state files.
+
+Tooling notes:
+
+- Confirmed the PlanExecute step-kind sequence: each
+  think-only step records `act` (via
+  `_call_llm(kind="act")` inside `_run_step`) followed by
+  an explicit `observe` record. The supervisor delegation
+  call records `plan` not `think` (via
+  `_call_llm(kind="plan")` in `_delegate`). MultiAgent's
+  stream emits `[plan, delegate × N, synthesize, done]`
+  per round-then-aggregate path.
+- Extract-method refactors keep the `with` block clean —
+  preferable to in-place indent shifts on 30+ line bodies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-002 + feat-009 v0.3.x strategy follow-ups bundle.**
+  Closes the two deferred items from the v0.3 polish bundle:
+  - **`strategy.iteration` OTel spans on ToT + MultiAgent.**
+    Both strategies now emit `strategy.iteration` child
+    spans under `agent.run` (attributes
+    `agentforge.iteration`, `agentforge.strategy`). The
+    inner loop body of each was extracted into
+    `_iterate_depth` / `_iterate_round` so the
+    `with tracer.start_as_current_span(...)` block wraps a
+    single helper call (avoiding the indent cascade that
+    blocked PR #40). Span-tree coverage now spans all four
+    built-in strategies.
+  - **PlanExecute / ToT / MultiAgent `stream()` overrides.**
+    Each strategy now reimplements its `run()` body in
+    `stream()` mode, yielding a `step` `StreamingEvent`
+    after each recorded step. PlanExecute flushes events
+    after the plan + batched execute + synthesize phases;
+    ToT flushes after each depth's `_iterate_depth` + the
+    final synthesize; MultiAgent flushes after each round's
+    `_iterate_round` + the final aggregate. The shared
+    `_events_for_new_steps` helper was lifted from
+    `react.py` into `_base.py` to keep duplication minimal.
+
 - **feat-002 + feat-009 v0.3 polish + feat-021 follow-up
   bundle.** Closes the three remaining v0.2 cycle items in
   one PR:

--- a/docs/features/feat-002-reasoning-strategies.md
+++ b/docs/features/feat-002-reasoning-strategies.md
@@ -446,6 +446,25 @@ Plan-Execute, ToT, and Multi-Agent stream() overrides
 deferred to v0.3.x (case-by-case; each strategy's iteration
 shape is meaningfully different from ReActLoop's).
 
+### v0.3 polish — strategy stream() overrides for the other three loops
+
+Shipped on the v0.1 → v0.2 line. All four built-in
+strategies now provide concrete `stream()` overrides:
+
+| Strategy | Stream shape |
+|---|---|
+| `ReActLoop` | per-iteration `step` events (think / act / observe) |
+| `PlanExecuteLoop` | `plan` event after planning, batched `act`/`observe` events from the topological-execute phase, final `synthesize` |
+| `TreeOfThoughts` | per-depth flush of `branch` events from `_iterate_depth`, final `synthesize` |
+| `MultiAgentSupervisor` | per-round flush: `plan` (delegation) + per-worker `delegate` events, final `synthesize` from `_aggregate` |
+
+Each strategy reuses the shared
+`_events_for_new_steps(state.steps, before)` helper (lifted
+from `react.py` into `_base.py`). The terminal `done` event
+yielded by each `stream()` carries the strategy-level
+`{run_id, cost_usd}` shape; `Agent.stream(task)` swallows it
+and emits the canonical RunResult-shaped done.
+
 ---
 
 ## Runbook

--- a/docs/features/feat-009-observability.md
+++ b/docs/features/feat-009-observability.md
@@ -425,17 +425,26 @@ override and feat-021's retriever-wiring follow-up.
 
 ### v0.3 polish deviations
 
-- **`strategy.iteration` spans on ToT + MultiAgent deferred**
-  to a v0.3.x patch. Their nested loop structure needs a
-  modest refactor (extract-method to keep indent legible
-  inside the `with tracer.start_as_current_span(...)` block).
-  ReActLoop + PlanExecute are the two most-used strategies
-  and ship with spans now.
 - **`a2a.call` span on the streaming path uses manual
   `__enter__` / `__exit__`** since `_stream_call` is an async
   generator (a `with` block doesn't compose cleanly with
   `yield`). The behaviour matches a context-managed
   invocation.
+
+### v0.3.x follow-up — strategy.iteration spans on ToT + MultiAgent
+
+Closes the deferred item from the v0.3 polish bundle. Both
+TreeOfThoughts and MultiAgentSupervisor now emit
+`strategy.iteration` child spans under `agent.run`, matching
+the ReActLoop / PlanExecuteLoop coverage. Implemented via an
+extract-method refactor (`_iterate_depth` on ToT,
+`_iterate_round` on MultiAgent) so the
+`with tracer.start_as_current_span(...)` block wraps a single
+helper call rather than the full inner-loop body. Span
+attributes (`agentforge.iteration`, `agentforge.strategy`)
+mirror the existing strategies; the in-memory exporter test
+in `agentforge-otel/tests/unit/test_hook.py` covers all four
+shipped strategies.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,7 +166,11 @@ Remaining for v0.3+:
 
 - A2A per-token streaming using `ReasoningStrategy.stream()`
   — **shipped** in feat-014 v0.3 follow-up.
-- Concrete `stream()` overrides on `ReActLoop`.
+- Concrete `stream()` overrides on all four built-in strategies
+  (`ReActLoop`, `PlanExecuteLoop`, `TreeOfThoughts`,
+  `MultiAgentSupervisor`) — **shipped** on the v0.3 polish
+  bundle (ReAct) and the v0.3.x strategy follow-ups bundle
+  (the other three).
 - Multi-cluster Redlock for `RedisSessionLock`.
 - Sentence-window streaming output guardrails.
 - Migration framework for the Postgres schema.
@@ -197,10 +201,14 @@ the package importable without the SDK.
 
 What remains for v0.3+ (per feat-009 spec):
 
-- Child OTel spans (`strategy.iteration`, `llm.call`,
-  `tool.<name>`, `evaluator.<name>`).
-- A2A trace propagation via OTel context.
-- Content-based PII redaction.
+- ~~Child OTel spans (`strategy.iteration`, `llm.call`,
+  `tool.<name>`, `evaluator.<name>`).~~ **Shipped** in the
+  v0.3 polish bundle (PR #40 — ReActLoop + PlanExecute) and
+  the v0.3.x strategy follow-ups bundle (ToT + MultiAgent).
+- ~~A2A trace propagation via OTel context.~~ **Shipped** in
+  the v0.3 polish bundle (PR #40).
+- ~~Content-based PII redaction.~~ **Shipped** in the v0.3
+  polish bundle (PR #40).
 - Evidently real-time drift dashboards via Cloud.
 
 ### Sub-feat backlog (no canonical number yet)

--- a/packages/agentforge-otel/tests/unit/test_hook.py
+++ b/packages/agentforge-otel/tests/unit/test_hook.py
@@ -365,6 +365,65 @@ async def test_child_span_tree_via_tot_strategy():
     assert attrs["agentforge.iteration"] == 0
 
 
+@pytest.mark.asyncio
+async def test_child_span_tree_via_multi_agent_strategy():
+    """Drive an Agent with the built-in ``MultiAgentSupervisor`` and
+    assert ``strategy.iteration`` spans land with
+    ``agentforge.strategy=multi_agent``.
+    """
+    from agentforge._testing import FakeLLMClient  # noqa: PLC0415
+    from agentforge.strategies._base import get_runtime  # noqa: PLC0415
+    from agentforge.strategies.multi_agent import MultiAgentSupervisor  # noqa: PLC0415
+    from agentforge_core.contracts.strategy import ReasoningStrategy  # noqa: PLC0415
+    from agentforge_core.values.messages import LLMResponse, TokenUsage  # noqa: PLC0415
+    from agentforge_core.values.state import Step as StepCls  # noqa: PLC0415
+
+    exporter = _install_inmemory_provider()
+
+    class _Worker(ReasoningStrategy):
+        async def run(self, state):
+            get_runtime(state).budget.check()
+            state.steps.append(StepCls(iteration=1, kind="synthesize", content="ok", cost_usd=0.0))
+            return state
+
+    def _resp(content: str) -> LLMResponse:
+        return LLMResponse(
+            content=content,
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=5, output_tokens=3),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    fake = FakeLLMClient(
+        responses=[
+            _resp('{"assignments": [{"worker": "a", "task": "subtask 1"}]}'),
+            _resp("aggregated answer."),
+        ]
+    )
+    otel = OpenTelemetryHook(service_name="test", endpoint="http://localhost:4317")
+    async with Agent(
+        model=fake,
+        tools=[],
+        strategy=MultiAgentSupervisor(workers={"a": _Worker()}, max_rounds=1),
+        on_step=otel,
+        on_finish=otel,
+    ) as agent:
+        await agent.run("big task")
+
+    finished = exporter.get_finished_spans()
+    by_name: dict[str, list] = {}
+    for s in finished:
+        by_name.setdefault(s.name, []).append(s)
+
+    assert len(by_name["agent.run"]) == 1
+    assert len(by_name["strategy.iteration"]) == 1
+    attrs = dict(by_name["strategy.iteration"][0].attributes or {})
+    assert attrs["agentforge.strategy"] == "multi_agent"
+    assert attrs["agentforge.iteration"] == 0
+
+
 # --- content-based PII redaction (feat-009 v0.3 polish) --------
 
 

--- a/packages/agentforge-otel/tests/unit/test_hook.py
+++ b/packages/agentforge-otel/tests/unit/test_hook.py
@@ -314,6 +314,57 @@ async def test_child_span_tree_via_react_loop():
     assert llm_attrs["agentforge.llm.tokens_in"] == 5
 
 
+@pytest.mark.asyncio
+async def test_child_span_tree_via_tot_strategy():
+    """Drive an Agent with the built-in ``TreeOfThoughts`` strategy
+    and assert ``strategy.iteration`` spans land under ``agent.run``
+    with ``agentforge.strategy=tot``.
+    """
+    from agentforge._testing import FakeLLMClient  # noqa: PLC0415
+    from agentforge.strategies.tot import TreeOfThoughts  # noqa: PLC0415
+    from agentforge_core.values.messages import LLMResponse, TokenUsage  # noqa: PLC0415
+
+    exporter = _install_inmemory_provider()
+
+    def _resp(content: str) -> LLMResponse:
+        return LLMResponse(
+            content=content,
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=5, output_tokens=3),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    fake = FakeLLMClient(
+        responses=[
+            _resp('{"thoughts": [{"id": "t1", "content": "thought 1"}]}'),
+            _resp('{"scores": [{"branch_id": "t1", "score": 0.9, "reasoning": "ok"}]}'),
+            _resp("Final answer."),
+        ]
+    )
+    otel = OpenTelemetryHook(service_name="test", endpoint="http://localhost:4317")
+    async with Agent(
+        model=fake,
+        tools=[],
+        strategy=TreeOfThoughts(branch_factor=1, depth=1, score_threshold=0.5),
+        on_step=otel,
+        on_finish=otel,
+    ) as agent:
+        await agent.run("solve x")
+
+    finished = exporter.get_finished_spans()
+    by_name: dict[str, list] = {}
+    for s in finished:
+        by_name.setdefault(s.name, []).append(s)
+
+    assert len(by_name["agent.run"]) == 1
+    assert len(by_name["strategy.iteration"]) == 1
+    attrs = dict(by_name["strategy.iteration"][0].attributes or {})
+    assert attrs["agentforge.strategy"] == "tot"
+    assert attrs["agentforge.iteration"] == 0
+
+
 # --- content-based PII redaction (feat-009 v0.3 polish) --------
 
 

--- a/packages/agentforge/src/agentforge/strategies/_base.py
+++ b/packages/agentforge/src/agentforge/strategies/_base.py
@@ -36,6 +36,7 @@ from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.contracts.tool import Tool
 from agentforge_core.observability.tracing import get_tracer
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import LLMResponse, Message, ToolSpec
 from agentforge_core.values.state import AgentState, Step, StepKind
 from pydantic import ValidationError
@@ -48,6 +49,23 @@ DEFAULT_TOOL_TIMEOUT_S = 30.0
 `agent.tool_options.timeout_s` in `agentforge.yaml`."""
 
 log = logging.getLogger(__name__)
+
+
+def _events_for_new_steps(steps: list[Step], before: int) -> list[StreamingEvent]:
+    """Build ``step`` `StreamingEvent`s for every step appended since
+    the ``before`` index. Keeps the streaming-side rendering of state
+    deltas separate from the strategy's recording semantics."""
+    return [
+        StreamingEvent(
+            kind="step",
+            content=step.content,
+            metadata={
+                "iteration": step.iteration,
+                "kind": step.kind,
+            },
+        )
+        for step in steps[before:]
+    ]
 
 
 def get_runtime(state: AgentState) -> RuntimeContext:

--- a/packages/agentforge/src/agentforge/strategies/multi_agent.py
+++ b/packages/agentforge/src/agentforge/strategies/multi_agent.py
@@ -46,17 +46,19 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from agentforge.resolver_register import register_strategy
 from agentforge.runtime import RUNTIME_KEY, RuntimeContext
-from agentforge.strategies._base import StrategyBase, get_runtime
+from agentforge.strategies._base import StrategyBase, _events_for_new_steps, get_runtime
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +194,53 @@ class MultiAgentSupervisor(StrategyBase):
         # PHASE 3 — AGGREGATE
         await self._aggregate(state, round_idx + 1, all_results)
         return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        """Per-round streaming override (feat-002 v0.3 polish).
+
+        Mirrors :meth:`run` but yields a ``step`` `StreamingEvent`
+        for each step recorded inside a round (delegate plan +
+        per-worker outputs; flushed after the round completes),
+        then the final aggregate step, then the terminal ``done``.
+        """
+        runtime = get_runtime(state)
+        round_idx = 0
+        all_results: list[_WorkerResult] = []
+        tracer = get_tracer()
+        before = len(state.steps)
+
+        while round_idx < self._max_rounds:
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": round_idx,
+                    "agentforge.strategy": "multi_agent",
+                },
+            ):
+                new_results, should_break = await self._iterate_round(
+                    state, runtime, round_idx, all_results
+                )
+            for ev in _events_for_new_steps(state.steps, before):
+                yield ev
+            before = len(state.steps)
+            all_results.extend(new_results)
+            round_idx += 1
+            if should_break:
+                break
+
+        # PHASE 3 — AGGREGATE
+        await self._aggregate(state, round_idx + 1, all_results)
+        for ev in _events_for_new_steps(state.steps, before):
+            yield ev
+
+        yield StreamingEvent(
+            kind="done",
+            content={
+                "run_id": state.run_id,
+                "cost_usd": float(runtime.budget.spent_usd),
+            },
+            metadata={},
+        )
 
     async def _iterate_round(
         self,

--- a/packages/agentforge/src/agentforge/strategies/multi_agent.py
+++ b/packages/agentforge/src/agentforge/strategies/multi_agent.py
@@ -48,6 +48,7 @@ import json
 import logging
 
 from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.production.budget import BudgetPolicy
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
@@ -170,40 +171,71 @@ class MultiAgentSupervisor(StrategyBase):
         runtime = get_runtime(state)
         round_idx = 0
         all_results: list[_WorkerResult] = []
+        tracer = get_tracer()
 
         while round_idx < self._max_rounds:
-            self._check_guardrails(state)
-
-            # PHASE 1 — DELEGATE
-            plan = await self._delegate(state, round_idx, prior=all_results)
-            assignments = self._filter_assignments(plan.assignments)
-            if not assignments:
-                log.info(
-                    "MultiAgentSupervisor: round %d produced no valid "
-                    "assignments; proceeding to aggregation.",
-                    round_idx,
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": round_idx,
+                    "agentforge.strategy": "multi_agent",
+                },
+            ):
+                new_results, should_break = await self._iterate_round(
+                    state, runtime, round_idx, all_results
                 )
-                break
-
-            # PHASE 2 — EXECUTE WORKERS (proportional budget split)
-            results = await self._execute_workers(state, runtime, assignments, round_idx=round_idx)
-            all_results.extend(results)
+            all_results.extend(new_results)
             round_idx += 1
-
-            if not any(r.error is None for r in results):
-                # Every worker failed in this round; nothing useful to
-                # iterate on. Bail out to aggregation rather than
-                # spinning the supervisor on the same failure.
-                log.warning(
-                    "MultiAgentSupervisor: every worker errored in round "
-                    "%d; aggregating with no successful outputs.",
-                    round_idx - 1,
-                )
+            if should_break:
                 break
 
         # PHASE 3 — AGGREGATE
         await self._aggregate(state, round_idx + 1, all_results)
         return state
+
+    async def _iterate_round(
+        self,
+        state: AgentState,
+        runtime: RuntimeContext,
+        round_idx: int,
+        prior_results: list[_WorkerResult],
+    ) -> tuple[list[_WorkerResult], bool]:
+        """Run one delegation round.
+
+        Returns ``(new_results, should_break)``. ``should_break`` is
+        True when the supervisor cannot make further progress this
+        run — either the delegation plan was empty or every worker
+        errored. The caller is responsible for extending the
+        aggregate result list and incrementing ``round_idx``.
+        """
+        self._check_guardrails(state)
+
+        # PHASE 1 — DELEGATE
+        plan = await self._delegate(state, round_idx, prior=prior_results)
+        assignments = self._filter_assignments(plan.assignments)
+        if not assignments:
+            log.info(
+                "MultiAgentSupervisor: round %d produced no valid "
+                "assignments; proceeding to aggregation.",
+                round_idx,
+            )
+            return [], True
+
+        # PHASE 2 — EXECUTE WORKERS (proportional budget split)
+        results = await self._execute_workers(state, runtime, assignments, round_idx=round_idx)
+
+        if not any(r.error is None for r in results):
+            # Every worker failed in this round; nothing useful to
+            # iterate on. Bail out to aggregation rather than
+            # spinning the supervisor on the same failure.
+            log.warning(
+                "MultiAgentSupervisor: every worker errored in round "
+                "%d; aggregating with no successful outputs.",
+                round_idx,
+            )
+            return results, True
+
+        return results, False
 
     # ------------------------------------------------------------------
     # Phase 1 — delegate

--- a/packages/agentforge/src/agentforge/strategies/plan_execute.py
+++ b/packages/agentforge/src/agentforge/strategies/plan_execute.py
@@ -27,16 +27,18 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from collections.abc import AsyncIterator
 from typing import Any
 
 from agentforge_core.contracts.tool import Tool
 from agentforge_core.observability.tracing import get_tracer
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
 from pydantic import ValidationError
 
 from agentforge.resolver_register import register_strategy
-from agentforge.strategies._base import StrategyBase, get_runtime
+from agentforge.strategies._base import StrategyBase, _events_for_new_steps, get_runtime
 from agentforge.strategies._plan import Plan, PlanStep, _topological_batches
 
 PLAN_SYSTEM_PROMPT = (
@@ -174,6 +176,106 @@ class PlanExecuteLoop(StrategyBase):
         )
 
         return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        """Per-phase streaming override (feat-002 v0.3 polish).
+
+        Mirrors :meth:`run` but yields ``step`` `StreamingEvent`s
+        after each phase that records steps: ``plan`` after the plan
+        is built, ``observe`` after each batch of execute steps,
+        ``synthesize`` after the final synthesis call. Replan cycles
+        emit a fresh plan event per attempt.
+        """
+        get_runtime(state)
+        replans = 0
+        plan_messages: list[Message] = [Message(role="user", content=state.task)]
+        tracer = get_tracer()
+        runtime = get_runtime(state)
+        before = len(state.steps)
+
+        while True:
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": replans,
+                    "agentforge.strategy": "plan_execute",
+                },
+            ):
+                plan = await self._build_plan(state, plan_messages, replans_done=replans)
+                self._record_step(
+                    state,
+                    iteration=0,
+                    kind="plan",
+                    content={"steps": [step.model_dump() for step in plan.steps]},
+                )
+                for ev in _events_for_new_steps(state.steps, before):
+                    yield ev
+                before = len(state.steps)
+
+                try:
+                    observations = await self._execute_plan(state, plan)
+                    for ev in _events_for_new_steps(state.steps, before):
+                        yield ev
+                    before = len(state.steps)
+                    break
+                except _StepFailure as failure:
+                    if not self._replan_on_failure or replans >= self._max_replans:
+                        observations = failure.observations_so_far
+                        self._record_step(
+                            state,
+                            iteration=len(plan.steps),
+                            kind="observe",
+                            content=(
+                                f"Plan execution failed at step {failure.failed_step.id!r}: "
+                                f"{failure.error}. No further re-plan attempts."
+                            ),
+                        )
+                        for ev in _events_for_new_steps(state.steps, before):
+                            yield ev
+                        before = len(state.steps)
+                        break
+                    replans += 1
+                    plan_messages.append(Message(role="assistant", content=plan.model_dump_json()))
+                    plan_messages.append(
+                        Message(
+                            role="user",
+                            content=(
+                                f"The plan failed at step {failure.failed_step.id!r} "
+                                f"({failure.failed_step.description!r}): {failure.error}. "
+                                f"Please re-plan."
+                            ),
+                        )
+                    )
+
+        # PHASE 3 — Synthesize
+        synth_messages: list[Message] = [
+            Message(role="user", content=state.task),
+            Message(
+                role="assistant",
+                content=(
+                    "Plan executed with the following observations:\n"
+                    + "\n".join(f"- {step_id}: {obs}" for step_id, obs in observations.items())
+                ),
+            ),
+        ]
+        await self._call_llm(
+            state,
+            iteration=len(plan.steps) + 1,
+            system=SYNTHESIS_SYSTEM_PROMPT,
+            messages=synth_messages,
+            kind="synthesize",
+        )
+        for ev in _events_for_new_steps(state.steps, before):
+            yield ev
+
+        yield StreamingEvent(
+            kind="done",
+            content={
+                "run_id": state.run_id,
+                "cost_usd": float(runtime.budget.spent_usd),
+            },
+            metadata={},
+        )
 
     # ------------------------------------------------------------------
     # Phase helpers

--- a/packages/agentforge/src/agentforge/strategies/react.py
+++ b/packages/agentforge/src/agentforge/strategies/react.py
@@ -20,10 +20,10 @@ from agentforge_core.contracts.tool import Tool
 from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
-from agentforge_core.values.state import AgentState, Step
+from agentforge_core.values.state import AgentState
 
 from agentforge.resolver_register import register_strategy
-from agentforge.strategies._base import StrategyBase, get_runtime
+from agentforge.strategies._base import StrategyBase, _events_for_new_steps, get_runtime
 
 DEFAULT_SYSTEM_PROMPT = (
     "You are a helpful AI assistant. You can use tools when they help "
@@ -228,23 +228,6 @@ class ReActLoop(StrategyBase):
                 "cost_usd": float(runtime.budget.spent_usd),
             },
         )
-
-
-def _events_for_new_steps(steps: list[Step], before: int) -> list[StreamingEvent]:
-    """Build ``step`` `StreamingEvent`s for every step appended since
-    the ``before`` index. Keeps the streaming-side rendering of state
-    deltas separate from the strategy's recording semantics."""
-    return [
-        StreamingEvent(
-            kind="step",
-            content=step.content,
-            metadata={
-                "iteration": step.iteration,
-                "kind": step.kind,
-            },
-        )
-        for step in steps[before:]
-    ]
 
 
 def _find_tool(tools: tuple[Tool, ...], name: str) -> Tool | None:

--- a/packages/agentforge/src/agentforge/strategies/tot.py
+++ b/packages/agentforge/src/agentforge/strategies/tot.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 from uuid import uuid4
 
+from agentforge_core.observability.tracing import get_tracer
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -175,6 +176,7 @@ class TreeOfThoughts(StrategyBase):
     async def run(self, state: AgentState) -> AgentState:
         runtime = get_runtime(state)
         by_id: dict[str, _Node] = {}
+        tracer = get_tracer()
 
         # Root — start from the task itself; no LLM call yet.
         root = _Node(id=str(uuid4()), parent_id=None, depth=0, content=state.task, score=1.0)
@@ -196,55 +198,14 @@ class TreeOfThoughts(StrategyBase):
                 )
                 break
 
-            new_survivors: list[_Node] = []
-            for parent in survivors:
-                self._check_guardrails(state)
-
-                # GENERATE candidates for this parent
-                candidates = await self._generate(state, parent, current_depth)
-                if not candidates:
-                    continue
-
-                # SCORE candidates
-                scored = await self._score(state, candidates, current_depth)
-
-                # Build child nodes + record branch step
-                for thought, score in scored:
-                    child = _Node(
-                        id=thought.id,
-                        parent_id=parent.id,
-                        depth=current_depth + 1,
-                        content=thought.content,
-                        score=score,
-                    )
-                    parent.children.append(child)
-                    by_id[child.id] = child
-                    self._record_step(
-                        state,
-                        iteration=current_depth + 1,
-                        kind="branch",
-                        content={
-                            "branch_id": child.id,
-                            "parent_id": parent.id,
-                            "score": score,
-                            "thought": thought.content,
-                        },
-                    )
-
-                # PRUNE: above threshold; optionally top-K (beam_width)
-                kept = [by_id[t.id] for (t, s) in scored if s >= self._score_threshold]
-                kept.sort(key=lambda n: n.score, reverse=True)
-                if self._beam_width is not None:
-                    kept = kept[: self._beam_width]
-                new_survivors.extend(kept)
-
-            # Across all parents at this level, also bound the global
-            # beam if set.
-            new_survivors.sort(key=lambda n: n.score, reverse=True)
-            if self._beam_width is not None:
-                new_survivors = new_survivors[: self._beam_width]
-
-            survivors = new_survivors
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": current_depth,
+                    "agentforge.strategy": "tot",
+                },
+            ):
+                survivors = await self._iterate_depth(state, by_id, survivors, current_depth)
             current_depth += 1
 
         # Pick the best leaf overall — the best surviving node, or the
@@ -273,6 +234,68 @@ class TreeOfThoughts(StrategyBase):
     # ------------------------------------------------------------------
     # Phase helpers
     # ------------------------------------------------------------------
+
+    async def _iterate_depth(
+        self,
+        state: AgentState,
+        by_id: dict[str, _Node],
+        survivors: list[_Node],
+        current_depth: int,
+    ) -> list[_Node]:
+        """Run one depth-level of generate/score/prune.
+
+        Returns the survivors of this level after threshold filtering
+        and (optional) global beam-width truncation. Records one
+        ``branch`` step per generated child.
+        """
+        new_survivors: list[_Node] = []
+        for parent in survivors:
+            self._check_guardrails(state)
+
+            # GENERATE candidates for this parent
+            candidates = await self._generate(state, parent, current_depth)
+            if not candidates:
+                continue
+
+            # SCORE candidates
+            scored = await self._score(state, candidates, current_depth)
+
+            # Build child nodes + record branch step
+            for thought, score in scored:
+                child = _Node(
+                    id=thought.id,
+                    parent_id=parent.id,
+                    depth=current_depth + 1,
+                    content=thought.content,
+                    score=score,
+                )
+                parent.children.append(child)
+                by_id[child.id] = child
+                self._record_step(
+                    state,
+                    iteration=current_depth + 1,
+                    kind="branch",
+                    content={
+                        "branch_id": child.id,
+                        "parent_id": parent.id,
+                        "score": score,
+                        "thought": thought.content,
+                    },
+                )
+
+            # PRUNE: above threshold; optionally top-K (beam_width)
+            kept = [by_id[t.id] for (t, s) in scored if s >= self._score_threshold]
+            kept.sort(key=lambda n: n.score, reverse=True)
+            if self._beam_width is not None:
+                kept = kept[: self._beam_width]
+            new_survivors.extend(kept)
+
+        # Across all parents at this level, also bound the global
+        # beam if set.
+        new_survivors.sort(key=lambda n: n.score, reverse=True)
+        if self._beam_width is not None:
+            new_survivors = new_survivors[: self._beam_width]
+        return new_survivors
 
     async def _generate(
         self, state: AgentState, parent: _Node, current_depth: int

--- a/packages/agentforge/src/agentforge/strategies/tot.py
+++ b/packages/agentforge/src/agentforge/strategies/tot.py
@@ -27,18 +27,20 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Literal
 from uuid import uuid4
 
 from agentforge_core.observability.tracing import get_tracer
+from agentforge_core.values.chat import StreamingEvent
 from agentforge_core.values.messages import Message
 from agentforge_core.values.state import AgentState
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from agentforge.resolver_register import register_strategy
 from agentforge.runtime import RuntimeContext
-from agentforge.strategies._base import StrategyBase, get_runtime
+from agentforge.strategies._base import StrategyBase, _events_for_new_steps, get_runtime
 
 log = logging.getLogger(__name__)
 
@@ -230,6 +232,77 @@ class TreeOfThoughts(StrategyBase):
         )
 
         return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        """Per-depth streaming override (feat-002 v0.3 polish).
+
+        Mirrors :meth:`run` but yields a ``step`` `StreamingEvent`
+        for each ``branch`` step recorded inside ``_iterate_depth``
+        (flushed after the helper returns), plus the final
+        ``synthesize`` step and the terminal ``done`` event.
+        """
+        runtime = get_runtime(state)
+        by_id: dict[str, _Node] = {}
+        tracer = get_tracer()
+
+        root = _Node(id=str(uuid4()), parent_id=None, depth=0, content=state.task, score=1.0)
+        by_id[root.id] = root
+
+        survivors: list[_Node] = [root]
+        current_depth = 0
+        before = len(state.steps)
+
+        while current_depth < self._depth and survivors:
+            self._check_guardrails(state)
+
+            if not self._can_afford_next_level(runtime, len(survivors)):
+                log.warning(
+                    "TreeOfThoughts: estimated next-level cost exceeds "
+                    "remaining budget; synthesising with current best."
+                )
+                break
+
+            with tracer.start_as_current_span(
+                "strategy.iteration",
+                attributes={
+                    "agentforge.iteration": current_depth,
+                    "agentforge.strategy": "tot",
+                },
+            ):
+                survivors = await self._iterate_depth(state, by_id, survivors, current_depth)
+            for ev in _events_for_new_steps(state.steps, before):
+                yield ev
+            before = len(state.steps)
+            current_depth += 1
+
+        best = max(by_id.values(), key=lambda n: n.score) if by_id else root
+        path = _path_to_root(best, by_id)
+        path_text = "\n".join(f"  depth={n.depth} score={n.score:.2f}: {n.content}" for n in path)
+
+        await self._call_llm(
+            state,
+            iteration=current_depth + 1,
+            system=SYNTHESIZE_SYSTEM_PROMPT,
+            messages=[
+                Message(role="user", content=state.task),
+                Message(
+                    role="assistant",
+                    content=f"Best path explored:\n{path_text}",
+                ),
+            ],
+            kind="synthesize",
+        )
+        for ev in _events_for_new_steps(state.steps, before):
+            yield ev
+
+        yield StreamingEvent(
+            kind="done",
+            content={
+                "run_id": state.run_id,
+                "cost_usd": float(runtime.budget.spent_usd),
+            },
+            metadata={},
+        )
 
     # ------------------------------------------------------------------
     # Phase helpers

--- a/packages/agentforge/tests/unit/test_multi_agent_stream.py
+++ b/packages/agentforge/tests/unit/test_multi_agent_stream.py
@@ -1,0 +1,117 @@
+"""Unit tests for `MultiAgentSupervisor.stream()` (feat-002 v0.3 polish).
+
+Exercises the per-round streaming override: yields a ``plan`` step
+event after the supervisor's delegation LLM call, a ``delegate``
+step per worker output, the final ``synthesize`` aggregate step,
+and the terminal ``done`` event.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent, InMemoryStore
+from agentforge._testing import FakeLLMClient
+from agentforge.runtime import RUNTIME_KEY, RuntimeContext
+from agentforge.strategies import MultiAgentSupervisor
+from agentforge.strategies._base import get_runtime
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.production.budget import BudgetPolicy
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+from agentforge_core.values.state import AgentState, Step
+
+
+class _ScriptedWorker(ReasoningStrategy):
+    """Worker that appends a synthesize step with a fixed reply."""
+
+    def __init__(self, reply: str = "worker output") -> None:
+        self.reply = reply
+
+    async def run(self, state):
+        rt = get_runtime(state)
+        rt.budget.check()
+        state.steps.append(Step(iteration=1, kind="synthesize", content=self.reply, cost_usd=0.0))
+        return state
+
+
+def _resp(content: str, *, cost: float = 0.0) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_plan_delegate_synthesize_then_canonical_done() -> None:
+    """One round, one worker, then aggregate. Expected step sequence:
+
+    - ``plan`` (delegation plan LLM call) → recorded by `_delegate`
+    - ``delegate`` (one per worker output) → recorded by `_execute_workers`
+    - ``synthesize`` (aggregate LLM call) → recorded by `_aggregate`
+    - canonical ``done`` emitted by `Agent.stream`
+    """
+    fake = FakeLLMClient(
+        responses=[
+            _resp('{"assignments": [{"worker": "a", "task": "subtask 1"}]}'),
+            _resp("aggregated final answer"),
+        ]
+    )
+    agent = Agent(
+        model=fake,
+        tools=[],
+        strategy=MultiAgentSupervisor(workers={"a": _ScriptedWorker()}, max_rounds=1),
+    )
+
+    events = [event async for event in agent.stream("big task")]
+    kinds = [e.kind for e in events]
+
+    assert kinds[-1] == "done"
+    assert all(k == "step" for k in kinds[:-1])
+
+    step_metadata_kinds = [e.metadata["kind"] for e in events if e.kind == "step"]
+    assert step_metadata_kinds[0] == "plan"
+    assert step_metadata_kinds.count("delegate") == 1
+    assert step_metadata_kinds[-1] == "synthesize"
+
+    done = events[-1]
+    assert isinstance(done.content, dict)
+    assert "run_id" in done.content
+    assert "output" in done.content
+
+
+@pytest.mark.asyncio
+async def test_strategy_stream_yields_strategy_level_done_when_driven_directly() -> None:
+    """Direct `strategy.stream(state)` surfaces the strategy-level
+    done (just run_id + cost_usd)."""
+    fake = FakeLLMClient(
+        responses=[
+            _resp('{"assignments": [{"worker": "a", "task": "subtask 1"}]}'),
+            _resp("aggregated"),
+        ]
+    )
+    state = AgentState(
+        run_id="r-1",
+        task="t",
+        metadata={
+            RUNTIME_KEY: RuntimeContext(
+                llm=fake,
+                tools=(),
+                memory=InMemoryStore(),
+                budget=BudgetPolicy(usd=5.0, max_iterations=10),
+            ),
+        },
+    )
+
+    events = [
+        event
+        async for event in MultiAgentSupervisor(
+            workers={"a": _ScriptedWorker()}, max_rounds=1
+        ).stream(state)
+    ]
+
+    assert events[-1].kind == "done"
+    assert isinstance(events[-1].content, dict)
+    assert set(events[-1].content.keys()) == {"run_id", "cost_usd"}

--- a/packages/agentforge/tests/unit/test_plan_execute_stream.py
+++ b/packages/agentforge/tests/unit/test_plan_execute_stream.py
@@ -1,0 +1,124 @@
+"""Unit tests for `PlanExecuteLoop.stream()` (feat-002 v0.3 polish).
+
+Exercises the per-phase streaming override: emit a ``plan`` step
+event, then one ``observe`` per execute step, then a ``synthesize``
+step, then the canonical ``done``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent
+from agentforge._testing import FakeLLMClient
+from agentforge.strategies.plan_execute import PlanExecuteLoop
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+
+
+def _resp(content: str, *, cost: float = 0.0) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_plan_observe_synthesize_then_canonical_done() -> None:
+    """Two think-only steps + synthesize: stream events in order.
+
+    Plan: two think-only steps (no dependencies → execute in parallel).
+    Expected sequence under `Agent.stream(task)`:
+      step (plan) → step (think) → step (think) → step (observe) →
+      step (observe) → step (synthesize) → done
+    """
+    plan_json = (
+        '{"steps": ['
+        '{"id": "s1", "description": "think about A", "tool": null, '
+        '"arguments": {}, "depends_on": []},'
+        '{"id": "s2", "description": "think about B", "tool": null, '
+        '"arguments": {}, "depends_on": []}'
+        "]}"
+    )
+    fake = FakeLLMClient(
+        responses=[
+            _resp(plan_json),
+            # Two think-only step LLM calls (parallel batch, order may vary):
+            _resp("about A"),
+            _resp("about B"),
+            # Synthesis:
+            _resp("final answer combining A and B"),
+        ]
+    )
+    agent = Agent(model=fake, tools=[], strategy=PlanExecuteLoop(max_parallel_steps=2))
+
+    events = [event async for event in agent.stream("combine A and B")]
+    kinds = [e.kind for e in events]
+
+    # All events except the final agent-canonical done are step events.
+    assert kinds[-1] == "done"
+    assert all(k == "step" for k in kinds[:-1])
+
+    step_metadata_kinds = [e.metadata["kind"] for e in events if e.kind == "step"]
+    # `_call_llm(kind="think")` inside `_build_plan` records a `think`
+    # step first, then the explicit `plan` step is recorded — both
+    # land before the execute phase starts.
+    assert step_metadata_kinds[0] == "think"
+    assert step_metadata_kinds[1] == "plan"
+    # Synthesize step is last.
+    assert step_metadata_kinds[-1] == "synthesize"
+    # Between plan and synthesize: two `act` (think-only steps record
+    # an `act` via `_call_llm(kind="act")`) and two `observe` records.
+    middle = step_metadata_kinds[2:-1]
+    assert middle.count("act") == 2
+    assert middle.count("observe") == 2
+
+    # Final done carries the agent-canonical RunResult shape.
+    done = events[-1]
+    assert isinstance(done.content, dict)
+    assert "run_id" in done.content
+    assert "output" in done.content
+
+
+@pytest.mark.asyncio
+async def test_strategy_stream_yields_strategy_level_done_when_driven_directly() -> None:
+    """Direct `strategy.stream(state)` surfaces the strategy-level
+    done (just run_id + cost_usd, not the full RunResult)."""
+    from agentforge import InMemoryStore  # noqa: PLC0415
+    from agentforge.runtime import RUNTIME_KEY, RuntimeContext  # noqa: PLC0415
+    from agentforge_core.production.budget import BudgetPolicy  # noqa: PLC0415
+    from agentforge_core.values.state import AgentState  # noqa: PLC0415
+
+    plan_json = (
+        '{"steps": ['
+        '{"id": "s1", "description": "think about it", "tool": null, '
+        '"arguments": {}, "depends_on": []}'
+        "]}"
+    )
+    fake = FakeLLMClient(
+        responses=[
+            _resp(plan_json),
+            _resp("thought"),
+            _resp("synth"),
+        ]
+    )
+    state = AgentState(
+        run_id="r-1",
+        task="t",
+        metadata={
+            RUNTIME_KEY: RuntimeContext(
+                llm=fake,
+                tools=(),
+                memory=InMemoryStore(),
+                budget=BudgetPolicy(usd=2.0, max_iterations=10),
+            ),
+        },
+    )
+
+    events = [event async for event in PlanExecuteLoop().stream(state)]
+
+    assert events[-1].kind == "done"
+    assert isinstance(events[-1].content, dict)
+    assert set(events[-1].content.keys()) == {"run_id", "cost_usd"}

--- a/packages/agentforge/tests/unit/test_tot_stream.py
+++ b/packages/agentforge/tests/unit/test_tot_stream.py
@@ -1,0 +1,114 @@
+"""Unit tests for `TreeOfThoughts.stream()` (feat-002 v0.3 polish).
+
+Exercises the per-depth streaming override: yields ``branch`` step
+events for each generated thought (as they're recorded inside
+``_iterate_depth``), the final ``synthesize`` step, and the
+terminal ``done`` event.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentforge import Agent
+from agentforge._testing import FakeLLMClient
+from agentforge.strategies.tot import TreeOfThoughts
+from agentforge_core.values.messages import LLMResponse, TokenUsage
+
+
+def _resp(content: str, *, cost: float = 0.0) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        stop_reason="end_turn",
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+        cost_usd=cost,
+        model="fake",
+        provider="fake",
+    )
+
+
+def _thoughts(n: int) -> str:
+    items = [f'{{"id": "t{i}", "content": "thought {i}"}}' for i in range(1, n + 1)]
+    return '{"thoughts": [' + ", ".join(items) + "]}"
+
+
+def _scores(scores_by_id: dict[str, float]) -> str:
+    items = [
+        f'{{"branch_id": "{k}", "score": {v}, "reasoning": "..."}}' for k, v in scores_by_id.items()
+    ]
+    return '{"scores": [' + ", ".join(items) + "]}"
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_branch_synthesize_then_canonical_done() -> None:
+    """depth=1, branch_factor=2: two `branch` steps + one
+    `synthesize` step + canonical done.
+    """
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(2)),
+            _resp(_scores({"t1": 0.9, "t2": 0.6})),
+            _resp("final answer based on best branch"),
+        ]
+    )
+    agent = Agent(
+        model=fake,
+        tools=[],
+        strategy=TreeOfThoughts(branch_factor=2, depth=1, score_threshold=0.5),
+    )
+
+    events = [event async for event in agent.stream("solve x")]
+    kinds = [e.kind for e in events]
+
+    assert kinds[-1] == "done"
+    assert all(k == "step" for k in kinds[:-1])
+
+    step_metadata_kinds = [e.metadata["kind"] for e in events if e.kind == "step"]
+    assert step_metadata_kinds.count("branch") == 2
+    assert step_metadata_kinds[-1] == "synthesize"
+
+    # Canonical done from Agent.stream carries the RunResult shape.
+    done = events[-1]
+    assert isinstance(done.content, dict)
+    assert "run_id" in done.content
+    assert "output" in done.content
+
+
+@pytest.mark.asyncio
+async def test_strategy_stream_yields_strategy_level_done_when_driven_directly() -> None:
+    """Direct `strategy.stream(state)` surfaces the strategy-level
+    done (just run_id + cost_usd)."""
+    from agentforge import InMemoryStore  # noqa: PLC0415
+    from agentforge.runtime import RUNTIME_KEY, RuntimeContext  # noqa: PLC0415
+    from agentforge_core.production.budget import BudgetPolicy  # noqa: PLC0415
+    from agentforge_core.values.state import AgentState  # noqa: PLC0415
+
+    fake = FakeLLMClient(
+        responses=[
+            _resp(_thoughts(1)),
+            _resp(_scores({"t1": 0.9})),
+            _resp("final"),
+        ]
+    )
+    state = AgentState(
+        run_id="r-1",
+        task="t",
+        metadata={
+            RUNTIME_KEY: RuntimeContext(
+                llm=fake,
+                tools=(),
+                memory=InMemoryStore(),
+                budget=BudgetPolicy(usd=2.0, max_iterations=10),
+            ),
+        },
+    )
+
+    events = [
+        event
+        async for event in TreeOfThoughts(branch_factor=1, depth=1, score_threshold=0.5).stream(
+            state
+        )
+    ]
+
+    assert events[-1].kind == "done"
+    assert isinstance(events[-1].content, dict)
+    assert set(events[-1].content.keys()) == {"run_id", "cost_usd"}


### PR DESCRIPTION
## Summary

Closes the two items deferred from PR #40:

- **`strategy.iteration` OTel spans on ToT + MultiAgent.** Both
  strategies now emit `strategy.iteration` child spans under
  `agent.run`, matching ReActLoop + PlanExecute coverage. Done
  via an extract-method refactor (`_iterate_depth` /
  `_iterate_round`) so the `with tracer.start_as_current_span`
  block wraps a single helper call — avoids the indent
  cascade that blocked the in-place approach in PR #40.
- **`stream()` overrides on PlanExecute / ToT / MultiAgent.**
  Each strategy now yields per-step `StreamingEvent`s as
  `state.steps` grows: PlanExecute flushes after plan-build /
  batched execute / synthesize; ToT flushes after each
  `_iterate_depth` + synthesize; MultiAgent flushes after each
  `_iterate_round` + aggregate. Shared `_events_for_new_steps`
  helper lifted from `react.py` into `_base.py`.

`docs/roadmap.md` cleanup also flips three v0.3+ "remains"
entries that PR #40 actually shipped (child OTel spans, A2A
trace propagation, content-based PII redaction) to shipped.

Span-tree coverage now spans all four built-in strategies;
`stream()` overrides cover all four as well.

## Chunks

- chunk 1 (\`57e66ce\`) — lift \`_events_for_new_steps\` to \`_base.py\`
- chunk 2 (\`9f7ca68\`) — ToT \`strategy.iteration\` span via \`_iterate_depth\`
- chunk 3 (\`5890b8a\`) — MultiAgent \`strategy.iteration\` span via \`_iterate_round\`
- chunk 4 (\`3b654cf\`) — PlanExecute.stream() override + test
- chunk 5 (\`87b9d9a\`) — ToT.stream() override + test
- chunk 6 (\`1c140f7\`) — MultiAgent.stream() override + docs + state

## Test plan

- [x] \`uv run pre-commit run --all-files\` green on every chunk
      (ruff + mypy --strict + bandit + pytest unit/integration
      + coverage ≥ 90%)
- [x] \`uv run pytest -q packages/agentforge-otel/tests/unit/test_hook.py\`
      asserts \`strategy.iteration\` spans on all four built-in
      strategies (ReAct, PlanExecute, ToT, MultiAgent)
- [x] \`uv run pytest -q packages/agentforge/tests/unit/test_react_stream.py packages/agentforge/tests/unit/test_plan_execute_stream.py packages/agentforge/tests/unit/test_tot_stream.py packages/agentforge/tests/unit/test_multi_agent_stream.py\`
      covers \`stream()\` overrides for all four strategies
      (agent-driven + direct-strategy paths each)
- [ ] CI green on ubuntu + macos + windows × py3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)