### PR TITLE
chore(release): v0.2.2 — scaffold validation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-05-21
+
+Validation-fix release. First-time scaffold of the `code-reviewer`
+agent against published v0.2.1 surfaced six framework bugs —
+every step between `agentforge new` and a working LLM API call
+was broken in some way. v0.2.2 fixes all six and adds a
+regression test that locks in scaffolded-agent end-to-end
+runnability.
+
+No new features. No breaking changes. Existing v0.2.1 installs
+without scaffolded agents are unaffected.
+
+### Fixed
+
+- **bug-001 — Scaffolded `pyproject.toml` missing provider
+  package + SDK extra.** `agentforge new --provider <name>`
+  previously rendered `dependencies = ["agentforge-py"]` only,
+  leaving the user with `ModuleError: No LLM provider
+  registered` on the first run. Templates now declare
+  `"agentforge-{{ llm_provider }}[{{ llm_provider }}]"` so the
+  scaffold's `uv sync` lands both the framework wrapper and
+  the vendor SDK in one step. Affects all six templates.
+- **bug-002 — Scaffolded `agentforge.yaml` missing required
+  `agent.strategy`.** No default was wired, so every fresh
+  agent raised `ModuleError: No reasoning strategy provided`
+  on `Agent()` construction. All templates except `research`
+  (which already shipped `plan-execute`) now default to
+  `strategy: "react"`.
+- **bug-003 — Scaffold README documented `python -m <pkg>`
+  but no `__main__.py` shipped.** Replaced with a real CLI
+  entry via `[project.scripts] {{ slug }} = "{{ snake }}.main:main"`
+  in every template's `pyproject.toml`; READMEs updated to use
+  `uv run {{ slug }} "..."`. Cleaner, survives reinstall, and
+  matches how `agentforge` itself ships.
+- **bug-004 — Stale `(when feat-002 ships)` parenthetical** in
+  the missing-strategy error in `Agent._resolve_strategy`.
+  feat-002 (ReActLoop) has shipped; the error now points at
+  the current fix paths.
+- **bug-005 — Install hints referenced `agentforge[<extra>]`
+  but the PyPI distribution is `agentforge-py`.** `pip install
+  agentforge[react]` 404s. Fixed in `agentforge/__init__.py`
+  and `agentforge/agent.py`.
+- **bug-006 — Scaffolded `.env.example` → `.env` never
+  loaded.** Templates now ship `python-dotenv` as a dep and
+  call `load_dotenv()` at module load in `main.py`, so the
+  credentials the README walks users through actually reach
+  the provider SDK.
+
+### Changed
+
+- **`agentforge-py[<provider>]` extras chain to provider SDK
+  extras.** `pip install "agentforge-py[anthropic]"` now
+  resolves to `agentforge-anthropic[anthropic]` (i.e., the
+  `anthropic` SDK lands too), so the public install path
+  documented in the README is end-to-end runnable without
+  scaffolding. Applies to `anthropic`, `openai`, `bedrock`.
+  `ollama`, `litellm`, `voyage` bundle their SDK as a hard
+  dep and are unchanged.
+- **All 34 workspace members bumped to `0.2.2`.** Every
+  `__version__` constant updated. Cross-package pins
+  refreshed from `~= 0.2.1` to `~= 0.2.2`.
+
+### Added
+
+- **`docs/bugs/` directory** with a canonical bug-doc format
+  (status / severity / found-in / found-via + symptom /
+  reproduction / root cause / fix / verification). Seven docs:
+  `README.md` + `bug-001..006`. Institutional memory for the
+  validation findings.
+- **`test_scaffold_resolves_runnable_end_to_end`** regression
+  test in `packages/agentforge/tests/unit/test_new_cmd.py` —
+  locks in bug-001 / 002 / 003 / 006 fixes against future
+  template drift.
+
+### Notes
+
+Existing scaffolded agents on v0.2.1 should upgrade with
+`agentforge upgrade --to 0.2.2` to pull in the template
+fixes — managed files refresh, custom `<!-- agentforge:custom -->`
+sections survive.
+
 ## [0.2.1] — 2026-05-15
 
 First PyPI-published release. v0.2.0 was tagged but never

