### PR TITLE
fix(scaffold): bugs 001-006 found via code-reviewer scaffold validation

### DIFF
--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -1,0 +1,13 @@
+# Bugs
+
+Validation bugs found against shipped releases. Each `bug-NNN-*.md`
+follows the format:
+
+- Frontmatter: `status`, `severity` (P0–P3), `found-in`, `found-via`.
+- Sections: Symptom · Reproduction · Root cause · Fix · Verification.
+
+A bug closes when its fix lands on `main` and a release ships
+containing it; the doc's frontmatter `status:` flips from `open` to
+`fixed-in: vX.Y.Z`. Bug docs are retained as institutional memory
+(so future contributors can see the same class of failure ever
+happened).

--- a/docs/bugs/bug-001-scaffold-pyproject-missing-provider-extra.md
+++ b/docs/bugs/bug-001-scaffold-pyproject-missing-provider-extra.md
@@ -1,0 +1,81 @@
+---
+status: open
+severity: P0
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-001 — `agentforge new` scaffold doesn't install the provider package
+
+## Symptom
+
+After `agentforge new my-agent --template <any> --provider anthropic`
+and `uv sync`, attempting to run the agent fails with:
+
+```
+agentforge_core.production.exceptions.ModuleError: No LLM provider
+registered for 'anthropic'. Install agentforge-anthropic …
+```
+
+## Reproduction
+
+```bash
+agentforge new code-reviewer --template code-reviewer --provider anthropic --no-prompts
+cd code-reviewer && uv sync
+python -m code_reviewer.main "hi"
+```
+
+## Root cause
+
+`packages/agentforge/src/agentforge/templates/<all>/pyproject.toml`
+declares only `agentforge-py` as a dep (plus a stale special-case
+for `bedrock`). The `llm_provider` Copier variable is not used to
+add the corresponding provider package.
+
+Even if the template *did* install `agentforge-<provider>`, that
+wouldn't pull the underlying SDK — the SDK lives behind a
+`[<provider>]` extra on each provider sister package (lazy-import
+pattern, per ADR-0004 + the `feedback_vendor_module_patterns`
+memory).
+
+## Fix
+
+In every template's `pyproject.toml`:
+
+```toml
+dependencies = [
+    "agentforge-py",
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
+]
+```
+
+(removes the obsolete `bedrock` special-case; relies on the
+`llm_provider` Copier choice matching one of `anthropic`,
+`openai`, `bedrock` — same set the template already restricts to
+via `copier.yml`.)
+
+Bonus: chain `agentforge-py[<provider>]` extras to
+`agentforge-<provider>[<sdk>]` in `packages/agentforge/pyproject.toml`
+so `pip install "agentforge-py[anthropic]"` (no scaffold) also lands
+the SDK end-to-end. Only applies to provider packages that *have*
+an SDK extra — `agentforge-anthropic`, `agentforge-openai`, and
+`agentforge-bedrock` do; `agentforge-ollama`, `agentforge-litellm`,
+and `agentforge-voyage` ship the SDK as a hard dep so no extra is
+needed:
+
+```toml
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.1"]
+openai    = ["agentforge-openai[openai] ~= 0.2.1"]
+bedrock   = ["agentforge-bedrock[bedrock] ~= 0.2.1"]
+# ollama, litellm, voyage: leave as-is (SDK is a hard dep).
+```
+
+## Verification
+
+```bash
+agentforge new test --template minimal --provider anthropic --no-prompts
+cd test && uv sync
+.venv/bin/pip list | grep -E "(agentforge-anthropic|^anthropic )"
+# Both lines should appear; second confirms the underlying SDK is installed.
+```

