### PR TITLE
feat-024 v0.3 polish: parameterized migrations for Postgres + SurrealDB vectors

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,46 +1,49 @@
 ---
-feature: feat-024 — Schema migrations framework
+feature: feat-024 v0.3 polish — parameterized migrations (Postgres + SurrealDB vectors)
 state: in_review
-branch: feat/024-schema-migrations
+branch: feat/024-parameterized-migrations-vectors
 started_at: 2026-05-14
 last_milestone_at: 2026-05-14
-last_shipped: feat-023 — GraphRAG hybrid retrieval shipped via PR #44 (merged 2026-05-14)
+last_shipped: feat-024 — Schema migrations framework shipped via PR #45 (merged 2026-05-14)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-Bundled feat-024 PR per user-chosen "Spec + framework +
-all four drivers" scope. Closes the last un-numbered v0.2
-persistence sub-feat from `docs/roadmap.md`.
+Bundled feat-024 v0.3 polish PR per user-chosen "Full
+bundle: core + Postgres + SurrealDB" scope. Closes the
+deferred dim-parameterized item from PR #45.
 
-- New canonical spec at
-  `docs/features/feat-024-schema-migrations.md`.
-- `Migration` Pydantic value + `MigrationStatus` +
-  `Migrator` Protocol +
-  `MigrationChecksumError` at
-  `agentforge_core/contracts/migrator.py`.
-- `discover_migrations(path, *, suffix)` helper at
-  `agentforge_core/migrations/discover.py`.
-- Per-driver migrators:
-  - `PostgresMigrator` + 2 migration files
-  - `SqliteMigrator` + 3 migration files (incl. feat-022
-    FTS5 as `0002`)
-  - `Neo4jMigrator` + 2 Cypher migration files
-  - `SurrealMigrator` + 2 SurrealQL migration files
-- `agentforge db migrate` + `agentforge db migrate-status`
-  CLI subcommands.
-- All four drivers' `init_schema()` continues to work,
-  now delegating to the migration framework.
+- `render_migration_up(body, variables)` helper at
+  `agentforge_core.migrations.template` —
+  `${var}` substitution via Python's `string.Template`
+  with `safe_substitute` semantics.
+- All four per-driver migrators
+  (`PostgresMigrator` / `SqliteMigrator` /
+  `Neo4jMigrator` / `SurrealMigrator`) gain an optional
+  `variables=` kwarg.
+- Postgres + SurrealDB get per-store migration
+  subdirectories. Vector migrations move to
+  `migrations/vector/0100_vectors.{sql,surql}` (id
+  range 0100-0199 to avoid colliding with memory's
+  0001 in the shared tracking table).
+- `PostgresVectorStore.migrator()` and
+  `SurrealVectorStore.migrator()` pre-configure with
+  `variables={"dimensions": str(self._dim)}` + the
+  vector subdir path.
+- `_build_init_schema_sql` / `_build_init_schema`
+  helpers removed; `init_schema()` on both vector
+  stores delegates to the migration framework.
 
 ## Last shipped
 
-feat-023 — GraphRAG hybrid retrieval shipped via PR #44
-(merged 2026-05-14).
+feat-024 — Schema migrations framework shipped via
+PR #45 (merged 2026-05-14).
 
 ### Previously
 