--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,161 @@
+# AgentForge v0.2.2 — Scaffold validation fixes
+
+First scaffolding-validation pass against published v0.2.1
+surfaced six framework bugs that combined to make every fresh
+`agentforge new` scaffold fail before the first LLM call.
+v0.2.2 fixes all six and locks in a regression guard.
+
+**No new features. No breaking changes.** Same 34 workspace
+packages, just polish on the scaffold + install path.
+
+---
+
+## Highlights
+
+- **`agentforge new` now scaffolds a runnable agent.** After
+  v0.2.2, the full developer arc is:
+
+  ```bash
+  pip install "agentforge-py[anthropic]==0.2.2"
+  agentforge new my-agent --template minimal --provider anthropic
+  cd my-agent && uv sync
+  cp .env.example .env       # add ANTHROPIC_API_KEY=…
+  uv run my-agent "Hi"
+  ```
+
+  No manual `uv add agentforge-anthropic[anthropic]`, no manual
+  `strategy:` patch to `agentforge.yaml`, no `python -m`
+  workaround, no missing `.env` loader.
+
+- **Public `pip install "agentforge-py[<provider>]"` path is
+  end-to-end runnable.** The optional extras now chain to the
+  provider's SDK extra, so a single `pip install` lands the
+  framework wrapper *and* the underlying vendor SDK. Applies to
+  `anthropic`, `openai`, `bedrock`; `ollama`, `litellm`,
+  `voyage` already shipped their SDK as a hard dep.
+
+- **Bug docs land.** New `docs/bugs/` directory adopts a
+  status / severity / repro / fix / verification format so
+  validation findings become institutional memory rather than
+  scattered postmortem.
+
+---
+
+## What's new
+
+### Fixed (six bugs — see `docs/bugs/bug-NNN-*.md` for the full write-ups)
+
+- **bug-001** — Scaffolded `pyproject.toml` now includes
+  `agentforge-{{ provider }}[{{ provider }}]` plus
+  `python-dotenv` so `uv sync` produces a runnable env.
+- **bug-002** — `agentforge.yaml` ships `strategy: "react"`
+  by default (research template stays on `plan-execute`).
+- **bug-003** — `[project.scripts]` entry in every template;
+  agent is invokable as `uv run <slug> "..."`.
+- **bug-004** — Stale `(when feat-002 ships)` removed from
+  the missing-strategy error; replaced with current guidance.
+- **bug-005** — `agentforge[<extra>]` install hints renamed
+  to `agentforge-py[<extra>]` (correct PyPI distribution).
+- **bug-006** — `main.py` calls `load_dotenv()` at module
+  load so credentials in `.env` reach the provider SDK.
+
+### Changed
+
+- **Extras chain.** `agentforge-py[anthropic|openai|bedrock]`
+  now resolves to `agentforge-<provider>[<sdk>]` (was just
+  `agentforge-<provider>`), so the SDK lands in the same
+  `pip install`.
+- **34 workspace packages bumped to `0.2.2`.** Cross-package
+  pins refreshed from `~= 0.2.1` to `~= 0.2.2`.
+
+### Added
+
+- `docs/bugs/` directory + 6 bug docs + bug-doc README.
+- `test_scaffold_resolves_runnable_end_to_end` regression test.
+
+---
+
+## Breaking changes
+
+None.
+
+---
+
+## Upgrade guide
+
+### From v0.2.1 — fresh install
+
+```bash
+pip install "agentforge-py[anthropic]==0.2.2"
+```
+
+### From v0.2.1 — existing scaffolded agent
+
+```bash
+cd my-agent
+agentforge upgrade --to 0.2.2
+uv sync     # picks up agentforge-<provider>[<sdk>] + python-dotenv
+```
+
+The upgrade hook three-way-merges the template fixes
+(`pyproject.toml`, `agentforge.yaml`, `main.py`, README) into
+your scaffold. `AGENTFORGE-MANAGED:` blocks refresh; any
+`<!-- agentforge:custom -->` sections you added survive.
+
+---
+
+## Coordinated release train
+
+Per ADR-0015, every framework release bumps every in-scope
+workspace package to the same minor version. v0.2.2 ships the
+same **34 packages** as v0.2.1, each at `0.2.2`, with
+cross-package pins refreshed to `~= 0.2.2`.
+
+---
+
+## Install / upgrade
+
+```bash
+# Fresh install
+pip install "agentforge-py[anthropic]==0.2.2"
+
+# From a scaffold
+agentforge new my-agent --template minimal --provider anthropic
+cd my-agent && uv sync
+cp .env.example .env       # add credentials
+uv run my-agent "Hi"
+
+# Upgrade an existing scaffolded agent
+agentforge upgrade --to 0.2.2
+```
+
+---
+
+## Acknowledgements
+
+Thanks to **kjoshi** — designer, implementer, reviewer.
+Generated with [Claude Code](https://claude.com/claude-code)
+(Anthropic) as the primary AI co-author per the
+`Co-Authored-By:` commit trailers.
+
+---
+
+## Full changelog
+
+- [`CHANGELOG.md`](../../CHANGELOG.md) — curated notes per
+  release.
+- `git log v0.2.1..v0.2.2 --oneline` — every commit in this
+  release.
+- Compare view:
+  [`Scaffoldic/agentforge-py/compare/v0.2.1...v0.2.2`](https://github.com/Scaffoldic/agentforge-py/compare/v0.2.1...v0.2.2).
+- GitHub Releases page:
+  [`Scaffoldic/agentforge-py/releases/tag/v0.2.2`](https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.2.2).
+- PyPI:
+  [`pypi.org/project/agentforge-py/0.2.2`](https://pypi.org/project/agentforge-py/0.2.2/).
+
+---
+
+## What's next
+
+v0.3 backlog unchanged — see
+[`docs/roadmap.md`](../roadmap.md).

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-a2a"
-version = "0.2.1"
+version = "0.2.2"
 description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-py ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-py ~= 0.2.2",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-anthropic/pyproject.toml
+++ b/packages/agentforge-anthropic/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-anthropic"
-version = "0.2.1"
+version = "0.2.2"
 description = "Anthropic native LLM provider for AgentForge — Claude with caching, extended thinking, streaming"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-anthropic/src/agentforge_anthropic/__init__.py
+++ b/packages/agentforge-anthropic/src/agentforge_anthropic/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from agentforge_anthropic._runner import AnthropicRunner
 from agentforge_anthropic.client import AnthropicClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "AnthropicClient",

--- a/packages/agentforge-bedrock/pyproject.toml
+++ b/packages/agentforge-bedrock/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-bedrock"
-version = "0.2.1"
+version = "0.2.2"
 description = "AWS Bedrock provider for AgentForge — Anthropic, Titan, Cohere on Bedrock"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "aioboto3>=13.0",
     "botocore>=1.35",
 ]

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/__init__.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from agentforge_bedrock.client import BedrockClient, accumulate_stream
 from agentforge_bedrock.embedding import BedrockEmbeddingClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "BedrockClient",

--- a/packages/agentforge-chat-history-postgres/pyproject.toml
+++ b/packages/agentforge-chat-history-postgres/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-history-postgres"
-version = "0.2.1"
+version = "0.2.2"
 description = "Postgres-backed ChatHistoryStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "asyncpg>=0.30",
 ]
 

--- a/packages/agentforge-chat-history-redis/pyproject.toml
+++ b/packages/agentforge-chat-history-redis/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-chat-history-redis"
-version = "0.2.1"
+version = "0.2.2"
 description = "Redis-backed ChatHistoryStore and SessionLock for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-chat ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-chat ~= 0.2.2",
     "redis>=5.0",
 ]
 

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-chat-http"
-version = "0.2.1"
+version = "0.2.2"
 description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,9 +24,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-py ~= 0.2.1",