--- a/docs/bugs/bug-002-scaffold-yaml-missing-strategy.md
+++ b/docs/bugs/bug-002-scaffold-yaml-missing-strategy.md
@@ -1,0 +1,56 @@
+---
+status: open
+severity: P0
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-002 — Scaffolded `agentforge.yaml` missing required `agent.strategy`
+
+## Symptom
+
+After fixing [bug-001](./bug-001-scaffold-pyproject-missing-provider-extra.md)
+(so the provider is installed), `Agent()` construction next fails
+with:
+
+```
+agentforge_core.production.exceptions.ModuleError: No reasoning
+strategy provided. …
+```
+
+## Reproduction
+
+```bash
+agentforge new test --template minimal --provider anthropic --no-prompts
+cd test && uv sync && python -m test.main "hi"
+```
+
+## Root cause
+
+`packages/agentforge/src/agentforge/templates/<all>/agentforge.yaml`
+does not set `agent.strategy`. The framework has no default and
+raises `ModuleError` on `Agent(...)` construction inside the user's
+`main.py`.
+
+## Fix
+
+Add `strategy: "react"` to every template's `agentforge.yaml`
+under `agent:`:
+
+```yaml
+agent:
+  name: "{{ project_slug }}"
+  model: "..."
+  strategy: "react"
+  ...
+```
+
+(Alternative: default `Agent._resolve_strategy` to `"react"` when
+the configured field is absent. Doing it in YAML is more explicit
+and lets users see + change the default. Pick the YAML fix.)
+
+## Verification
+
+Re-scaffold and confirm `Agent()` construction passes without
+manual yaml edits — i.e., the only remaining hurdle for an
+end-to-end run is providing a real API key in `.env`.

--- a/docs/bugs/bug-003-scaffold-missing-console-script.md
+++ b/docs/bugs/bug-003-scaffold-missing-console-script.md
@@ -1,0 +1,68 @@
+---
+status: open
+severity: P1
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-003 — Scaffolded README points at `python -m <pkg>` but that fails
+
+## Symptom
+
+The scaffolded agent's own README says:
+
+```bash
+python -m code_reviewer "your task here"
+```
+
+But running it fails immediately:
+
+```
+'code_reviewer' is a package and cannot be directly executed
+```
+
+Workaround: `python -m code_reviewer.main "…"` — but that's not
+what the README told the user.
+
+## Reproduction
+
+```bash
+agentforge new test --template minimal --no-prompts
+cd test && uv sync
+python -m test "hi"   # fails
+```
+
+## Root cause
+
+The package directory `src/<slug>/` ships `__init__.py` + `main.py`
+but **no `__main__.py`** — so `python -m <pkg>` has no entry point.
+
+## Fix
+
+Add a `[project.scripts]` entry to every template's
+`pyproject.toml`:
+
+```toml
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
+```
+
+And rewrite every template's README to use it:
+
+```bash
+uv sync
+cp .env.example .env
+uv run {{ project_slug }} "your task here"
+```
+
+This is more Pythonic than dropping a `__main__.py` shim, survives
+reinstall cleanly, and matches the pattern `agentforge` itself uses
+(the `agentforge` CLI ships as `[project.scripts] agentforge = …`).
+
+## Verification
+
+```bash
+agentforge new test --template minimal --no-prompts
+cd test && uv sync && uv run test "hi"
+# Should reach Agent() construction without "cannot be directly executed".
+```

