### PR TITLE
feat-020 v0.3 polish: sentence-window streaming output guardrails

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,43 +1,45 @@
 ---
-feature: feat-025 — Neo4jVectorStore + SurrealDB native lexical_search
+feature: feat-020 v0.3 polish — sentence-window streaming output guardrails
 state: in_review
-branch: feat/025-neo4j-vector-store-plus-surrealdb-lexical
+branch: chore/feat-020-sentence-window-guardrails
 started_at: 2026-05-14
 last_milestone_at: 2026-05-14
-last_shipped: feat-024 v0.3 polish — parameterized migrations shipped via PR #46 (merged 2026-05-14)
+last_shipped: feat-025 — Neo4jVectorStore + SurrealDB native lexical_search shipped via PR #47 (merged 2026-05-14)
 blocker: null
 flags_for_user: []
 ---
 
 ## Active feature
 
-Bundled PR per user-chosen "Both in one PR" scope. Closes
-two adjacent retrieval-completeness gaps:
+Closes the deferred safety gap from feat-020 v0.2: per-token
+streamed text on `ChatSession.stream()` now passes through
+output validators at sentence boundaries when
+`safety_mode == "sentence-window"` (or its current alias
+`"stream-then-redact"`). Default `"buffer-then-stream"` is
+unchanged.
 
-1. **feat-025** — `agentforge-memory-neo4j` lacked a
-   `VectorStore`. New `Neo4jVectorStore` uses Neo4j 5.13+
-   native `CREATE VECTOR INDEX` + `CREATE FULLTEXT INDEX`.
-2. **feat-022 follow-up** — SurrealDB was the last
-   `VectorStore` without native `lexical_search`. New
-   migration adds `DEFINE ANALYZER` + `SEARCH ANALYZER
-   ... BM25` index; `SurrealVectorStore.lexical_search`
-   queries via `WHERE text @0@ $query` + `search::score`.
-
-After this PR every shipped VectorStore (InMemory /
-Postgres / SQLite / SurrealDB / Neo4j) passes both
-`run_vector_conformance` and `run_hybrid_search_conformance`.
+- New `_SentenceWindowBuffer` at
+  `agentforge_chat/_window.py`.
+- `ChatSessionConfig.safety_mode` Literal expanded.
+- `SafetyMode` re-exported from `agentforge_chat`.
+- `ChatSession.__init__` gains `safety_mode=` kwarg;
+  `_stream_per_token` dispatches accordingly.
+- `build_chat_session_from_config` reads
+  `modules.chat.session.safety_mode` and forwards it.
 
 ## Last shipped
 
-feat-024 v0.3 polish — parameterized migrations shipped
-via PR #46 (merged 2026-05-14).
+feat-025 — Neo4jVectorStore + SurrealDB native
+lexical_search shipped via PR #47 (merged 2026-05-14).
 
 ### Previously
 