-    "agentforge-chat ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-py ~= 0.2.2",
+    "agentforge-chat ~= 0.2.2",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-chat-slack/pyproject.toml
+++ b/packages/agentforge-chat-slack/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-slack"
-version = "0.2.1"
+version = "0.2.2"
 description = "Slack reference channel adapter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-chat ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-chat ~= 0.2.2",
     "slack-bolt>=1.20",
     "slack-sdk>=3.30",
 ]

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-chat"
-version = "0.2.1"
+version = "0.2.2"
 description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-py ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-py ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-core"
-version = "0.2.1"
+version = "0.2.2"
 description = "AgentForge core — stable contracts (ABCs, value types) for the agentic framework"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -124,7 +124,7 @@ from agentforge_core.values import (
     VectorMatch,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "OBSERVABILITY_SCOPE_NAME",

--- a/packages/agentforge-eval-geval/pyproject.toml
+++ b/packages/agentforge-eval-geval/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-eval-geval"
-version = "0.2.1"
+version = "0.2.2"
 description = "LLM-judge evaluators (G-Eval) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "PyYAML>=6.0",
 ]
 

--- a/packages/agentforge-evidently/pyproject.toml
+++ b/packages/agentforge-evidently/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-evidently"
-version = "0.2.1"
+version = "0.2.2"
 description = "Evidently AI metrics + drift hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-guard-llamaguard/pyproject.toml
+++ b/packages/agentforge-guard-llamaguard/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-llamaguard"
-version = "0.2.1"
+version = "0.2.2"
 description = "Llama Guard 3 classifier for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.1"]