--- a/docs/bugs/bug-004-stale-feat-002-error-message.md
+++ b/docs/bugs/bug-004-stale-feat-002-error-message.md
@@ -1,0 +1,55 @@
+---
+status: open
+severity: P2
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-004 — Error message says "when feat-002 ships" but feat-002 has shipped
+
+## Symptom
+
+When `Agent()` is constructed without a strategy, the error reads:
+
+```
+No reasoning strategy provided. feat-001 ships only the
+ReasoningStrategy ABC; install agentforge[react] (when feat-002
+ships) or pass a custom ReasoningStrategy instance via
+Agent(strategy=...).
+```
+
+The `(when feat-002 ships)` parenthetical is wrong — feat-002 has
+shipped. ReActLoop is registered by default. Mentioning it as
+"future" is misleading at best, and at worst suggests the framework
+isn't actually production-ready to a first-time user reading the
+trace.
+
+## Reproduction
+
+Construct `Agent()` without `strategy=` and without a `strategy:`
+field in `agentforge.yaml`.
+
+## Root cause
+
+`packages/agentforge/src/agentforge/agent.py:241-246` — stale
+string from feat-001 era, never updated when feat-002 shipped.
+
+## Fix
+
+```python
+raise ModuleError(
+    "No reasoning strategy provided. Set `agent.strategy: \"react\"` "
+    "in agentforge.yaml, pass `strategy=\"react\"` to `Agent(...)`, "
+    "or pass a custom `ReasoningStrategy` instance via "
+    "`Agent(strategy=...)`."
+)
+```
+
+## Verification
+
+```bash
+grep -rn "feat-00[0-9]" packages/*/src/
+# No user-facing string should reference feat-NNN as a future event.
+# (Doc references to feat-NNN.md specs are fine — they're spec links,
+# not "when feat-NNN ships" statements.)
+```

--- a/docs/bugs/bug-005-import-vs-distribution-name-confusion.md
+++ b/docs/bugs/bug-005-import-vs-distribution-name-confusion.md
@@ -1,0 +1,51 @@
+---
+status: open
+severity: P2
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-005 — Error messages refer to `agentforge[<extra>]` instead of `agentforge-py[<extra>]`
+
+## Symptom
+
+Two locations in the framework refer to `agentforge[<extra>]`
+install commands. But the PyPI distribution is `agentforge-py`, not
+`agentforge` — the latter import name is only the Python module.
+Users who copy-paste the install command get:
+
+```
+ERROR: Could not find a version that satisfies the requirement agentforge[react]
+ERROR: No matching distribution found for agentforge[react]
+```
+
+## Reproduction
+
+```bash
+pip install "agentforge[react]"   # 404
+```
+
+## Root cause
+
+The import package is `agentforge` but the PyPI distribution is
+`agentforge-py` (per `packages/agentforge/pyproject.toml` line 16:
+`name = "agentforge-py"`). Two strings drift across the codebase:
+
+- `packages/agentforge/src/agentforge/__init__.py:14` —
+  module docstring: *"… or use the `agentforge[<extra>]` install
+  (per ADR-0003)."*
+- `packages/agentforge/src/agentforge/agent.py:243` — error
+  message in `_resolve_strategy` (overlaps with [bug-004](./bug-004-stale-feat-002-error-message.md)).
+
+## Fix
+
+Replace `agentforge[<extra>]` with `agentforge-py[<extra>]` in both
+locations.
+
+## Verification
+
+```bash
+grep -rn 'agentforge\[' packages/agentforge*/src/
+# Should return no results — every install hint should read
+# agentforge-py[...].
+```

--- a/docs/bugs/bug-006-scaffold-env-not-auto-loaded.md
+++ b/docs/bugs/bug-006-scaffold-env-not-auto-loaded.md
@@ -1,0 +1,75 @@
+---
+status: open
+severity: P1
+found-in: v0.2.1
+found-via: scaffold validation, 2026-05-21
+---
+
+# bug-006 — Scaffolded `.env` is never loaded by the agent's entry point
+
+## Symptom
+
+The scaffold ships `.env.example` and the agent README tells the
+user to:
+
+```bash
+cp .env.example .env
+# add ANTHROPIC_API_KEY=… to .env
+uv run <slug> "task"
+```
+
+But the resulting run fails because the entry-point `main.py`
+doesn't load `.env` — the Anthropic SDK never sees the key:
+
+```
+TypeError: Could not resolve authentication method. Expected one of
+api_key, auth_token, or credentials to be set …
+```
+
+## Reproduction
+
+```bash
+agentforge new test --template minimal --no-prompts
+cd test && uv sync
+cp .env.example .env
+# write ANTHROPIC_API_KEY=… to .env
+uv run test "hi"      # fails on missing key, despite .env being filled
+```
+
+## Root cause
+
+`packages/agentforge/src/agentforge/templates/*/src/.../main.py`
+does not call `load_dotenv()`. The `.env` file is created by the
+template, copied by the user, then ignored by the agent at runtime.
+
+## Fix
+
+In every template's `main.py.tmpl`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+from agentforge import Agent
+
+load_dotenv()
+```
+
+`python-dotenv` is added to template dependencies as part of the
+[bug-001](./bug-001-scaffold-pyproject-missing-provider-extra.md)
+fix, so this needs no extra dependency wiring.
+
+(Alternative: `Agent()` itself could call `load_dotenv()` on
+construction. Doing it in user code is more explicit and visible —
+and matches what every Python developer expects when they see a
+`.env` file in a scaffold.)
+
+## Verification
+
+After `agentforge new` + `cp .env.example .env` (with the key
+filled in), `uv run <slug> "hi"` succeeds end-to-end against the
+provider.

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -55,10 +55,14 @@ dependencies = [
 # resolves to `agentforge-py + agentforge-anthropic`, etc.
 # Add a new entry here every time a new sister package ships.
 
-# LLM providers
-anthropic = ["agentforge-anthropic ~= 0.2.1"]
-openai = ["agentforge-openai ~= 0.2.1"]
-bedrock = ["agentforge-bedrock ~= 0.2.1"]
+# LLM providers — for providers with a vendor-SDK extra
+# (anthropic / openai / bedrock), the extra is included so a single
+# `pip install "agentforge-py[<provider>]"` lands both the framework
+# wrapper AND the underlying SDK. ollama / litellm bundle their SDK
+# as a hard dep, so no `[<sdk>]` extra is needed.
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.1"]
+openai = ["agentforge-openai[openai] ~= 0.2.1"]
+bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.1"]
 ollama = ["agentforge-ollama ~= 0.2.1"]
 litellm = ["agentforge-litellm ~= 0.2.1"]
 

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -11,7 +11,7 @@ This package is the default runtime. It ships:
 
 For provider clients, persistence drivers, MCP, observability backends,
 and safety modules, install the corresponding `agentforge-<X>` packages
-or use the `agentforge[<extra>]` install (per ADR-0003).
+or use the `agentforge-py[<extra>]` install (per ADR-0003).
 
 See the project docs at `docs/README.md` (in the design workspace) and
 the per-feature specs under `docs/features/`.

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -239,10 +239,10 @@ class Agent:
             return strategy
         if strategy is None:
             raise ModuleError(
-                "No reasoning strategy provided. feat-001 ships only the "
-                "ReasoningStrategy ABC; install agentforge[react] (when feat-002 "
-                "ships) or pass a custom ReasoningStrategy instance via "
-                "Agent(strategy=...)."
+                'No reasoning strategy provided. Set `agent.strategy: "react"` '
+                'in agentforge.yaml, pass `strategy="react"` to `Agent(...)`, '
+                "or pass a custom `ReasoningStrategy` instance via "
+                "`Agent(strategy=...)`."
             )
         # String name — look up in the resolver (feat-002 will register
         # ReActLoop here when it ships).

--- a/packages/agentforge/src/agentforge/templates/code-reviewer/README.md
+++ b/packages/agentforge/src/agentforge/templates/code-reviewer/README.md
@@ -5,7 +5,7 @@
 ```bash
 uv sync
 cp .env.example .env
-python -m {{ project_slug | replace('-', '_') }} "review the diff at /path/to.patch"
+uv run {{ project_slug }} "review the diff at /path/to.patch"
 ```
 
 Drop in evaluator graders (faithfulness / correctness) once you

--- a/packages/agentforge/src/agentforge/templates/code-reviewer/agentforge.yaml
+++ b/packages/agentforge/src/agentforge/templates/code-reviewer/agentforge.yaml
@@ -1,6 +1,7 @@
 agent:
   name: "{{ project_slug }}"
   model: "{% if llm_provider == 'bedrock' %}bedrock:us.anthropic.claude-sonnet-4-5-20250929{% elif llm_provider == 'anthropic' %}anthropic:claude-sonnet-4-5{% else %}openai:gpt-4o{% endif %}"
+  strategy: "react"
   system_prompt: |
     You are a careful code reviewer. For each issue, emit a
     SimpleFinding with severity, category, file, line, and a

--- a/packages/agentforge/src/agentforge/templates/code-reviewer/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/code-reviewer/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/code-reviewer/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/code-reviewer/src/{{project_slug.replace('-', '_')}}/main.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
 from agentforge.tools import file_read
+
+load_dotenv()
 
 
 async def run_agent(task: str) -> str:
@@ -22,7 +26,7 @@ async def run_agent(task: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<task>"')
+        print('Usage: {{ project_slug }} "<task>"')
         sys.exit(1)
     output = asyncio.run(run_agent(" ".join(sys.argv[1:])))
     print(output)

--- a/packages/agentforge/src/agentforge/templates/docs-qa/README.md
+++ b/packages/agentforge/src/agentforge/templates/docs-qa/README.md
@@ -6,7 +6,7 @@ Outputs `NarrativeFinding`s — markdown prose with citations.
 ```bash
 uv sync
 cp .env.example .env
-python -m {{ project_slug | replace('-', '_') }} "how does the auth flow work?"
+uv run {{ project_slug }} "how does the auth flow work?"
 ```
 
 For real RAG, install `agentforge-memory-sqlite` (or postgres),

--- a/packages/agentforge/src/agentforge/templates/docs-qa/agentforge.yaml
+++ b/packages/agentforge/src/agentforge/templates/docs-qa/agentforge.yaml
@@ -1,6 +1,7 @@
 agent:
   name: "{{ project_slug }}"
   model: "{% if llm_provider == 'bedrock' %}bedrock:us.anthropic.claude-sonnet-4-5-20250929{% elif llm_provider == 'anthropic' %}anthropic:claude-sonnet-4-5{% else %}openai:gpt-4o{% endif %}"
+  strategy: "react"
   system_prompt: |
     You answer questions using only the supplied documentation /
     source. Emit a `NarrativeFinding` with the answer as `body`

--- a/packages/agentforge/src/agentforge/templates/docs-qa/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/docs-qa/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/docs-qa/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/docs-qa/src/{{project_slug.replace('-', '_')}}/main.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
 from agentforge.tools import file_read, web_search
+
+load_dotenv()
 
 
 async def run_agent(task: str) -> str:
@@ -22,7 +26,7 @@ async def run_agent(task: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<question>"')
+        print('Usage: {{ project_slug }} "<question>"')
         sys.exit(1)
     output = asyncio.run(run_agent(" ".join(sys.argv[1:])))
     print(output)

--- a/packages/agentforge/src/agentforge/templates/minimal/README.md
+++ b/packages/agentforge/src/agentforge/templates/minimal/README.md
@@ -8,7 +8,7 @@
 uv sync
 cp .env.example .env
 # Fill in credentials in .env, then:
-python -m {{ project_slug | replace('-', '_') }} "your task here"
+uv run {{ project_slug }} "your task here"
 ```
 
 ## Configuration

--- a/packages/agentforge/src/agentforge/templates/minimal/agentforge.yaml
+++ b/packages/agentforge/src/agentforge/templates/minimal/agentforge.yaml
@@ -1,6 +1,7 @@
 agent:
   name: "{{ project_slug }}"
   model: "{% if llm_provider == 'bedrock' %}bedrock:us.anthropic.claude-sonnet-4-5-20250929{% elif llm_provider == 'anthropic' %}anthropic:claude-sonnet-4-5{% else %}openai:gpt-4o{% endif %}"
+  strategy: "react"
   budget:
     usd: 2.0
   max_iterations: 25

--- a/packages/agentforge/src/agentforge/templates/minimal/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/minimal/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/minimal/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/minimal/src/{{project_slug.replace('-', '_')}}/main.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
+
+load_dotenv()
 
 
 async def run_agent(task: str) -> str:
@@ -23,7 +27,7 @@ async def run_agent(task: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<task>"')
+        print('Usage: {{ project_slug }} "<task>"')
         sys.exit(1)
     task = " ".join(sys.argv[1:])
     output = asyncio.run(run_agent(task))

--- a/packages/agentforge/src/agentforge/templates/patch-bot/README.md
+++ b/packages/agentforge/src/agentforge/templates/patch-bot/README.md
@@ -6,7 +6,7 @@ with rationale + confidence — for downstream consumers to apply.
 ```bash
 uv sync
 cp .env.example .env
-python -m {{ project_slug | replace('-', '_') }} "replace deprecated time.clock() in src/"
+uv run {{ project_slug }} "replace deprecated time.clock() in src/"
 ```
 
 The agent does NOT apply the patches itself — the consumer (CI

--- a/packages/agentforge/src/agentforge/templates/patch-bot/agentforge.yaml
+++ b/packages/agentforge/src/agentforge/templates/patch-bot/agentforge.yaml
@@ -1,6 +1,7 @@
 agent:
   name: "{{ project_slug }}"
   model: "{% if llm_provider == 'bedrock' %}bedrock:us.anthropic.claude-sonnet-4-5-20250929{% elif llm_provider == 'anthropic' %}anthropic:claude-sonnet-4-5{% else %}openai:gpt-4o{% endif %}"
+  strategy: "react"
   system_prompt: |
     You generate patches. For each fix, emit a `PatchFinding` with
     a unified-diff `patch`, a one-line `rationale`, and a

--- a/packages/agentforge/src/agentforge/templates/patch-bot/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/patch-bot/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/patch-bot/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/patch-bot/src/{{project_slug.replace('-', '_')}}/main.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
 from agentforge.tools import file_read
+
+load_dotenv()
 
 
 async def run_agent(task: str) -> str:
@@ -22,7 +26,7 @@ async def run_agent(task: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<task>"')
+        print('Usage: {{ project_slug }} "<task>"')
         sys.exit(1)
     output = asyncio.run(run_agent(" ".join(sys.argv[1:])))
     print(output)

--- a/packages/agentforge/src/agentforge/templates/research/README.md
+++ b/packages/agentforge/src/agentforge/templates/research/README.md
@@ -7,7 +7,7 @@ into sub-tasks, then synthesises a `NarrativeFinding`.
 ```bash
 uv sync
 cp .env.example .env
-python -m {{ project_slug | replace('-', '_') }} "what changed in claude-sonnet 4.5 vs 4.7?"
+uv run {{ project_slug }} "what changed in claude-sonnet 4.5 vs 4.7?"
 ```
 
 Defaults to `web_search` (DuckDuckGo HTML scrape). Replace with a

--- a/packages/agentforge/src/agentforge/templates/research/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/research/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/research/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/research/src/{{project_slug.replace('-', '_')}}/main.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
 from agentforge.tools import web_search
+
+load_dotenv()
 
 
 async def run_agent(question: str) -> str:
@@ -21,7 +25,7 @@ async def run_agent(question: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<research question>"')
+        print('Usage: {{ project_slug }} "<research question>"')
         sys.exit(1)
     output = asyncio.run(run_agent(" ".join(sys.argv[1:])))
     print(output)

--- a/packages/agentforge/src/agentforge/templates/triage/README.md
+++ b/packages/agentforge/src/agentforge/templates/triage/README.md
@@ -7,7 +7,7 @@ keeps cost bounded.
 ```bash
 uv sync
 cp .env.example .env
-python -m {{ project_slug | replace('-', '_') }} "triage this issue text..."
+uv run {{ project_slug }} "triage this issue text..."
 ```
 
 Add a `Coverage` evaluator with a known-issue reference set to

--- a/packages/agentforge/src/agentforge/templates/triage/agentforge.yaml
+++ b/packages/agentforge/src/agentforge/templates/triage/agentforge.yaml
@@ -1,6 +1,7 @@
 agent:
   name: "{{ project_slug }}"
   model: "{% if llm_provider == 'bedrock' %}bedrock:us.anthropic.claude-haiku-4-5{% elif llm_provider == 'anthropic' %}anthropic:claude-haiku-4-5{% else %}openai:gpt-4o-mini{% endif %}"
+  strategy: "react"
   system_prompt: |
     You triage incoming issues / tickets / alerts. For each item
     emit a `SimpleFinding` with `severity` in

--- a/packages/agentforge/src/agentforge/templates/triage/pyproject.toml
+++ b/packages/agentforge/src/agentforge/templates/triage/pyproject.toml
@@ -5,10 +5,12 @@ description = "{{ description }}"
 requires-python = ">=3.13"
 dependencies = [
     "agentforge-py",
-{%- if llm_provider == 'bedrock' %}
-    "agentforge-bedrock",
-{%- endif %}
+    "agentforge-{{ llm_provider }}[{{ llm_provider }}]",
+    "python-dotenv>=1.0",
 ]
+
+[project.scripts]
+{{ project_slug }} = "{{ project_slug | replace('-', '_') }}.main:main"
 
 [build-system]
 requires = ["hatchling>=1.27"]

--- a/packages/agentforge/src/agentforge/templates/triage/src/{{project_slug.replace('-', '_')}}/main.py
+++ b/packages/agentforge/src/agentforge/templates/triage/src/{{project_slug.replace('-', '_')}}/main.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import asyncio
 import sys
 
+from dotenv import load_dotenv
+
 from agentforge import Agent
+
+load_dotenv()
 
 
 async def run_agent(item: str) -> str:
@@ -20,7 +24,7 @@ async def run_agent(item: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print('Usage: python -m {{ project_slug | replace("-", "_") }} "<item to triage>"')
+        print('Usage: {{ project_slug }} "<item to triage>"')
         sys.exit(1)
     output = asyncio.run(run_agent(" ".join(sys.argv[1:])))
     print(output)

--- a/packages/agentforge/tests/unit/test_new_cmd.py
+++ b/packages/agentforge/tests/unit/test_new_cmd.py
@@ -41,7 +41,12 @@ def test_minimal_template_renders_with_no_prompts(tmp_path: Path, capsys):
     main_py = (dst / "src" / "my_agent" / "main.py").read_text()
     # Templated path-imports + content rendered with the slug.
     assert "{{ project_slug" not in main_py
-    assert "my_agent" in main_py  # snake_case import path
+    assert "my-agent" in main_py  # kebab slug in the Usage hint
+
+    # The kebab→snake transform produces the right console-script
+    # entry point in pyproject.toml.
+    pyproject = (dst / "pyproject.toml").read_text()
+    assert "my_agent.main:main" in pyproject
 
     # Lock file + answers file are written by chunk 3
     # (`.agentforge-state/` plumbing).
@@ -169,3 +174,44 @@ def test_rendered_python_package_has_underscore_name(tmp_path: Path):
     )
     assert (dst / "src" / "my_pr_reviewer" / "__init__.py").exists()
     assert not (dst / "src" / "my-pr-reviewer").exists()
+
+
+def test_scaffold_resolves_runnable_end_to_end(tmp_path: Path):
+    """Regression for bugs 001, 002, 003, 006 — the scaffolded agent
+    must contain everything needed to run end-to-end after
+    ``uv sync`` + ``cp .env.example .env``. Together, these checks
+    lock in:
+
+    - bug-001: provider package + SDK extra in pyproject deps.
+    - bug-002: default reasoning strategy in agentforge.yaml.
+    - bug-003: console-script entry in pyproject [project.scripts].
+    - bug-006: load_dotenv() in main.py.
+    """
+    dst = tmp_path / "agent"
+    _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="minimal",
+            provider="anthropic",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+
+    pyproject = (dst / "pyproject.toml").read_text()
+    # bug-001 — provider's SDK extra reaches the agent's deps.
+    assert "agentforge-anthropic[anthropic]" in pyproject
+    # bug-006 — python-dotenv shipped so .env loading works.
+    assert "python-dotenv" in pyproject
+    # bug-003 — agent is invokable as a CLI command.
+    assert "[project.scripts]" in pyproject
+    assert "agent.main:main" in pyproject
+
+    # bug-002 — default reasoning strategy is wired.
+    cfg = yaml.safe_load((dst / "agentforge.yaml").read_text())
+    assert cfg["agent"].get("strategy"), "agentforge.yaml missing agent.strategy"
+
+    # bug-006 — main.py actually calls load_dotenv().
+    main_py = (dst / "src" / "agent" / "main.py").read_text()
+    assert "from dotenv import load_dotenv" in main_py
+    assert "load_dotenv()" in main_py

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ all = [
     { name = "agentforge-voyage" },
 ]
 anthropic = [
-    { name = "agentforge-anthropic" },
+    { name = "agentforge-anthropic", extra = ["anthropic"] },
 ]
 bedrock = [
     { name = "agentforge-bedrock" },
@@ -612,7 +612,7 @@ ollama = [
     { name = "agentforge-ollama" },
 ]
 openai = [
-    { name = "agentforge-openai" },
+    { name = "agentforge-openai", extra = ["openai"] },
 ]
 otel = [
     { name = "agentforge-otel" },
@@ -647,9 +647,9 @@ requires-dist = [
     { name = "agentforge-a2a", marker = "extra == 'a2a'", editable = "packages/agentforge-a2a" },
     { name = "agentforge-a2a", marker = "extra == 'all'", editable = "packages/agentforge-a2a" },
     { name = "agentforge-anthropic", marker = "extra == 'all'", editable = "packages/agentforge-anthropic" },
-    { name = "agentforge-anthropic", marker = "extra == 'anthropic'", editable = "packages/agentforge-anthropic" },
+    { name = "agentforge-anthropic", extras = ["anthropic"], marker = "extra == 'anthropic'", editable = "packages/agentforge-anthropic" },
     { name = "agentforge-bedrock", marker = "extra == 'all'", editable = "packages/agentforge-bedrock" },
-    { name = "agentforge-bedrock", marker = "extra == 'bedrock'", editable = "packages/agentforge-bedrock" },
+    { name = "agentforge-bedrock", extras = ["bedrock"], marker = "extra == 'bedrock'", editable = "packages/agentforge-bedrock" },
     { name = "agentforge-chat", marker = "extra == 'all'", editable = "packages/agentforge-chat" },
     { name = "agentforge-chat", marker = "extra == 'chat'", editable = "packages/agentforge-chat" },
     { name = "agentforge-chat-history-postgres", marker = "extra == 'all'", editable = "packages/agentforge-chat-history-postgres" },
@@ -690,7 +690,7 @@ requires-dist = [
     { name = "agentforge-ollama", marker = "extra == 'all'", editable = "packages/agentforge-ollama" },
     { name = "agentforge-ollama", marker = "extra == 'ollama'", editable = "packages/agentforge-ollama" },
     { name = "agentforge-openai", marker = "extra == 'all'", editable = "packages/agentforge-openai" },
-    { name = "agentforge-openai", marker = "extra == 'openai'", editable = "packages/agentforge-openai" },
+    { name = "agentforge-openai", extras = ["openai"], marker = "extra == 'openai'", editable = "packages/agentforge-openai" },
     { name = "agentforge-otel", marker = "extra == 'all'", editable = "packages/agentforge-otel" },
     { name = "agentforge-otel", marker = "extra == 'otel'", editable = "packages/agentforge-otel" },
     { name = "agentforge-phoenix", marker = "extra == 'all'", editable = "packages/agentforge-phoenix" },


### PR DESCRIPTION
## Summary

Six framework bugs surfaced when first-scaffolding the `code-reviewer` agent against v0.2.1 — everything between `agentforge new` and a working LLM API call was broken in some way. This PR documents all six in `docs/bugs/`, fixes them, and adds a regression test so they don't come back.

The agent is now scaffold-and-run-able end-to-end. The only step left to a working call after `uv sync` is providing a real API key in `.env`.

### Bugs fixed (all referenced in `docs/bugs/bug-NNN-*.md`)

| # | Severity | What | Where the fix lives |
|---|---|---|---|
| 001 | P0 | Scaffolded `pyproject.toml` missing provider package + SDK extra | All 6 template `pyproject.toml.tmpl`s + `agentforge-py` extras chain |
| 002 | P0 | Scaffolded `agentforge.yaml` missing required `agent.strategy` | 5 template yamls (research already had `plan-execute`) |
| 003 | P1 | Scaffold README says `python -m <pkg>` but no `__main__.py` ships | All 6 templates — `[project.scripts]` entry + README update |
| 004 | P2 | Stale `(when feat-002 ships)` in missing-strategy error | `agent.py:_resolve_strategy` |
| 005 | P2 | Error refers to `agentforge[<extra>]` but PyPI dist is `agentforge-py` | `__init__.py` docstring + `agent.py` error |
| 006 | P1 | Scaffold's `.env` not loaded by entry-point `main.py` | All 6 templates — `load_dotenv()` + `python-dotenv` dep |

### Templates changed (all 6)

- `pyproject.toml` — provider extra dep, dotenv dep, `[project.scripts]` entry
- `agentforge.yaml` — `strategy: \"react\"` default (5 of 6)
- `src/.../main.py` — `from dotenv import load_dotenv; load_dotenv()` + updated Usage hint
- `README.md` — `python -m <slug_snake>` → `uv run <slug>`

### Framework source changed

- `packages/agentforge/src/agentforge/agent.py:_resolve_strategy` — error rewrite (bug-004, bug-005).
- `packages/agentforge/src/agentforge/__init__.py` — docstring (bug-005).
- `packages/agentforge/pyproject.toml` — extras chain for `anthropic` / `openai` / `bedrock` now includes the provider's `[<sdk>]` extra (bug-001 bonus).

## Test plan

- [x] Pre-commit gate green (`uv run pre-commit run --all-files`) — ruff + mypy --strict + bandit + pytest + ≥ 90 % cov.
- [x] Re-scaffold from local templates: `uv run agentforge new test --template minimal --provider anthropic --no-prompts --dst /tmp/...`
- [x] `uv sync` lands `agentforge-anthropic`, `anthropic` (SDK), `python-dotenv`.
- [x] `uv run test \"hi\"` reaches the Anthropic SDK auth check — no `ModuleError` on missing provider, no missing-strategy error, no `python -m` failure.
- [x] New regression test `test_scaffold_resolves_runnable_end_to_end` asserts all four scaffold-side fixes (bug-001/002/003/006) hold.
- [ ] Reviewer eyeballs the rendered template tree on GitHub.
- [ ] After merge: cut v0.2.2 to ship the fixes to PyPI. Re-test by scaffolding via the **published** CLI (not the workspace one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)