+- feat-023 — GraphRAG hybrid retrieval (PR #44).
 - feat-022 v0.2 follow-up — native hybrid for Postgres +
   SQLite (PR #43).
 - feat-022 — BM25 + vector hybrid search (PR #42).
@@ -49,8 +52,8 @@ feat-023 — GraphRAG hybrid retrieval shipped via PR #44
 - feat-002 + feat-009 v0.3 polish + feat-021 follow-up
   bundle (PR #40).
 - feat-021 vendor reranker sister packages (PR #39).
-- feat-021 v0.2 follow-up — `retrieval:` YAML block +
-  builder (PR #38).
+- feat-021 v0.2 follow-up — `retrieval:` YAML block
+  + builder (PR #38).
 - feat-021 — Reranker ABC + Retriever integration
   (PR #37).
 - feat-009 v0.2 — vendor observability backends (PR #36).
@@ -60,17 +63,16 @@ feat-023 — GraphRAG hybrid retrieval shipped via PR #44
 
 ## Next pick candidates
 
-Remaining v0.2 backlog (sister-package follow-ups + v0.3+
-items):
+Remaining backlog (sister-package follow-ups + v0.3+
+polish):
 
 - **Native `lexical_search` on Neo4j / SurrealDB**
   (feat-022 sister-package follow-up).
 - **Native single-query graph-augmented retrieval inside
-  Neo4j / SurrealDB** (feat-023 sister-package follow-up).
-- **Parameterized migrations** for Postgres `vector(N)` +
-  SurrealDB `HNSW DIMENSION N` (feat-024 v0.3+ open
-  item).
-- **`down` migrations / schema rollback** (feat-024 v0.3+).
+  Neo4j / SurrealDB** (feat-023 sister-package
+  follow-up).
+- **`down` migrations / schema rollback** (feat-024
+  v0.3+).
 - **Evidently real-time drift dashboards via Cloud**
   (feat-009 v0.3+).
 - **Multi-cluster Redlock for `RedisSessionLock`** and
@@ -100,7 +102,9 @@ items):
 - feat-022 v0.2 follow-up — native hybrid for Postgres +
   SQLite (PR #43).
 - feat-023 — GraphRAG hybrid retrieval (PR #44).
-- feat-024 — Schema migrations framework (in review).
+- feat-024 — Schema migrations framework (PR #45).
+- feat-024 v0.3 polish — parameterized migrations
+  (in review).
 
 ## Reading order on session resume
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2313,3 +2313,61 @@ Tooling notes:
 - pytest collection conflicts on `test_migrator.py`
   across two packages — rename one (we renamed both:
   `test_postgres_migrator.py` + `test_sqlite_migrator.py`).
+
+---
+
+## 2026-05-14T16:00 — feat-024 v0.3 polish (parameterized migrations) in review
+
+Closes the dim-parameterized item deferred from PR #45
+per the user's "Parameterized migrations (feat-024
+v0.3+)" + "Full bundle: core + Postgres + SurrealDB"
+choices.
+
+Branch: `feat/024-parameterized-migrations-vectors`.
+
+Chunked across 3 commits:
+
+- chunk 1 (`ce3141a`): `render_migration_up(body,
+  variables)` at `agentforge_core/migrations/template.py`.
+  Uses `string.Template.safe_substitute` so unknown
+  placeholders pass through. Re-exported via
+  `agentforge_core.migrations`. 6 new unit tests
+  including a checksum-over-template invariant test.
+- chunk 2 (`a25193a`): all four per-driver migrators
+  gain `variables=` kwarg. Postgres + SurrealDB get
+  per-store migration subdirectories: vector migrations
+  move to `migrations/vector/0100_vectors.{sql,surql}`
+  (id range 0100+ avoids colliding with memory's 0001
+  in the shared tracking table).
+  `Postgres/SurrealVectorStore.migrator()` returns a
+  migrator configured with `variables={"dimensions":
+  str(self._dim)}` + the vector subdir path.
+  `_build_init_schema_sql` / `_build_init_schema`
+  helpers removed; both vector stores' `init_schema()`
+  delegate to the migration framework.
+- chunk 3 (about-to-commit): spec subsection + roadmap
+  flip + CHANGELOG + state.
+
+Design notes:
+
+- Per-store subdirectories use `path.glob(pattern)`
+  which is non-recursive, so the memory store's
+  migrator at `migrations/` doesn't pick up files in
+  `migrations/vector/`. Same for SurrealDB.
+- The `0000_migrations_table.{sql,surql}` is duplicated
+  in both the root and the vector subdir (identical
+  content). Same SHA-256 checksum, so the second store
+  to run sees `0000` already applied and skips. The
+  shared tracking table works for both stores.
+- ID ranges per store (Postgres + SurrealDB): memory =
+  0001-0099, vector = 0100-0199, graph = 0200-0299
+  (future). Future stores follow the same pattern to
+  keep ids unique across the shared tracking table.
+- SQLite + Neo4j get the `variables=` kwarg as
+  passthrough — no functional change today, but
+  unblocks future driver-specific parameterized
+  migrations without another framework bump.
+- Checksum-over-template is the load-bearing decision:
+  re-deploying with a different dim value produces the
+  same checksum, so drift detection stays correct.
+  Verified with a dedicated unit test in chunk 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-024 v0.3 polish — parameterized migrations.** Closes
+  the deferred dim-parameterized item from PR #45. Migration
+  bodies may now contain `${var}` placeholders, rendered at
+  apply time via the new
+  `render_migration_up(body, variables)` helper at
+  `agentforge_core.migrations.template`. Checksums are
+  computed over the un-substituted template — re-deploys
+  with different variable values don't trigger drift.
+  - **`render_migration_up`** uses Python's
+    `string.Template` with `safe_substitute` semantics
+    (unknown placeholders pass through so template-key
+    typos surface as apply-time SQL errors).
+  - **All four per-driver migrators** (`PostgresMigrator`,
+    `SqliteMigrator`, `Neo4jMigrator`, `SurrealMigrator`)
+    gain an optional `variables: dict[str, str] | None
+    = None` constructor kwarg.
+  - **Postgres + SurrealDB** get per-store migration
+    subdirectories. Vector migrations move to
+    `migrations/vector/0100_vectors.{sql,surql}` (id
+    range 0100-0199 avoids colliding with memory's
+    0001 in the shared tracking table).
+  - **`PostgresVectorStore.migrator()`** /
+    **`SurrealVectorStore.migrator()`** pre-configure
+    with `variables={"dimensions": str(self._dim)}` and
+    point at the vector subdirectory.
+  - **`_build_init_schema_sql`** / **`_build_init_schema`**
+    helpers removed; `init_schema()` on both vector stores
+    delegates to the migration framework.
+
+### Changed
+
+- **All four per-driver migrators** (`PostgresMigrator` /
+  `SqliteMigrator` / `Neo4jMigrator` / `SurrealMigrator`)
+  gain an optional `variables=` constructor kwarg. Default
+  `None` keeps existing migrations working unchanged.
+
 - **feat-024 — Schema migrations framework.** New canonical
   feature closing the last un-numbered v0.2 persistence
   sub-feat. Ships as a single PR across all four

--- a/docs/features/feat-024-schema-migrations.md
+++ b/docs/features/feat-024-schema-migrations.md
@@ -320,6 +320,29 @@ choice. Chunked across 7 commits:
 - Migration squashing — when the list grows long.
 - TypeScript port — v0.4.
 
+### v0.3 polish — parameterized migrations (Postgres + SurrealDB vectors)
+
+Closes the deferred dim-parameterized item from the v0.2
+ship. Migration bodies now support `${var}` placeholders
+via Python's `string.Template` semantics; per-driver
+migrator constructors gain an optional `variables:
+dict[str, str]` kwarg. Checksums are computed over the
+un-substituted template body — re-deploying with a
+different value (e.g. swapping a 768-dim embedder for
+1536) produces the same checksum, so drift detection
+stays correct.
+
+| Chunk | Commit | What landed |
+|---|---|---|
+| 1 | `ce3141a` | `render_migration_up(body, variables)` helper at `agentforge_core/migrations/template.py`. Uses `safe_substitute` so unknown placeholders pass through (template-key typos surface as apply-time SQL errors). Re-exported via `agentforge_core.migrations`. 6 new unit tests covering substitution, `$$` escape, and checksum-over-template invariant. |
+| 2 | `a25193a` | `PostgresMigrator` / `SqliteMigrator` / `Neo4jMigrator` / `SurrealMigrator` constructors all gain optional `variables=` kwarg. Postgres + SurrealDB get per-store migration subdirectories: vector migrations move to `migrations/vector/0100_vectors.{sql,surql}` (id range 0100-0199 to avoid colliding with memory's 0001). `PostgresVectorStore.migrator()` and `SurrealVectorStore.migrator()` pre-configure with `variables={"dimensions": str(self._dim)}` + the vector subdir path. `_build_init_schema_sql` / `_build_init_schema` helpers removed; `init_schema()` on both vector stores delegates to the migration framework. SQLite + Neo4j migrators get the same passthrough kwarg for future-proofing (no functional change today). |
+| 3 | this commit | Spec subsection + catalogue + roadmap flip + CHANGELOG + state. |
+
+The dim parameter is the only one in v0.2. Future
+follow-ups can use the same mechanism for embedding
+provider names, custom table prefixes, or per-tenant
+schema namespacing.
+
 ## 12. Runbook
 
 Audience: agent developers + operators upgrading deployments.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,8 +253,8 @@ targeted for v0.2:
   **shipped** in v0.2 (`Migration` value + `Migrator` Protocol +
   `discover_migrations` helper + per-driver migrators for
   Postgres / SQLite / Neo4j / SurrealDB +
-  `agentforge db migrate` / `migrate-status` CLI). Dim-parameterized
-  vector schemas (Postgres `vector(N)`, SurrealDB `HNSW DIMENSION N`)
-  stay under the existing `init_schema()` until parameterized
-  migrations land in v0.3+. `down` migrations / schema rollback
-  deferred to v0.3.
+  `agentforge db migrate` / `migrate-status` CLI). v0.3 polish
+  bundle adds template support (`${var}` placeholders in migration
+  bodies) so Postgres `vector(N)` + SurrealDB `HNSW DIMENSION N`
+  schemas now live under the migration framework too. `down`
+  migrations / schema rollback deferred to v0.3+.

--- a/packages/agentforge-core/src/agentforge_core/migrations/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/migrations/__init__.py
@@ -9,5 +9,6 @@ migration files at startup. The contract type :class:`Migration`
 from __future__ import annotations
 
 from agentforge_core.migrations.discover import _checksum, discover_migrations
+from agentforge_core.migrations.template import render_migration_up
 
-__all__ = ["_checksum", "discover_migrations"]
+__all__ = ["_checksum", "discover_migrations", "render_migration_up"]

--- a/packages/agentforge-core/src/agentforge_core/migrations/template.py
+++ b/packages/agentforge-core/src/agentforge_core/migrations/template.py
@@ -1,0 +1,34 @@
+"""Migration body templating (feat-024 v0.3 follow-up).
+
+Per-driver migrators may need per-deployment variables in their
+migration bodies — Postgres `vector(${dimensions})` and SurrealDB
+`HNSW DIMENSION ${dimensions}` are the canonical cases. The
+templating syntax is Python's :class:`string.Template` with
+``${var}`` placeholders and ``$$`` for a literal ``$``.
+
+Important invariant: the migration's checksum is computed over the
+*un-substituted* template body. Re-deploying with a different
+variable value (e.g. swapping a 768-dim embedder for a 1536-dim
+one) produces the same checksum, so the framework's drift
+detection stays correct.
+
+Unknown placeholders left untouched (`safe_substitute` semantics)
+— template-key typos surface as SQL syntax errors at apply time
+rather than silently empty replacements.
+"""
+
+from __future__ import annotations
+
+from string import Template
+
+
+def render_migration_up(body: str, variables: dict[str, str] | None) -> str:
+    """Substitute ``${var}`` placeholders in ``body`` with ``variables``.
+
+    Returns ``body`` unchanged when ``variables`` is ``None`` or
+    empty. Unknown placeholders pass through unchanged so callers
+    can spot template-key typos as apply-time SQL errors.
+    """
+    if not variables:
+        return body
+    return Template(body).safe_substitute(**variables)

--- a/packages/agentforge-core/tests/unit/test_migrations.py
+++ b/packages/agentforge-core/tests/unit/test_migrations.py
@@ -10,6 +10,7 @@ from agentforge_core import (
     MigrationChecksumError,
     discover_migrations,
 )
+from agentforge_core.migrations import render_migration_up
 from agentforge_core.migrations.discover import _checksum
 from agentforge_core.production.exceptions import ModuleError
 
@@ -130,6 +131,56 @@ def test_discover_computes_checksum_from_file_contents(tmp_path: Path) -> None:
     (tmp_path / "0001_init.sql").write_text(body)
     migrations = discover_migrations(tmp_path, suffix="sql")
     assert migrations[0].checksum == _checksum(body)
+
+
+# ---- render_migration_up (template) ----
+
+
+def test_render_passes_through_when_variables_none() -> None:
+    body = "CREATE TABLE foo (id INT);"
+    assert render_migration_up(body, None) == body
+
+
+def test_render_passes_through_when_variables_empty() -> None:
+    body = "CREATE TABLE foo (id INT);"
+    assert render_migration_up(body, {}) == body
+
+
+def test_render_substitutes_named_placeholders() -> None:
+    body = "CREATE TABLE vectors (embedding vector(${dimensions}));"
+    rendered = render_migration_up(body, {"dimensions": "768"})
+    assert "vector(768)" in rendered
+    assert "${dimensions}" not in rendered
+
+
+def test_render_leaves_unknown_placeholders_untouched() -> None:
+    body = "CREATE TABLE vectors (col ${unknown});"
+    rendered = render_migration_up(body, {"dimensions": "768"})
+    # Unknown ${unknown} passes through; caller sees SQL syntax
+    # error at apply time rather than a silently empty replacement.
+    assert "${unknown}" in rendered
+
+
+def test_render_dollar_escape_works() -> None:
+    body = "SELECT '$$' AS price"
+    rendered = render_migration_up(body, {"dimensions": "768"})
+    assert rendered == "SELECT '$' AS price"
+
+
+def test_checksum_is_over_unrendered_body() -> None:
+    """Checksum must NOT vary with substitution — that's the
+    whole point of the template invariant."""
+    template = "CREATE TABLE vectors (embedding vector(${dimensions}));"
+    checksum_template = _checksum(template)
+    # The rendered body produces a *different* checksum (it
+    # includes the substituted value); the framework records the
+    # template's checksum, not the rendered body's, so re-deploys
+    # with different `dimensions` don't trigger drift detection.
+    rendered_768 = render_migration_up(template, {"dimensions": "768"})
+    rendered_1536 = render_migration_up(template, {"dimensions": "1536"})
+    assert _checksum(template) == checksum_template
+    assert _checksum(rendered_768) != checksum_template
+    assert _checksum(rendered_1536) != checksum_template
 
 
 # ---- MigrationChecksumError ----

--- a/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/_migrator.py
+++ b/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/_migrator.py
@@ -22,7 +22,7 @@ from agentforge_core.contracts.migrator import (
     MigrationChecksumError,
     MigrationStatus,
 )
-from agentforge_core.migrations import discover_migrations
+from agentforge_core.migrations import discover_migrations, render_migration_up
 
 from agentforge_memory_neo4j._runner import CypherRunner
 
@@ -57,10 +57,12 @@ class Neo4jMigrator:
         self,
         runner: CypherRunner,
         *,
+        variables: dict[str, str] | None = None,
         migrations_path: Path | None = None,
     ) -> None:
         self._r = runner
         self._path = migrations_path or _default_migrations_path()
+        self._variables = variables
         self._migrations: list[Migration] = discover_migrations(self._path, suffix="cypher")
 
     @property
@@ -118,7 +120,8 @@ class Neo4jMigrator:
         for migration in self._migrations:
             if migration.id in applied:
                 continue
-            for stmt in _split_statements(migration.up):
+            rendered = render_migration_up(migration.up, self._variables)
+            for stmt in _split_statements(rendered):
                 await self._r.execute_write(stmt, {})
             await self._r.execute_write(
                 f"CREATE (m:{_MIGRATION_LABEL} "

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/_migrator.py
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/_migrator.py
@@ -22,7 +22,7 @@ from agentforge_core.contracts.migrator import (
     MigrationChecksumError,
     MigrationStatus,
 )
-from agentforge_core.migrations import discover_migrations
+from agentforge_core.migrations import discover_migrations, render_migration_up
 
 from agentforge_memory_postgres._runner import PostgresRunner
 
@@ -58,10 +58,12 @@ class PostgresMigrator:
         self,
         runner: PostgresRunner,
         *,
+        variables: dict[str, str] | None = None,
         migrations_path: Path | None = None,
     ) -> None:
         self._r = runner
         self._path = migrations_path or _default_migrations_path()
+        self._variables = variables
         self._migrations: list[Migration] = discover_migrations(self._path, suffix="sql")
 
     @property
@@ -120,7 +122,8 @@ class PostgresMigrator:
         for migration in self._migrations:
             if migration.id in applied:
                 continue
-            await self._r.execute(migration.up)
+            rendered = render_migration_up(migration.up, self._variables)
+            await self._r.execute(rendered)
             await self._r.execute(
                 _INSERT_APPLIED_SQL,
                 migration.id,

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/migrations/vector/0000_migrations_table.sql
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/migrations/vector/0000_migrations_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS agentforge_migrations (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    checksum    TEXT NOT NULL,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/migrations/vector/0100_vectors.sql
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/migrations/vector/0100_vectors.sql
@@ -1,0 +1,14 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE TABLE IF NOT EXISTS vectors (
+    id        TEXT PRIMARY KEY,
+    embedding vector(${dimensions}) NOT NULL,
+    text      TEXT NOT NULL,
+    metadata  JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_vectors_embedding
+    ON vectors USING hnsw (embedding vector_cosine_ops);
+ALTER TABLE vectors
+    ADD COLUMN IF NOT EXISTS embedding_tsv tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', coalesce(text, ''))) STORED;
+CREATE INDEX IF NOT EXISTS idx_vectors_tsv
+    ON vectors USING gin (embedding_tsv);

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/vector.py
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/vector.py
@@ -26,6 +26,7 @@ import asyncpg
 from agentforge_core.contracts.vector_store import VectorStore
 from agentforge_core.values.vector import VectorItem, VectorMatch
 
+from agentforge_memory_postgres._migrator import PostgresMigrator
 from agentforge_memory_postgres._runner import PostgresRunner, _AsyncpgPoolRunner
 
 # Table is a framework constant; all SQL composed from it is
@@ -69,34 +70,6 @@ _LEXICAL_SEARCH_SQL = (
     f"  FROM ranked "
     f" ORDER BY raw DESC"
 )
-
-
-def _build_init_schema_sql(dimensions: int) -> str:
-    """Compose schema-bootstrap SQL. `dimensions` is validated as an
-    `int` by the constructor — never a free-form string — so the
-    interpolation is safe. Tagged S608 / B608 nonetheless to keep the
-    lint surface honest.
-
-    Includes the feat-022 lexical-search column (``embedding_tsv``)
-    + GIN index. Upgrade from a pre-feat-022 schema: re-run
-    ``init_schema()`` to gain the column + index.
-    """
-    return (
-        "CREATE EXTENSION IF NOT EXISTS vector;"
-        f"CREATE TABLE IF NOT EXISTS {_VECTORS_TABLE} ("  # nosec B608
-        "    id        TEXT PRIMARY KEY,"
-        f"    embedding vector({int(dimensions)}) NOT NULL,"
-        "    text      TEXT NOT NULL,"
-        "    metadata  JSONB NOT NULL DEFAULT '{}'::jsonb"
-        ");"
-        f"CREATE INDEX IF NOT EXISTS idx_{_VECTORS_TABLE}_embedding "
-        f"    ON {_VECTORS_TABLE} USING hnsw (embedding vector_cosine_ops);"
-        f"ALTER TABLE {_VECTORS_TABLE} "  # nosec B608
-        f"    ADD COLUMN IF NOT EXISTS embedding_tsv tsvector "
-        f"    GENERATED ALWAYS AS (to_tsvector('english', coalesce(text, ''))) STORED;"
-        f"CREATE INDEX IF NOT EXISTS idx_{_VECTORS_TABLE}_tsv "
-        f"    ON {_VECTORS_TABLE} USING gin (embedding_tsv);"
-    )
 
 
 class PostgresVectorStore(VectorStore):
@@ -154,14 +127,42 @@ class PostgresVectorStore(VectorStore):
     ) -> None:
         await self.close()
 
+    def migrator(self) -> PostgresMigrator:
+        """Return a `PostgresMigrator` pre-configured with the
+        ``dimensions`` template variable + the vector-store
+        migrations subdirectory (feat-024 v0.3 follow-up).
+
+        The vector migrations use ``vector(${dimensions})`` placeholders
+        that the migrator renders at apply time. Checksums are
+        computed over the un-substituted template, so re-deploying
+        with a different `dimensions` value doesn't trigger drift
+        detection.
+
+        Migration files live under
+        ``migrations/vector/`` (vector-store specific; id range
+        0100-0199); the shared ``0000_migrations_table`` bootstraps
+        the tracking table the first time any store applies it.
+        """
+        from pathlib import Path  # noqa: PLC0415
+
+        path = Path(__file__).parent / "migrations" / "vector"
+        return PostgresMigrator(
+            self._r,
+            variables={"dimensions": str(self._dim)},
+            migrations_path=path,
+        )
+
     async def init_schema(self) -> None:
-        """Provision the vectors table + HNSW index. Idempotent.
+        """Provision the vectors table + HNSW index + feat-022
+        tsvector column via the migration framework (feat-024).
+        Idempotent.
 
         After this returns, the store declares the `"native_ann"`
-        capability — the HNSW index is in place. Skip this for
-        read-only workloads or when the schema is managed externally.
+        and `"hybrid_search"` capabilities — the indexes are in
+        place. Skip this for read-only workloads or when the schema
+        is managed externally.
         """
-        await self._r.execute(_build_init_schema_sql(self._dim))
+        await self.migrator().apply_pending()
         self._ann = True
 
     async def close(self) -> None:

--- a/packages/agentforge-memory-postgres/tests/unit/test_postgres_migrator.py
+++ b/packages/agentforge-memory-postgres/tests/unit/test_postgres_migrator.py
@@ -61,3 +61,32 @@ async def test_checksum_drift_raises(postgres_fake_runner) -> None:  # type: ign
 
     with pytest.raises(MigrationChecksumError, match="checksum drift"):
         await migrator.apply_pending()
+
+
+@pytest.mark.asyncio
+async def test_apply_pending_renders_dimension_placeholder(postgres_fake_runner) -> None:  # type: ignore[no-untyped-def]
+    """feat-024 v0.3 follow-up: when `variables={"dimensions": ...}`
+    is set, the vector migration's `${dimensions}` placeholder is
+    rendered at apply time. Checksum stays over the unrendered
+    template so re-deploys with a different dim don't trigger
+    drift."""
+    from pathlib import Path  # noqa: PLC0415
+
+    vector_path = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "agentforge_memory_postgres"
+        / "migrations"
+        / "vector"
+    )
+    migrator = PostgresMigrator(
+        postgres_fake_runner,
+        variables={"dimensions": "768"},
+        migrations_path=vector_path,
+    )
+    await migrator.apply_pending()
+
+    sqls = [q.sql for q in postgres_fake_runner.queries]
+    flat = " ".join(sqls)
+    assert "vector(768)" in flat
+    assert "${dimensions}" not in flat

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/_migrator.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/_migrator.py
@@ -21,7 +21,7 @@ from agentforge_core.contracts.migrator import (
     MigrationChecksumError,
     MigrationStatus,
 )
-from agentforge_core.migrations import discover_migrations
+from agentforge_core.migrations import discover_migrations, render_migration_up
 
 
 def _default_migrations_path() -> Path:
@@ -35,10 +35,12 @@ class SqliteMigrator:
         self,
         connection: aiosqlite.Connection,
         *,
+        variables: dict[str, str] | None = None,
         migrations_path: Path | None = None,
     ) -> None:
         self._db = connection
         self._path = migrations_path or _default_migrations_path()
+        self._variables = variables
         self._migrations: list[Migration] = discover_migrations(self._path, suffix="sql")
 
     @property
@@ -99,7 +101,8 @@ class SqliteMigrator:
             # `executescript` handles multi-statement migrations.
             # It implicitly commits, so we explicitly BEGIN before
             # and rely on the script's final state for the row write.
-            await self._db.executescript(migration.up)
+            rendered = render_migration_up(migration.up, self._variables)
+            await self._db.executescript(rendered)
             await self._db.execute(
                 "INSERT INTO agentforge_migrations(id, name, checksum) VALUES (?, ?, ?)",
                 (migration.id, migration.name, migration.checksum),

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/_migrator.py
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/_migrator.py
@@ -24,7 +24,7 @@ from agentforge_core.contracts.migrator import (
     MigrationChecksumError,
     MigrationStatus,
 )
-from agentforge_core.migrations import discover_migrations
+from agentforge_core.migrations import discover_migrations, render_migration_up
 
 from agentforge_memory_surrealdb._runner import SurrealRunner
 
@@ -54,10 +54,12 @@ class SurrealMigrator:
         self,
         runner: SurrealRunner,
         *,
+        variables: dict[str, str] | None = None,
         migrations_path: Path | None = None,
     ) -> None:
         self._r = runner
         self._path = migrations_path or _default_migrations_path()
+        self._variables = variables
         self._migrations: list[Migration] = discover_migrations(self._path, suffix="surql")
 
     @property
@@ -112,7 +114,8 @@ class SurrealMigrator:
         for migration in self._migrations:
             if migration.id in applied:
                 continue
-            await self._r.query(migration.up)
+            rendered = render_migration_up(migration.up, self._variables)
+            await self._r.query(rendered)
             await self._r.query(
                 f"CREATE type::thing('{_MIGRATIONS_TABLE}', $id) "  # nosec B608
                 "CONTENT { af_id: $id, name: $name, checksum: $checksum, "

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/migrations/vector/0000_migrations_table.surql
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/migrations/vector/0000_migrations_table.surql
@@ -1,0 +1,3 @@
+DEFINE TABLE IF NOT EXISTS agentforge_migrations SCHEMALESS;
+DEFINE INDEX IF NOT EXISTS agentforge_migrations_id_idx
+    ON agentforge_migrations FIELDS af_id UNIQUE;

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/migrations/vector/0100_vectors.surql
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/migrations/vector/0100_vectors.surql
@@ -1,0 +1,5 @@
+DEFINE TABLE IF NOT EXISTS af_vector SCHEMALESS;
+DEFINE INDEX IF NOT EXISTS af_vector_id_idx
+    ON af_vector FIELDS af_id UNIQUE;
+DEFINE INDEX IF NOT EXISTS af_vector_hnsw_idx
+    ON af_vector FIELDS embedding HNSW DIMENSION ${dimensions} DIST COSINE;

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/vector.py
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/vector.py
@@ -20,6 +20,7 @@ from agentforge_core.contracts.vector_store import VectorStore
 from agentforge_core.values.vector import VectorItem, VectorMatch
 from surrealdb import AsyncSurreal
 
+from agentforge_memory_surrealdb._migrator import SurrealMigrator
 from agentforge_memory_surrealdb._runner import SurrealRunner, _SurrealClientRunner
 
 # Table name is a framework constant. S608 noqa annotations below are
@@ -33,19 +34,6 @@ _UPSERT_VECTOR_QUERY = (
 _SELECT_ALL_VECTORS = f"SELECT * FROM {_VECTOR_TABLE}"  # noqa: S608  # nosec B608
 _SELECT_VECTORS_BY_IDS = f"SELECT af_id FROM {_VECTOR_TABLE} WHERE af_id IN $ids"  # noqa: S608  # nosec B608
 _DELETE_VECTORS_BY_IDS = f"DELETE FROM {_VECTOR_TABLE} WHERE af_id IN $ids"  # noqa: S608  # nosec B608
-
-
-def _build_init_schema(dimensions: int) -> str:
-    """Compose the schema-bootstrap query. `dimensions` is validated as
-    `int` by the constructor — never a free-form string."""
-    return (
-        f"DEFINE TABLE IF NOT EXISTS {_VECTOR_TABLE} SCHEMALESS;"
-        f"DEFINE INDEX IF NOT EXISTS {_VECTOR_TABLE}_id_idx "
-        f"ON {_VECTOR_TABLE} FIELDS af_id UNIQUE;"
-        f"DEFINE INDEX IF NOT EXISTS {_VECTOR_TABLE}_hnsw_idx "
-        f"ON {_VECTOR_TABLE} FIELDS embedding HNSW DIMENSION {int(dimensions)} "
-        "DIST COSINE;"
-    )
 
 
 class SurrealVectorStore(VectorStore):
@@ -92,9 +80,24 @@ class SurrealVectorStore(VectorStore):
     ) -> None:
         await self.close()
 
+    def migrator(self) -> SurrealMigrator:
+        """Return a `SurrealMigrator` pre-configured with the
+        ``dimensions`` template variable + the vector-store
+        migrations subdirectory (feat-024 v0.3 follow-up).
+        """
+        from pathlib import Path  # noqa: PLC0415
+
+        path = Path(__file__).parent / "migrations" / "vector"
+        return SurrealMigrator(
+            self._r,
+            variables={"dimensions": str(self._dim)},
+            migrations_path=path,
+        )
+
     async def init_schema(self) -> None:
-        """Provision the HNSW index. Idempotent."""
-        await self._r.query(_build_init_schema(self._dim))
+        """Provision the af_vector table + HNSW index via the
+        migration framework (feat-024). Idempotent."""
+        await self.migrator().apply_pending()
         self._ann = True
 
     async def close(self) -> None:

--- a/packages/agentforge-memory-surrealdb/tests/unit/test_surreal_migrator.py
+++ b/packages/agentforge-memory-surrealdb/tests/unit/test_surreal_migrator.py
@@ -37,3 +37,30 @@ async def test_checksum_drift_raises(surreal_fake_runner) -> None:  # type: igno
     record["checksum"] = "deadbeef" * 8
     with pytest.raises(MigrationChecksumError, match="checksum drift"):
         await migrator.apply_pending()
+
+
+@pytest.mark.asyncio
+async def test_apply_pending_renders_dimension_placeholder(surreal_fake_runner) -> None:  # type: ignore[no-untyped-def]
+    """feat-024 v0.3 follow-up: with `variables={"dimensions": ...}`,
+    the vector migration's `${dimensions}` placeholder renders at
+    apply time. Checksum stays over the un-substituted template."""
+    from pathlib import Path  # noqa: PLC0415
+
+    vector_path = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "agentforge_memory_surrealdb"
+        / "migrations"
+        / "vector"
+    )
+    migrator = SurrealMigrator(
+        surreal_fake_runner,
+        variables={"dimensions": "1024"},
+        migrations_path=vector_path,
+    )
+    await migrator.apply_pending()
+
+    qs = [q.surrealql for q in surreal_fake_runner.queries]
+    flat = " ".join(qs)
+    assert "DIMENSION 1024" in flat
+    assert "${dimensions}" not in flat


### PR DESCRIPTION
## Summary

Closes the dim-parameterized item deferred from PR #45 (feat-024).
Brings Postgres \`vector(N)\` and SurrealDB \`HNSW DIMENSION N\`
schemas under the migration framework so the only ad-hoc
\`init_schema()\` paths left on the project are gone.

- **\`render_migration_up(body, variables)\`** at
  \`agentforge_core.migrations.template\`. Uses Python's
  \`string.Template.safe_substitute\` semantics — unknown
  placeholders pass through so template-key typos surface
  as apply-time SQL errors rather than silent empty
  replacements.
- **Checksum-over-template invariant.** SHA-256 stays
  computed over the un-substituted body, so re-deploying
  with a different dim value produces the same checksum
  and the framework's drift detection stays correct.
- **All four per-driver migrators** (Postgres / SQLite /
  Neo4j / SurrealDB) gain an optional \`variables=\` kwarg.
  Default \`None\` means existing migrations work unchanged.
- **Per-store subdirectories** on Postgres + SurrealDB:
  vector migrations live at
  \`migrations/vector/0100_vectors.{sql,surql}\` (id range
  0100-0199 avoids colliding with memory's 0001 in the
  shared tracking table).
- **\`PostgresVectorStore.migrator()\` /
  \`SurrealVectorStore.migrator()\`** pre-configure with
  \`variables={"dimensions": str(self._dim)}\` + the
  vector subdir path.
- **\`_build_init_schema_sql\` / \`_build_init_schema\`**
  helpers removed; both vector stores' \`init_schema()\`
  delegate to the migration framework.

## Chunks

- chunk 1 (\`ce3141a\`) — core template support + 6 unit tests
- chunk 2 (\`a25193a\`) — Postgres + SurrealDB vector migrations + variables passthrough on all four migrators + 2 new migrator unit tests
- chunk 3 (\`0165520\`) — spec subsection + roadmap + CHANGELOG + state

## Test plan

- [x] \`uv run pre-commit run --all-files\` green on every chunk
- [x] \`uv run pytest -q packages/agentforge-core/tests/unit/test_migrations.py\` (24 tests; 6 new for template + checksum-stability)
- [x] \`uv run pytest -q packages/agentforge-memory-postgres/tests/unit/ packages/agentforge-memory-sqlite/tests/unit/ packages/agentforge-memory-neo4j/tests/unit/ packages/agentforge-memory-surrealdb/tests/unit/\` (100 tests, no regressions)
- [ ] Live tests: \`RUN_LIVE_POSTGRES=1 ... uv run pytest -m live\` to confirm \`vector(\${dimensions})\` renders cleanly against real Postgres + pgvector
- [ ] CI green on ubuntu + macos + windows × py3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)