+dependencies = ["agentforge-core ~= 0.2.2"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-llmguard/pyproject.toml
+++ b/packages/agentforge-guard-llmguard/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-llmguard"
-version = "0.2.1"
+version = "0.2.2"
 description = "LLM Guard scanners for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.urls]

--- a/packages/agentforge-guard-nemo/pyproject.toml
+++ b/packages/agentforge-guard-nemo/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-nemo"
-version = "0.2.1"
+version = "0.2.2"
 description = "NeMo Guardrails programmable rails for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.1"]
+dependencies = ["agentforge-core ~= 0.2.2"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-presidio/pyproject.toml
+++ b/packages/agentforge-guard-presidio/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-presidio"
-version = "0.2.1"
+version = "0.2.2"
 description = "Microsoft Presidio PII detector for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.urls]

--- a/packages/agentforge-langfuse/pyproject.toml
+++ b/packages/agentforge-langfuse/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-langfuse"
-version = "0.2.1"
+version = "0.2.2"
 description = "Langfuse trace dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/pyproject.toml
+++ b/packages/agentforge-litellm/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-litellm"
-version = "0.2.1"
+version = "0.2.2"
 description = "LiteLLM router-based LLM provider for AgentForge — 100+ underlying providers through one interface"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/src/agentforge_litellm/__init__.py
+++ b/packages/agentforge-litellm/src/agentforge_litellm/__init__.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 from agentforge_litellm._runner import LiteLLMRunner
 from agentforge_litellm.client import LiteLLMClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["LiteLLMClient", "LiteLLMRunner", "__version__"]

--- a/packages/agentforge-mcp/pyproject.toml
+++ b/packages/agentforge-mcp/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Model Context Protocol integration for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 # feat-013 v0.2: the `mcp` SDK is required only for the production

--- a/packages/agentforge-memory-neo4j/pyproject.toml
+++ b/packages/agentforge-memory-neo4j/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-memory-neo4j"
-version = "0.2.1"
+version = "0.2.2"
 description = "Neo4j-backed MemoryStore and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "neo4j>=5.20",
 ]
 

--- a/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/__init__.py
+++ b/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/__init__.py
@@ -13,7 +13,7 @@ from agentforge_memory_neo4j.graph import Neo4jGraphStore
 from agentforge_memory_neo4j.memory import Neo4jMemoryStore
 from agentforge_memory_neo4j.vector import Neo4jVectorStore
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "Neo4jGraphStore",

--- a/packages/agentforge-memory-postgres/pyproject.toml
+++ b/packages/agentforge-memory-postgres/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "agentforge-memory-postgres"
-version = "0.2.1"
+version = "0.2.2"
 description = "Postgres + pgvector-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "asyncpg>=0.30",
     "pgvector>=0.3",
 ]

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/__init__.py
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/__init__.py
@@ -14,6 +14,6 @@ from __future__ import annotations
 from agentforge_memory_postgres.memory import PostgresMemoryStore
 from agentforge_memory_postgres.vector import PostgresVectorStore
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["PostgresMemoryStore", "PostgresVectorStore", "__version__"]

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-memory-sqlite"
-version = "0.2.1"
+version = "0.2.2"
 description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "aiosqlite>=0.20",
 ]
 

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
@@ -12,6 +12,6 @@ from __future__ import annotations
 from agentforge_memory_sqlite.memory import SqliteMemoryStore
 from agentforge_memory_sqlite.vector import SqliteVectorStore
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["SqliteMemoryStore", "SqliteVectorStore", "__version__"]

--- a/packages/agentforge-memory-surrealdb/pyproject.toml
+++ b/packages/agentforge-memory-surrealdb/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "agentforge-memory-surrealdb"
-version = "0.2.1"
+version = "0.2.2"
 description = "SurrealDB-backed MemoryStore, VectorStore, and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "surrealdb>=1.0",
 ]
 

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/__init__.py
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/__init__.py
@@ -12,7 +12,7 @@ from agentforge_memory_surrealdb.graph import SurrealGraphStore
 from agentforge_memory_surrealdb.memory import SurrealMemoryStore
 from agentforge_memory_surrealdb.vector import SurrealVectorStore
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "SurrealGraphStore",

--- a/packages/agentforge-ollama/pyproject.toml
+++ b/packages/agentforge-ollama/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-ollama"
-version = "0.2.1"
+version = "0.2.2"
 description = "Ollama local LLM + embedding provider for AgentForge — llama / mistral / qwen / mxbai-embed on localhost"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-ollama/src/agentforge_ollama/__init__.py
+++ b/packages/agentforge-ollama/src/agentforge_ollama/__init__.py
@@ -6,7 +6,7 @@ from agentforge_ollama._runner import OllamaRunner
 from agentforge_ollama.client import OllamaClient
 from agentforge_ollama.embedding import OllamaEmbeddingClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "OllamaClient",