+- feat-024 v0.3 polish — parameterized migrations
+  (PR #46).
 - feat-024 — Schema migrations framework (PR #45).
 - feat-023 — GraphRAG hybrid retrieval (PR #44).
-- feat-022 v0.2 follow-up — native hybrid for Postgres
-  + SQLite (PR #43).
+- feat-022 v0.2 follow-up — native hybrid for Postgres +
+  SQLite (PR #43).
 - feat-022 — BM25 + vector hybrid search (PR #42).
 - feat-002 + feat-009 v0.3.x strategy follow-ups bundle
   (PR #41).
@@ -46,8 +48,7 @@ via PR #46 (merged 2026-05-14).
 
 ## Next pick candidates
 
-Remaining backlog (v0.3+ open items + sister-package
-follow-ups):
+Remaining v0.3+ open items:
 
 - **`down` migrations / schema rollback** (feat-024
   v0.3+).
@@ -56,8 +57,7 @@ follow-ups):
   follow-up).
 - **Evidently real-time drift dashboards via Cloud**
   (feat-009 v0.3+).
-- **Multi-cluster Redlock for `RedisSessionLock`** and
-  **sentence-window streaming output guardrails**
+- **Multi-cluster Redlock for `RedisSessionLock`**
   (feat-020 v0.3+).
 
 **Already shipped on the v0.1 → v0.2 line:**
@@ -87,7 +87,9 @@ follow-ups):
 - feat-024 v0.3 polish — parameterized migrations
   (PR #46).
 - feat-025 — Neo4jVectorStore + SurrealDB native
-  lexical_search (in review).
+  lexical_search (PR #47).
+- feat-020 v0.3 polish — sentence-window streaming
+  output guardrails (in review).
 
 ## Reading order on session resume
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2454,3 +2454,61 @@ Design notes:
   attribute). Acceptable for a test fixture since the
   fake is co-located with the package; production
   code never touches `_items`.
+
+---
+
+## 2026-05-14T18:00 — feat-020 v0.3 polish (sentence-window streaming output guardrails) in review
+
+Closes the deferred safety gap from feat-020 v0.2 per
+the user's "Sentence-window streaming guardrails" pick.
+
+Branch: `chore/feat-020-sentence-window-guardrails`.
+
+Chunked across 2 commits:
+
+- chunk 1: `_SentenceWindowBuffer` at
+  `agentforge_chat/_window.py` (push + flush;
+  punctuation-then-whitespace OR newline OR 200-char
+  hard cap boundary heuristic). `ChatSessionConfig.safety_mode`
+  Literal expanded to add `"sentence-window"`. `SafetyMode`
+  type alias re-exported from `agentforge_chat`.
+  `ChatSession.__init__` gains
+  `safety_mode: SafetyMode = "buffer-then-stream"`.
+  `_stream_per_token` dispatches: in sentence-window
+  mode every `text` event accumulates in the buffer;
+  each completed sentence runs through
+  `_agent._guardrails.check_output(sentence, ctx)`
+  before being emitted as a `ChatChunk(kind="text")`.
+  Non-text events pass through unbuffered. End-of-stream
+  flushes residual through the same validator. Terminal
+  `check_output` is skipped in sentence-window mode
+  since each sentence was already validated.
+  `build_chat_session_from_config` reads
+  `chat_cfg.session.safety_mode` and forwards into
+  `ChatSession(safety_mode=...)`. 7 buffer unit tests +
+  4 session-level safety-mode tests; 48 existing chat
+  tests pass without regression.
+- chunk 2 (about-to-commit): feat-020 spec §11 flips
+  the "post-stream guardrails" deviation + "sentence-
+  window streaming guardrails" deferred item to
+  shipped; adds a "v0.3 polish" subsection describing
+  the pipeline. Roadmap line flipped. CHANGELOG entry
+  for the new safety_mode value + the additive
+  Literal change. State files updated.
+
+Design notes:
+
+- `stream-then-redact` is kept as an accepted Literal
+  value but aliases sentence-window for v0.3. A future
+  v0.3+ pass may implement true inline regex redaction
+  without buffering — the schema field stays valid so
+  YAMLs can opt into the (eventually distinct)
+  behaviour without a config-schema bump later.
+- The terminal `check_output` is intentionally skipped
+  in sentence-window mode: each sentence was already
+  validated, and re-running over the validated
+  cumulative could trigger surprising results for
+  non-idempotent validators.
+- Per-token `text` events in sentence-window mode
+  don't emit `ChatChunk` until a sentence boundary
+  fires. This is the intended latency trade-off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-020 v0.3 polish — sentence-window streaming
+  output guardrails.** Closes the deferred safety gap from
+  the v0.2 chat-agents ship. Per-token streaming on
+  `ChatSession.stream()` now consults
+  `safety_mode` to decide how `OutputValidator`s gate the
+  emitted text:
+  - **`"buffer-then-stream"`** (default) — unchanged.
+  - **`"sentence-window"`** — new. Streamed text
+    accumulates in a `_SentenceWindowBuffer` until a
+    sentence boundary (`.!?` + whitespace, OR newline,
+    OR 200-char hard cap). Each completed sentence runs
+    through `check_output` before being emitted as a
+    `text` chunk. End-of-stream flushes residual.
+  - **`"stream-then-redact"`** — current alias for
+    `sentence-window`. A future v0.3+ pass may add
+    inline regex redaction without buffering.
+  - `SafetyMode` Literal re-exported from
+    `agentforge_chat`.
+  - `build_chat_session_from_config` reads
+    `modules.chat.session.safety_mode` and forwards it.
+
+### Changed
+
+- **`ChatSessionConfig.safety_mode`** Literal expanded:
+  `Literal["buffer-then-stream", "sentence-window",
+  "stream-then-redact"]`. Additive — default unchanged.
+
 - **feat-025 — Neo4jVectorStore + SurrealDB native
   `lexical_search`.** Completes hybrid_search coverage
   across every shipped `VectorStore` (InMemory / Postgres

--- a/docs/features/feat-020-chat-agents.md
+++ b/docs/features/feat-020-chat-agents.md
@@ -643,8 +643,10 @@ Remaining for v0.3+:
   out-of-the-box agents emit per-token text without a custom
   strategy.
 - Multi-cluster `Redlock` for `RedisSessionLock`.
-- Sentence-window streaming guardrails (v0.2 keeps the
-  post-stream final-text check).
+- ~~Sentence-window streaming guardrails (v0.2 keeps the
+  post-stream final-text check).~~ **Shipped in v0.3 polish**
+  via `safety_mode: "sentence-window"`. See the v0.3
+  polish subsection below.
 
 ### v0.2 follow-up — postgres + redis + slack + per-token streaming + cross-process lock + provider-aware tokeniser
 
@@ -672,9 +674,15 @@ items from v0.1.
   UUID fencing**, not full multi-cluster Redlock. Sufficient
   for the typical chat-http deployment (1-N workers sharing
   one Redis); multi-cluster Redlock is a v0.3 follow-up.
-- **Output guardrails still run post-stream**, not against
+- ~~**Output guardrails still run post-stream**, not against
   the streaming buffer. v0.2 ships the contract; sentence-
-  window streaming guardrails wait for v0.3.
+  window streaming guardrails wait for v0.3.~~ **Shipped in
+  v0.3 polish** — `safety_mode: "sentence-window"` on
+  `ChatSession` (or via `modules.chat.session.safety_mode`
+  in YAML) buffers streamed tokens until a sentence
+  boundary, runs `check_output` per completed sentence,
+  and only emits the validated text downstream.
+  `"stream-then-redact"` is a current alias.
 - **`Agent.stream()` is a public method.** Spec §4.2 only
   documented `ChatSession.stream`; adding `Agent.stream` was
   the cleanest path to per-token chat streaming without
@@ -690,6 +698,37 @@ items from v0.1.
   models (one-line additions in v0.3 when first user lands).
 - Migration framework for the Postgres schema.
 - Multi-cluster Redlock for RedisSessionLock.
+
+### v0.3 polish — sentence-window streaming output guardrails
+
+Closes the deferred safety gap from the v0.2 ship.
+Per-token streaming on `ChatSession.stream()` previously
+forwarded each `text` event to the wire immediately and
+only ran output guardrails at end-of-stream — meaning
+streamed PII / unsafe content could reach the client
+before any validator saw it.
+
+`ChatSession` now consults `safety_mode` to decide how
+streamed text passes through validators:
+
+- `"buffer-then-stream"` (default) — unchanged from v0.2.
+  Agent runs to completion; output validators see the
+  full text once; the assembled response is then
+  sentence-segmented for the wire.
+- `"sentence-window"` — streamed text accumulates in
+  `_SentenceWindowBuffer`. Each push extracts completed
+  sentences (`.!?` + whitespace, OR newline, OR a
+  200-char hard cap). Every completed sentence runs
+  through `check_output`; the validated text emits as
+  the next `text` chunk. End-of-stream flushes any
+  residual through the same pipeline.
+- `"stream-then-redact"` — current alias for
+  `sentence-window`. A future v0.3+ pass may add inline
+  regex redaction without buffering.
+
+`SafetyMode` is re-exported from `agentforge_chat`.
+`build_chat_session_from_config` reads
+`modules.chat.session.safety_mode` and forwards it.
 
 ## 12. Runbook
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,7 +172,12 @@ Remaining for v0.3+:
   bundle (ReAct) and the v0.3.x strategy follow-ups bundle
   (the other three).
 - Multi-cluster Redlock for `RedisSessionLock`.
-- Sentence-window streaming output guardrails.
+- ~~Sentence-window streaming output guardrails.~~ — **shipped**
+  in feat-020 v0.3 polish. `ChatSession(safety_mode="sentence-window")`
+  buffers streamed tokens until a sentence boundary, runs
+  `OutputValidator.check_output` per completed sentence, and emits
+  the validated text downstream. Wired through YAML via
+  `modules.chat.session.safety_mode`.
 - Migration framework for the Postgres schema.
 
 ### feat-009 vendor observability sub-feats

--- a/packages/agentforge-chat/src/agentforge_chat/__init__.py
+++ b/packages/agentforge-chat/src/agentforge_chat/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from agentforge_chat.build import build_chat_session_from_config
 from agentforge_chat.history import InMemoryChatHistory
-from agentforge_chat.session import ChatSession
+from agentforge_chat.session import ChatSession, SafetyMode
 from agentforge_chat.sqlite import SqliteChatHistory
 from agentforge_chat.tokenisers import (
     Tokeniser,
@@ -28,6 +28,7 @@ __all__ = [
     "ChatSession",
     "Hybrid",
     "InMemoryChatHistory",
+    "SafetyMode",
     "SlidingWindow",
     "SqliteChatHistory",
     "SummariseOldest",

--- a/packages/agentforge-chat/src/agentforge_chat/_window.py
+++ b/packages/agentforge-chat/src/agentforge_chat/_window.py
@@ -1,0 +1,86 @@
+"""Sentence-window buffer for the streaming output-guardrail path
+(feat-020 v0.3 polish).
+
+When `ChatSession.safety_mode == "sentence-window"`, streamed text
+tokens accumulate in a `_SentenceWindowBuffer`. Each `push(text)` call
+returns the completed sentences ready to validate (terminator
+followed by whitespace, OR newline, OR 200-char hard cap so a
+paragraph without punctuation still flushes). The buffer's
+`flush()` returns whatever residual remains so callers can pipe
+the partial through the guardrail one last time at end-of-stream.
+
+Boundary heuristic mirrors :mod:`agentforge_chat._segment` so the
+streaming and buffer-then-stream paths produce comparable chunk
+shapes. Multi-language sentence segmentation is out of scope for
+v0.3; the regex is English-centric.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SOFT_MAX_CHARS = 200
+"""Soft cap so an unpunctuated paragraph still emits as chunks."""
+
+_BOUNDARY_RE = re.compile(r"[.!?]\s+|\n+")
+
+
+class _SentenceWindowBuffer:
+    """Accumulates streamed tokens; releases completed sentences.
+
+    Not thread-safe — `ChatSession._stream_per_token` already
+    serialises per-session via a lock, so each buffer instance is
+    single-writer / single-reader.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def push(self, text: str) -> list[str]:
+        """Append `text` to the buffer; return any completed sentences.
+
+        A sentence is "completed" when:
+        - a `.!?` is followed by whitespace, OR
+        - a newline appears, OR
+        - the buffer length exceeds `_SOFT_MAX_CHARS`.
+
+        Remaining partial text stays buffered until the next push
+        or a `flush()`.
+        """
+        if not text:
+            return []
+        self._buf += text
+        completed: list[str] = []
+        while True:
+            cut = self._find_cut()
+            if cut is None:
+                break
+            sentence = self._buf[:cut].rstrip()
+            if sentence:
+                completed.append(sentence)
+            self._buf = self._buf[cut:].lstrip()
+        return completed
+
+    def flush(self) -> str:
+        """Return the residual buffer contents + reset internal state.
+
+        Callers run this through their per-sentence pipeline one
+        last time so end-of-stream text isn't dropped on the floor.
+        Returns an empty string when the buffer is already empty.
+        """
+        residual, self._buf = self._buf, ""
+        return residual
+
+    def _find_cut(self) -> int | None:
+        """Return the byte index at which to slice off a completed
+        sentence, or `None` if nothing is ready yet.
+
+        Priority: punctuation/newline boundary first; hard-cap
+        fallback at `_SOFT_MAX_CHARS`.
+        """
+        match = _BOUNDARY_RE.search(self._buf)
+        if match is not None:
+            return match.end()
+        if len(self._buf) >= _SOFT_MAX_CHARS:
+            return _SOFT_MAX_CHARS
+        return None

--- a/packages/agentforge-chat/src/agentforge_chat/build.py
+++ b/packages/agentforge-chat/src/agentforge_chat/build.py
@@ -24,7 +24,7 @@ from agentforge_core.production.exceptions import ModuleError
 from agentforge_core.resolver import Resolver
 
 from agentforge_chat.history import InMemoryChatHistory
-from agentforge_chat.session import ChatSession
+from agentforge_chat.session import ChatSession, SafetyMode
 from agentforge_chat.truncation import SlidingWindow
 
 
@@ -47,6 +47,7 @@ async def build_chat_session_from_config(
     per_turn = None
     per_session = None
     idem_window = 60.0
+    safety_mode: SafetyMode = "buffer-then-stream"
     if chat_cfg is not None:
         if chat_cfg.history is not None:
             history = await _build_history(chat_cfg.history.driver, chat_cfg.history.config)
@@ -55,6 +56,7 @@ async def build_chat_session_from_config(
         per_turn = chat_cfg.session.per_turn_budget_usd
         per_session = chat_cfg.session.per_session_budget_usd
         idem_window = chat_cfg.session.idempotency_window_s
+        safety_mode = chat_cfg.session.safety_mode
     return ChatSession(
         agent=agent,
         session_id=session_id,
@@ -65,6 +67,7 @@ async def build_chat_session_from_config(
         per_turn_budget_usd=per_turn,
         per_session_budget_usd=per_session,
         idempotency_window_s=idem_window,
+        safety_mode=safety_mode,
     )
 
 

--- a/packages/agentforge-chat/src/agentforge_chat/session.py
+++ b/packages/agentforge-chat/src/agentforge_chat/session.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncIterator, Callable
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from agentforge.agent import Agent
@@ -43,10 +43,17 @@ from agentforge_chat._locks import (
     default_session_lock_factory,
 )
 from agentforge_chat._segment import segment_for_stream
+from agentforge_chat._window import _SentenceWindowBuffer
 from agentforge_chat.history import InMemoryChatHistory
 from agentforge_chat.truncation import SlidingWindow
 
 OnTurnHook = Callable[[ChatTurn], None]
+
+SafetyMode = Literal["buffer-then-stream", "sentence-window", "stream-then-redact"]
+"""Output-guardrail policy on streamed assistant turns. See
+:class:`agentforge_core.config.schema.ChatSessionConfig` for
+per-value semantics. ``"stream-then-redact"`` is currently an
+alias for ``"sentence-window"`` (feat-020 v0.3 polish)."""
 
 
 class ChatSession:
@@ -66,6 +73,7 @@ class ChatSession:
         idempotency_window_s: float = 60.0,
         on_turn: OnTurnHook | None = None,
         session_lock_factory: SessionLockFactory | None = None,
+        safety_mode: SafetyMode = "buffer-then-stream",
     ) -> None:
         self._agent = agent
         self._session_id = session_id if session_id is not None else uuid4().hex
@@ -88,6 +96,7 @@ class ChatSession:
         self._total_cost = 0.0
         self._turn_count = 0
         self._closed = False
+        self._safety_mode: SafetyMode = safety_mode
 
     # ------------------------------------------------------------------
     # Public properties
@@ -334,7 +343,7 @@ class ChatSession:
             async for chunk in self._chunks_for(response):
                 yield chunk
 
-    async def _stream_per_token(
+    async def _stream_per_token(  # noqa: PLR0912
         self,
         message: str,
         *,
@@ -344,6 +353,13 @@ class ChatSession:
         `StreamingEvent` as a `ChatChunk`. Persists the user + final
         assistant turns and updates per-session budgets the same way
         `_run_turn` does.
+
+        When ``safety_mode == "sentence-window"`` (or its current
+        alias ``"stream-then-redact"``), `text` events are buffered
+        until a sentence boundary; each completed sentence runs
+        through ``check_output`` before being emitted to the wire.
+        Non-text events (``tool_call``, ``step``, ``error``) pass
+        through unbuffered.
         """
         ctx = self._guard_context()
         validated_msg = await self._agent._guardrails.check_input(message, ctx)
@@ -355,6 +371,8 @@ class ChatSession:
         cumulative = ""
         run_summary: dict[str, Any] | None = None
         start = time.monotonic()
+        buffered = self._safety_mode in ("sentence-window", "stream-then-redact")
+        window = _SentenceWindowBuffer() if buffered else None
         async for event in self._agent.stream(task):
             if event.kind == "done":
                 if isinstance(event.content, dict):
@@ -364,8 +382,32 @@ class ChatSession:
                 # `finally: reset_run(token)` fires deterministically.
                 continue
             if event.kind == "text" and isinstance(event.content, str):
+                if window is not None:
+                    for sentence in window.push(event.content):
+                        validated = await self._agent._guardrails.check_output(sentence, ctx)
+                        cumulative += validated
+                        yield ChatChunk(
+                            kind="text",
+                            content=validated,
+                            cumulative_text=cumulative,
+                            turn_id=assistant_turn_id,
+                            metadata=dict(event.metadata),
+                        )
+                    continue
                 cumulative += event.content
             yield self._chunk_from_event(event, assistant_turn_id)
+        if window is not None:
+            residual = window.flush()
+            if residual:
+                validated = await self._agent._guardrails.check_output(residual, ctx)
+                cumulative += validated
+                yield ChatChunk(
+                    kind="text",
+                    content=validated,
+                    cumulative_text=cumulative,
+                    turn_id=assistant_turn_id,
+                    metadata={},
+                )
         duration_ms = int((time.monotonic() - start) * 1000)
         if run_summary is None:
             run_summary = {
@@ -377,12 +419,18 @@ class ChatSession:
                 "finish_reason": "completed",
                 "duration_ms": duration_ms,
             }
-        final_text = (
-            str(run_summary.get("output", cumulative))
-            if isinstance(run_summary.get("output"), str)
-            else cumulative
-        )
-        validated_out = await self._agent._guardrails.check_output(final_text, ctx)
+        if buffered:
+            # Each sentence already passed through `check_output`;
+            # `cumulative` is the validated text. Skip the terminal
+            # double-validation.
+            validated_out = cumulative
+        else:
+            final_text = (
+                str(run_summary.get("output", cumulative))
+                if isinstance(run_summary.get("output"), str)
+                else cumulative
+            )
+            validated_out = await self._agent._guardrails.check_output(final_text, ctx)
         assistant_turn = ChatTurn(
             id=assistant_turn_id,
             session_id=self._session_id,

--- a/packages/agentforge-chat/tests/unit/test_sentence_window.py
+++ b/packages/agentforge-chat/tests/unit/test_sentence_window.py
@@ -1,0 +1,60 @@
+"""Unit tests for `_SentenceWindowBuffer` (feat-020 v0.3 polish)."""
+
+from __future__ import annotations
+
+from agentforge_chat._window import _SOFT_MAX_CHARS, _SentenceWindowBuffer
+
+
+def test_push_returns_empty_until_terminator() -> None:
+    buf = _SentenceWindowBuffer()
+    assert buf.push("hello ") == []
+    assert buf.push("world") == []
+    # Terminator with no trailing whitespace stays buffered too —
+    # we wait for the punctuation-then-whitespace pattern.
+    assert buf.push(".") == []
+    # Now a trailing space closes the sentence.
+    assert buf.push(" ") == ["hello world."]
+
+
+def test_push_extracts_multiple_sentences() -> None:
+    buf = _SentenceWindowBuffer()
+    sentences = buf.push("First sentence. Second one! Third? ")
+    assert sentences == ["First sentence.", "Second one!", "Third?"]
+
+
+def test_push_treats_newline_as_boundary() -> None:
+    buf = _SentenceWindowBuffer()
+    sentences = buf.push("Line one\nLine two\n")
+    assert sentences == ["Line one", "Line two"]
+
+
+def test_push_keeps_partial_after_terminator() -> None:
+    buf = _SentenceWindowBuffer()
+    sentences = buf.push("Done. Continuing")
+    assert sentences == ["Done."]
+    # The partial stays in the buffer; flushing returns it.
+    assert buf.flush() == "Continuing"
+
+
+def test_push_hard_caps_long_unpunctuated_text() -> None:
+    """A paragraph without punctuation must still emit before the
+    buffer grows unbounded — the soft cap fires at
+    `_SOFT_MAX_CHARS`."""
+    buf = _SentenceWindowBuffer()
+    long_text = "a" * (_SOFT_MAX_CHARS + 50)
+    completed = buf.push(long_text)
+    assert len(completed) == 1
+    assert len(completed[0]) == _SOFT_MAX_CHARS
+
+
+def test_flush_empties_the_buffer() -> None:
+    buf = _SentenceWindowBuffer()
+    buf.push("Partial without terminator")
+    assert buf.flush() == "Partial without terminator"
+    assert buf.flush() == ""
+
+
+def test_push_empty_text_is_noop() -> None:
+    buf = _SentenceWindowBuffer()
+    assert buf.push("") == []
+    assert buf.flush() == ""

--- a/packages/agentforge-chat/tests/unit/test_session_safety_modes.py
+++ b/packages/agentforge-chat/tests/unit/test_session_safety_modes.py
@@ -1,0 +1,172 @@
+"""Tests for `ChatSession.safety_mode` dispatch (feat-020 v0.3 polish).
+
+Exercises the three safety modes against a streaming strategy:
+
+- ``"buffer-then-stream"`` (default) — per-token text passes
+  through unbuffered; terminal `check_output` runs once.
+- ``"sentence-window"`` — text accumulates in
+  `_SentenceWindowBuffer`; each completed sentence runs through
+  `check_output` before being emitted as a `text` chunk.
+- ``"stream-then-redact"`` — current alias for
+  ``sentence-window``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from agentforge.agent import Agent
+from agentforge_chat import ChatSession, InMemoryChatHistory
+from agentforge_core.contracts.guardrails import OutputValidator
+from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.values.chat import StreamingEvent
+from agentforge_core.values.guardrails import ValidationResult
+from agentforge_core.values.messages import LLMResponse, Message, TokenUsage, ToolSpec
+from agentforge_core.values.state import AgentState, Step
+
+
+class _FakeLLM(LLMClient):
+    async def call(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> LLMResponse:
+        del system, messages, tools
+        return LLMResponse(
+            content="",
+            tool_calls=(),
+            stop_reason="end_turn",
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            model="fake",
+            provider="fake",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+class _StreamingStrategy(ReasoningStrategy):
+    """Streams a fixed transcript token-by-token via per-text events.
+
+    The transcript contains ``sk-SECRET`` so output-validator tests
+    can verify the value is redacted in sentence-window mode.
+    """
+
+    _TOKENS = (
+        "My ",
+        "key ",
+        "is ",
+        "sk-SECRET",
+        ". ",
+        "Don't ",
+        "share ",
+        "it",
+        ". ",
+        "Goodbye",
+        ".",
+    )
+
+    async def run(self, state: AgentState) -> AgentState:
+        text = "".join(self._TOKENS)
+        state.steps.append(Step(iteration=0, kind="synthesize", content=text, cost_usd=0.0))
+        return state
+
+    async def stream(self, state: AgentState) -> AsyncIterator[StreamingEvent]:
+        for token in self._TOKENS:
+            yield StreamingEvent(kind="text", content=token, metadata={})
+        # `Agent.stream` wraps this with the canonical `done` event;
+        # don't need to emit our own.
+
+
+class _SecretRedactor(OutputValidator):
+    """Replaces `sk-SECRET` with `<redacted>` in any output text."""
+
+    name = "secret-redactor"
+    description = "Test redactor for the sk-SECRET token (feat-020 v0.3)."
+
+    async def validate(self, content: str, context: dict[str, Any]) -> ValidationResult:
+        del context
+        if "sk-SECRET" in content:
+            return ValidationResult(
+                passed=False,
+                violations=("secret_token",),
+                redacted_content=content.replace("sk-SECRET", "<redacted>"),
+            )
+        return ValidationResult(passed=True)
+
+
+def _agent_with_redactor() -> Agent:
+    return Agent(
+        model=_FakeLLM(),
+        strategy=_StreamingStrategy(),
+        output_validators=[_SecretRedactor()],
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_safety_mode_is_buffer_then_stream() -> None:
+    session = ChatSession(_agent_with_redactor(), history_store=InMemoryChatHistory())
+    assert session._safety_mode == "buffer-then-stream"
+
+
+@pytest.mark.asyncio
+async def test_sentence_window_redacts_per_sentence() -> None:
+    """Sentence-window mode runs `check_output` per completed
+    sentence; the secret is masked BEFORE any chunk reaches the
+    wire."""
+    session = ChatSession(
+        _agent_with_redactor(),
+        history_store=InMemoryChatHistory(),
+        safety_mode="sentence-window",
+    )
+    chunks = [chunk async for chunk in await session.stream("anything")]
+    text_chunks = [c for c in chunks if c.kind == "text"]
+    # All emitted text chunks have the secret masked.
+    for chunk in text_chunks:
+        assert "sk-SECRET" not in str(chunk.content)
+    # At least one chunk contains the redaction marker.
+    assert any("<redacted>" in str(c.content) for c in text_chunks)
+    # Stream still terminates with a `done` chunk.
+    assert chunks[-1].kind == "done"
+
+
+@pytest.mark.asyncio
+async def test_buffer_then_stream_still_redacts_at_end() -> None:
+    """The default `buffer-then-stream` path forwards raw token
+    chunks (no per-token redaction) but the persisted assistant
+    turn is redacted by the terminal `check_output`."""
+    session = ChatSession(
+        _agent_with_redactor(),
+        history_store=InMemoryChatHistory(),
+        safety_mode="buffer-then-stream",
+    )
+    chunks = [chunk async for chunk in await session.stream("anything")]
+    # Per-token forwarding means the secret CAN appear in
+    # individual text chunks (this is the trade-off this mode
+    # makes). Sentence-window is the safer alternative.
+    text_chunks = [c for c in chunks if c.kind == "text"]
+    raw_seen = any("sk-SECRET" in str(c.content) for c in text_chunks)
+    assert raw_seen
+    # But the persisted assistant turn is redacted.
+    history = await session.history(roles=["assistant"])
+    assert all("sk-SECRET" not in t.content for t in history)
+
+
+@pytest.mark.asyncio
+async def test_stream_then_redact_aliases_sentence_window() -> None:
+    """`stream-then-redact` currently behaves identically to
+    `sentence-window`."""
+    session = ChatSession(
+        _agent_with_redactor(),
+        history_store=InMemoryChatHistory(),
+        safety_mode="stream-then-redact",
+    )
+    chunks = [chunk async for chunk in await session.stream("anything")]
+    text_chunks = [c for c in chunks if c.kind == "text"]
+    for chunk in text_chunks:
+        assert "sk-SECRET" not in str(chunk.content)

--- a/packages/agentforge-core/src/agentforge_core/config/schema.py
+++ b/packages/agentforge-core/src/agentforge_core/config/schema.py
@@ -269,7 +269,24 @@ class ChatSessionConfig(BaseModel):
     per_session_budget_usd: float | None = Field(default=None, ge=0.0)
     idempotency_window_s: float = Field(default=60.0, ge=0.0)
     concurrency: Literal["queue", "reject", "replace"] = "queue"
-    safety_mode: Literal["buffer-then-stream", "stream-then-redact"] = "buffer-then-stream"
+    safety_mode: Literal["buffer-then-stream", "sentence-window", "stream-then-redact"] = (
+        "buffer-then-stream"
+    )
+    """Output-guardrail policy on streamed assistant turns:
+
+    - ``"buffer-then-stream"`` (default) — agent runs to completion;
+      output validators see the full text once; the assembled response
+      is then sentence-segmented for the wire. Existing v0.2 behaviour.
+    - ``"sentence-window"`` (feat-020 v0.3) — for real per-token
+      streaming, buffer tokens until a sentence boundary, run
+      ``check_output`` over each completed sentence, emit the
+      validated sentence as the next ``text`` chunk. Trades a small
+      latency hit (visible chunks at sentence boundaries) for
+      streaming-aware safety.
+    - ``"stream-then-redact"`` (deferred) — currently an alias for
+      ``sentence-window``. A future v0.3+ pass may add inline regex
+      redaction without buffering.
+    """
 
 
 class ChatConfig(BaseModel):


### PR DESCRIPTION
## Summary

Closes the deferred safety gap from feat-020 v0.2.
Per-token streaming on \`ChatSession.stream()\` previously
forwarded each \`text\` event to the wire immediately and
only ran output guardrails at end-of-stream — meaning
streamed PII / unsafe content could reach the client
before any \`OutputValidator\` saw it.

\`ChatSession\` now consults \`safety_mode\` to decide how
streamed text passes through validators:

- **\`"buffer-then-stream"\`** (default) — unchanged.
- **\`"sentence-window"\`** — new. Streamed text
  accumulates in \`_SentenceWindowBuffer\` until a
  sentence boundary (\`.!?\` + whitespace, OR newline,
  OR 200-char hard cap). Each completed sentence runs
  through \`check_output\` before being emitted as a
  \`text\` chunk. End-of-stream flushes residual.
- **\`"stream-then-redact"\`** — current alias for
  \`sentence-window\`. A future v0.3+ pass may add inline
  regex redaction without buffering.

\`SafetyMode\` re-exported from \`agentforge_chat\`.
\`build_chat_session_from_config\` reads
\`modules.chat.session.safety_mode\` and forwards it.

Trade-off: visible chunks land at sentence boundaries
instead of per-token. Validators get full sentences to
inspect.

## Chunks

- chunk 1 — \`_SentenceWindowBuffer\` + ChatSession \`safety_mode\` dispatch + 11 new unit tests
- chunk 2 — feat-020 spec subsection + roadmap + CHANGELOG + state

## Test plan

- [x] \`uv run pre-commit run --all-files\` green on every chunk
- [x] \`uv run pytest -q packages/agentforge-chat/tests/unit/\` (48 + 11 new = 59 tests; no regressions)
- [ ] CI green on ubuntu + macos + windows × py3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)