--- a/packages/agentforge-openai/pyproject.toml
+++ b/packages/agentforge-openai/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-openai"
-version = "0.2.1"
+version = "0.2.2"
 description = "OpenAI LLM + embeddings provider for AgentForge — gpt-4o / o-series + text-embedding-3-*"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-openai/src/agentforge_openai/__init__.py
+++ b/packages/agentforge-openai/src/agentforge_openai/__init__.py
@@ -6,7 +6,7 @@ from agentforge_openai._runner import OpenAIRunner
 from agentforge_openai.client import OpenAIClient
 from agentforge_openai.embedding import OpenAIEmbeddingClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "OpenAIClient",

--- a/packages/agentforge-otel/pyproject.toml
+++ b/packages/agentforge-otel/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-otel"
-version = "0.2.1"
+version = "0.2.2"
 description = "OpenTelemetry tracing + metrics emitter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-grpc>=1.27",
 ]

--- a/packages/agentforge-phoenix/pyproject.toml
+++ b/packages/agentforge-phoenix/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-phoenix"
-version = "0.2.1"
+version = "0.2.2"
 description = "Arize Phoenix dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-cohere/pyproject.toml
+++ b/packages/agentforge-reranker-cohere/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-reranker-cohere"
-version = "0.2.1"
+version = "0.2.2"
 description = "Cohere managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-mixedbread/pyproject.toml
+++ b/packages/agentforge-reranker-mixedbread/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.1"
+version = "0.2.2"
 description = "Mixedbread AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-sentence-transformers/pyproject.toml
+++ b/packages/agentforge-reranker-sentence-transformers/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.1"
+version = "0.2.2"
 description = "SentenceTransformers cross-encoder reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-voyage/pyproject.toml
+++ b/packages/agentforge-reranker-voyage/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-voyage"
-version = "0.2.1"
+version = "0.2.2"
 description = "Voyage AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-statsd/pyproject.toml
+++ b/packages/agentforge-statsd/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-statsd"
-version = "0.2.1"
+version = "0.2.2"
 description = "StatsD metrics emitter hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-testing/pyproject.toml
+++ b/packages/agentforge-testing/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-testing"
-version = "0.2.1"
+version = "0.2.2"
 description = "Richer test helpers for AgentForge (golden-set runner, snapshot, recording analysis)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
-    "agentforge-py ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
+    "agentforge-py ~= 0.2.2",
 ]
 
 [project.urls]

--- a/packages/agentforge-voyage/pyproject.toml
+++ b/packages/agentforge-voyage/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-voyage"
-version = "0.2.1"
+version = "0.2.2"
 description = "Voyage AI embedding provider for AgentForge — voyage-3 / voyage-large / voyage-code"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-voyage/src/agentforge_voyage/__init__.py
+++ b/packages/agentforge-voyage/src/agentforge_voyage/__init__.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 from agentforge_voyage._runner import VoyageRunner
 from agentforge_voyage.embedding import VoyageEmbeddingClient
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["VoyageEmbeddingClient", "VoyageRunner", "__version__"]

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "agentforge-py"
-version = "0.2.1"
+version = "0.2.2"
 description = "AgentForge — open-source plug-and-play framework for production AI agents"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.1",
+    "agentforge-core ~= 0.2.2",
     "pydantic>=2.10",
     "pyyaml>=6.0",
     "typer>=0.15",
@@ -60,93 +60,93 @@ dependencies = [
 # `pip install "agentforge-py[<provider>]"` lands both the framework
 # wrapper AND the underlying SDK. ollama / litellm bundle their SDK
 # as a hard dep, so no `[<sdk>]` extra is needed.
-anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.1"]
-openai = ["agentforge-openai[openai] ~= 0.2.1"]
-bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.1"]
-ollama = ["agentforge-ollama ~= 0.2.1"]
-litellm = ["agentforge-litellm ~= 0.2.1"]
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.2"]
+openai = ["agentforge-openai[openai] ~= 0.2.2"]
+bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.2"]
+ollama = ["agentforge-ollama ~= 0.2.2"]
+litellm = ["agentforge-litellm ~= 0.2.2"]
 
 # Embeddings
-voyage = ["agentforge-voyage ~= 0.2.1"]
+voyage = ["agentforge-voyage ~= 0.2.2"]
 
 # Memory backends
-memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.1"]
-memory-postgres = ["agentforge-memory-postgres ~= 0.2.1"]
-memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.1"]
-memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.1"]
+memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.2"]
+memory-postgres = ["agentforge-memory-postgres ~= 0.2.2"]
+memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.2"]
+memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.2"]
 
 # Chat surface
-chat = ["agentforge-chat ~= 0.2.1"]
-chat-http = ["agentforge-chat-http ~= 0.2.1"]
-chat-slack = ["agentforge-chat-slack ~= 0.2.1"]
-chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.1"]
-chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.1"]
+chat = ["agentforge-chat ~= 0.2.2"]
+chat-http = ["agentforge-chat-http ~= 0.2.2"]
+chat-slack = ["agentforge-chat-slack ~= 0.2.2"]
+chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.2"]
+chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.2"]
 
 # Rerankers
-reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.1"]
-reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.1"]
-reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.1"]
-reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.1"]
+reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.2"]
+reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.2"]
+reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.2"]
+reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.2"]
 
 # Guardrails
-guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.1"]
-guard-presidio = ["agentforge-guard-presidio ~= 0.2.1"]
-guard-nemo = ["agentforge-guard-nemo ~= 0.2.1"]
-guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.1"]
+guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.2"]
+guard-presidio = ["agentforge-guard-presidio ~= 0.2.2"]
+guard-nemo = ["agentforge-guard-nemo ~= 0.2.2"]
+guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.2"]
 
 # Observability
-langfuse = ["agentforge-langfuse ~= 0.2.1"]
-phoenix = ["agentforge-phoenix ~= 0.2.1"]
-otel = ["agentforge-otel ~= 0.2.1"]
-statsd = ["agentforge-statsd ~= 0.2.1"]
-evidently = ["agentforge-evidently ~= 0.2.1"]
+langfuse = ["agentforge-langfuse ~= 0.2.2"]
+phoenix = ["agentforge-phoenix ~= 0.2.2"]
+otel = ["agentforge-otel ~= 0.2.2"]
+statsd = ["agentforge-statsd ~= 0.2.2"]
+evidently = ["agentforge-evidently ~= 0.2.2"]
 
 # Protocols
-mcp = ["agentforge-mcp ~= 0.2.1"]
-a2a = ["agentforge-a2a ~= 0.2.1"]
+mcp = ["agentforge-mcp ~= 0.2.2"]
+a2a = ["agentforge-a2a ~= 0.2.2"]
 
 # Eval
-eval = ["agentforge-eval-geval ~= 0.2.1"]
+eval = ["agentforge-eval-geval ~= 0.2.2"]
 
 # Testing
-testing = ["agentforge-testing ~= 0.2.1"]
+testing = ["agentforge-testing ~= 0.2.2"]
 
 # Everything (development / docs / smoke-test convenience — not
 # recommended for production deploys; pick the actual integrations
 # you use to keep the dependency tree small).
 all = [
-    "agentforge-anthropic ~= 0.2.1",
-    "agentforge-openai ~= 0.2.1",
-    "agentforge-bedrock ~= 0.2.1",
-    "agentforge-ollama ~= 0.2.1",
-    "agentforge-litellm ~= 0.2.1",
-    "agentforge-voyage ~= 0.2.1",
-    "agentforge-memory-sqlite ~= 0.2.1",
-    "agentforge-memory-postgres ~= 0.2.1",
-    "agentforge-memory-neo4j ~= 0.2.1",
-    "agentforge-memory-surrealdb ~= 0.2.1",
-    "agentforge-chat ~= 0.2.1",
-    "agentforge-chat-http ~= 0.2.1",
-    "agentforge-chat-slack ~= 0.2.1",
-    "agentforge-chat-history-postgres ~= 0.2.1",
-    "agentforge-chat-history-redis ~= 0.2.1",
-    "agentforge-reranker-cohere ~= 0.2.1",
-    "agentforge-reranker-voyage ~= 0.2.1",
-    "agentforge-reranker-mixedbread ~= 0.2.1",
-    "agentforge-reranker-sentence-transformers ~= 0.2.1",
-    "agentforge-guard-llmguard ~= 0.2.1",
-    "agentforge-guard-presidio ~= 0.2.1",
-    "agentforge-guard-nemo ~= 0.2.1",
-    "agentforge-guard-llamaguard ~= 0.2.1",
-    "agentforge-langfuse ~= 0.2.1",
-    "agentforge-phoenix ~= 0.2.1",
-    "agentforge-otel ~= 0.2.1",
-    "agentforge-statsd ~= 0.2.1",
-    "agentforge-evidently ~= 0.2.1",
-    "agentforge-mcp ~= 0.2.1",
-    "agentforge-a2a ~= 0.2.1",
-    "agentforge-eval-geval ~= 0.2.1",
-    "agentforge-testing ~= 0.2.1",
+    "agentforge-anthropic ~= 0.2.2",
+    "agentforge-openai ~= 0.2.2",
+    "agentforge-bedrock ~= 0.2.2",
+    "agentforge-ollama ~= 0.2.2",
+    "agentforge-litellm ~= 0.2.2",
+    "agentforge-voyage ~= 0.2.2",
+    "agentforge-memory-sqlite ~= 0.2.2",
+    "agentforge-memory-postgres ~= 0.2.2",
+    "agentforge-memory-neo4j ~= 0.2.2",
+    "agentforge-memory-surrealdb ~= 0.2.2",
+    "agentforge-chat ~= 0.2.2",
+    "agentforge-chat-http ~= 0.2.2",
+    "agentforge-chat-slack ~= 0.2.2",
+    "agentforge-chat-history-postgres ~= 0.2.2",
+    "agentforge-chat-history-redis ~= 0.2.2",
+    "agentforge-reranker-cohere ~= 0.2.2",
+    "agentforge-reranker-voyage ~= 0.2.2",
+    "agentforge-reranker-mixedbread ~= 0.2.2",
+    "agentforge-reranker-sentence-transformers ~= 0.2.2",
+    "agentforge-guard-llmguard ~= 0.2.2",
+    "agentforge-guard-presidio ~= 0.2.2",
+    "agentforge-guard-nemo ~= 0.2.2",
+    "agentforge-guard-llamaguard ~= 0.2.2",
+    "agentforge-langfuse ~= 0.2.2",
+    "agentforge-phoenix ~= 0.2.2",
+    "agentforge-otel ~= 0.2.2",
+    "agentforge-statsd ~= 0.2.2",
+    "agentforge-evidently ~= 0.2.2",
+    "agentforge-mcp ~= 0.2.2",
+    "agentforge-a2a ~= 0.2.2",
+    "agentforge-eval-geval ~= 0.2.2",
+    "agentforge-testing ~= 0.2.2",
 ]
 
 [project.scripts]

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -69,7 +69,7 @@ from agentforge.strategies import (
     get_runtime,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "RUNTIME_KEY",

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ members = [
 
 [[package]]
 name = "agentforge-a2a"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-a2a" }
 dependencies = [
     { name = "agentforge-core" },
@@ -72,7 +72,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-anthropic"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-anthropic" }
 dependencies = [
     { name = "agentforge-core" },
@@ -92,7 +92,7 @@ provides-extras = ["anthropic"]
 
 [[package]]
 name = "agentforge-bedrock"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-bedrock" }
 dependencies = [
     { name = "agentforge-core" },
@@ -109,7 +109,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge-core" },
@@ -131,7 +131,7 @@ provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-chat-history-postgres"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-chat-history-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -146,7 +146,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-history-redis"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-chat-history-redis" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -163,7 +163,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-http"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-chat-http" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -186,7 +186,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-slack"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-chat-slack" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -205,7 +205,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-core"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-core" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -222,7 +222,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-eval-geval"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-eval-geval" }
 dependencies = [
     { name = "agentforge-core" },
@@ -237,7 +237,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-evidently"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-evidently" }
 dependencies = [
     { name = "agentforge-core" },
@@ -257,7 +257,7 @@ provides-extras = ["evidently"]
 
 [[package]]
 name = "agentforge-guard-llamaguard"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-guard-llamaguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -268,7 +268,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llmguard"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-guard-llmguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -279,7 +279,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-nemo"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-guard-nemo" }
 dependencies = [
     { name = "agentforge-core" },
@@ -290,7 +290,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-presidio"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-guard-presidio" }
 dependencies = [
     { name = "agentforge-core" },
@@ -301,7 +301,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-langfuse"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-langfuse" }
 dependencies = [
     { name = "agentforge-core" },
@@ -321,7 +321,7 @@ provides-extras = ["langfuse"]
 
 [[package]]
 name = "agentforge-litellm"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-litellm" }
 dependencies = [
     { name = "agentforge-core" },
@@ -341,7 +341,7 @@ provides-extras = ["litellm"]
 
 [[package]]
 name = "agentforge-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-mcp" }
 dependencies = [
     { name = "agentforge-core" },
@@ -361,7 +361,7 @@ provides-extras = ["mcp"]
 
 [[package]]
 name = "agentforge-memory-neo4j"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-memory-neo4j" }
 dependencies = [
     { name = "agentforge-core" },
@@ -376,7 +376,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-postgres"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-memory-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -393,7 +393,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-sqlite"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-memory-sqlite" }
 dependencies = [
     { name = "agentforge-core" },
@@ -408,7 +408,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-surrealdb"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-memory-surrealdb" }
 dependencies = [
     { name = "agentforge-core" },
@@ -423,7 +423,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-ollama"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-ollama" }
 dependencies = [
     { name = "agentforge-core" },
@@ -443,7 +443,7 @@ provides-extras = ["ollama"]
 
 [[package]]
 name = "agentforge-openai"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-openai" }
 dependencies = [
     { name = "agentforge-core" },
@@ -463,7 +463,7 @@ provides-extras = ["openai"]
 
 [[package]]
 name = "agentforge-otel"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-otel" }
 dependencies = [
     { name = "agentforge-core" },
@@ -480,7 +480,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-phoenix"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-phoenix" }
 dependencies = [
     { name = "agentforge-core" },
@@ -500,7 +500,7 @@ provides-extras = ["phoenix"]
 
 [[package]]
 name = "agentforge-py"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge" }
 dependencies = [
     { name = "agentforge-core" },
@@ -718,7 +718,7 @@ provides-extras = ["anthropic", "openai", "bedrock", "ollama", "litellm", "voyag
 
 [[package]]
 name = "agentforge-reranker-cohere"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-reranker-cohere" }
 dependencies = [
     { name = "agentforge-core" },
@@ -738,7 +738,7 @@ provides-extras = ["cohere"]
 
 [[package]]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-reranker-mixedbread" }
 dependencies = [
     { name = "agentforge-core" },
@@ -758,7 +758,7 @@ provides-extras = ["mixedbread"]
 
 [[package]]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-reranker-sentence-transformers" }
 dependencies = [
     { name = "agentforge-core" },
@@ -778,7 +778,7 @@ provides-extras = ["sentence-transformers"]
 
 [[package]]
 name = "agentforge-reranker-voyage"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-reranker-voyage" }
 dependencies = [
     { name = "agentforge-core" },
@@ -798,7 +798,7 @@ provides-extras = ["voyage"]
 
 [[package]]
 name = "agentforge-statsd"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-statsd" }
 dependencies = [
     { name = "agentforge-core" },
@@ -818,7 +818,7 @@ provides-extras = ["statsd"]
 
 [[package]]
 name = "agentforge-testing"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-testing" }
 dependencies = [
     { name = "agentforge-core" },
@@ -833,7 +833,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-voyage"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/agentforge-voyage" }
 dependencies = [
     { name = "agentforge-core" },


### PR DESCRIPTION
## Summary

Coordinated release-train bump to **0.2.2** (per ADR-0015). Ships the scaffold validation fixes landed in PR #53.

- **34 workspace packages** bumped to `0.2.2` (every `pyproject.toml` `version =` + every `__version__` constant).
- **Cross-package pins** refreshed from `~= 0.2.1` to `~= 0.2.2`.
- **`agentforge-py[<provider>]` extras chain** (added in PR #53) bumped — `~= 0.2.1` → `~= 0.2.2`.
- **`uv.lock`** re-resolved.
- **`CHANGELOG.md` + `docs/releases/v0.2.2.md`** ship curated release notes.

## What's in this release

Pure fix release — six bugs found via scaffolding-validation:

- bug-001: scaffold provider extra missing
- bug-002: scaffold `agent.strategy` missing
- bug-003: scaffold `python -m <pkg>` failed (no `__main__`)
- bug-004: stale "when feat-002 ships" error message
- bug-005: `agentforge[<extra>]` install hint should be `agentforge-py[<extra>]`
- bug-006: scaffold `.env` never loaded

All documented under `docs/bugs/bug-NNN-*.md`. Full release notes in `docs/releases/v0.2.2.md`.

## Test plan

- [x] Pre-commit gate green (ruff + mypy --strict + bandit + pytest + ≥ 90 % cov).
- [x] `uv sync` re-resolves cleanly with new versions.
- [x] No stale `0.2.1` strings remain in `packages/*/pyproject.toml`.
- [ ] Reviewer eyeballs the rendered CHANGELOG + release notes on GitHub.
- [ ] **After merge:** tag `v0.2.2` and run `release.yml`. The 8 already-on-PyPI packages publish v0.2.2 cleanly (no new-project quota). The remaining 26 still hit the daily quota — same drip-feed as v0.2.1 until admin grants quota increase.
- [ ] Smoke install once at least `agentforge-py`, `agentforge-core`, `agentforge-anthropic` land at 0.2.2:
  ```bash
  pip install "agentforge-py[anthropic]==0.2.2"
  agentforge new my-agent --template minimal --provider anthropic --no-prompts
  cd my-agent && uv sync && uv run my-agent "Hi"   # with key set
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)