### PR TITLE
fix(upgrade): bug-007 — agentforge upgrade now functional + v0.2.3 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-05-21
+
+Upgrade-flow fix. v0.2.2's scaffold fixes only reached new
+scaffolds — existing v0.2.x agents couldn't pull them via
+`agentforge upgrade` because the command was non-functional. Bug-007
+fixes both halves: `agentforge new` now persists the scaffold
+answers, and `agentforge upgrade` no longer depends on Copier's
+VCS-driven `run_update`.
+
+### Fixed
+
+- **bug-007 — `agentforge upgrade` was non-functional.**
+  - Part A: `agentforge new` did not persist
+    `.agentforge-state/answers.yml`. Copier's `_answers_file`
+    directive doesn't write reliably for in-package templates;
+    `new_cmd._run_new` now writes the file itself with the
+    resolved Copier answers (including a `_template_name`
+    discriminator the upgrade path uses).
+  - Part B: `upgrade_cmd._run_upgrade` previously called Copier's
+    `run_update`, which requires the template source to be
+    VCS-versioned. AgentForge's templates ship inside the
+    framework package, not as a separate git repo. The upgrade
+    now uses `run_copy` against a temp directory and copies each
+    non-forked managed file in place — refreshing hashes,
+    preserving forked entries, and adding files the new template
+    introduced.
+
+### Changed
+
+- **34 workspace packages bumped to `0.2.3`.** Cross-package
+  pins refreshed from `~= 0.2.2` to `~= 0.2.3`.
+
+### Added
+
+- `docs/bugs/bug-007-upgrade-non-functional.md` — full
+  reproduction + root-cause analysis for both halves of the bug.
+- Three new regression tests in
+  `packages/agentforge/tests/unit/test_scaffold_state.py`:
+  `test_new_writes_answers_yml`,
+  `test_upgrade_refreshes_managed_files`,
+  `test_upgrade_preserves_forked_files`.
+
+### Notes
+
+End-to-end validated against `agents/code-reviewer/` (an agent
+scaffolded under buggy v0.2.1 templates). `agentforge upgrade
+--to 0.2.3` cleanly pulled all six v0.2.2 scaffold fixes into the
+existing agent — `agentforge-anthropic[anthropic]` + dotenv in
+pyproject.toml, `strategy: "react"` in agentforge.yaml,
+`load_dotenv()` in main.py, `[project.scripts]` entry, README
+invocation — without touching any forked files or
+`<!-- agentforge:custom -->` blocks.
+
+The v0.4 spec-aligned migration (templates as a separate
+`agentforge-templates` git repo + Copier three-way merge for
+managed files) remains a v0.4 target. The v0.2.3 fix is a clean
+band-aid that makes the upgrade contract functional today.
+
 ## [0.2.2] — 2026-05-21
 
 Validation-fix release. First-time scaffold of the `code-reviewer`

--- a/docs/bugs/bug-007-upgrade-non-functional.md
+++ b/docs/bugs/bug-007-upgrade-non-functional.md
@@ -1,0 +1,184 @@
+---
+status: open
+severity: P0
+found-in: v0.2.2
+found-via: scaffold-upgrade validation, 2026-05-21
+---
+
+# bug-007 — `agentforge upgrade` is non-functional
+
+## Symptom
+
+The `agentforge upgrade` command always fails in v0.2.x:
+
+```bash
+$ agentforge upgrade --to 0.2.2
+No .agentforge-state/answers.yml; this directory wasn't scaffolded
+by `agentforge new`. Nothing to upgrade.
+```
+
+Even on agents that *were* scaffolded by `agentforge new`. Even if
+the user hand-writes `.agentforge-state/answers.yml`, the second
+failure mode is:
+
+```bash
+$ agentforge upgrade --to 0.2.2
+upgrade failed: copier update failed: Template not found
+```
+
+The command is documented as the migration path in the
+README, the `agentforge upgrade --help` output, the per-template
+scaffold READMEs, and the runbook
+`docs/runbooks/15-upgrade-your-agent.md`. None of them work today.
+
+## Reproduction
+
+```bash
+agentforge new my-agent --template minimal --provider anthropic --no-prompts
+cd my-agent
+ls .agentforge-state/                    # → only managed-files.lock, no answers.yml
+agentforge upgrade                       # → "Nothing to upgrade"
+
+# Hand-write answers.yml with minimum fields:
+cat > .agentforge-state/answers.yml <<EOF
+_commit: HEAD
+_src_path: $(python -c "from importlib import resources; print(resources.files('agentforge.templates').joinpath('minimal'))")
+project_slug: my-agent
+llm_provider: anthropic
+EOF
+
+agentforge upgrade --to 0.2.2            # → "copier update failed: Template not found"
+```
+
+## Root cause
+
+Two related problems, one architectural:
+
+### Part A — `agentforge new` does not write `answers.yml`
+
+`packages/agentforge/src/agentforge/cli/new_cmd.py:_run_new` calls
+`_run_copier` which invokes Copier's `run_copy`. Copier's
+`_answers_file` directive in each template's `copier.yml`
+(`_answers_file: ".agentforge-state/answers.yml"`) should cause
+Copier to write the resolved answers to that path. Empirically it
+does not, across multiple fresh scaffolds with
+`--no-prompts`.
+
+Even if Copier *did* write it reliably, the file would not be
+sufficient for `agentforge upgrade` because of Part B.
+
+### Part B — Copier's `run_update` requires a VCS-versioned template
+
+`packages/agentforge/src/agentforge/cli/upgrade_cmd.py:_run_copier_update`
+delegates to Copier's `run_update`. `run_update` performs a
+three-way merge by:
+
+1. Reading the recorded `_src_path` and `_commit` from
+   `answers.yml`.
+2. Doing a VCS checkout of the template at the recorded commit
+   (the "old" version).
+3. Doing a VCS checkout at the new version (`vcs_ref`).
+4. Three-way merging the diff into the destination.
+
+AgentForge ships templates **inside** the framework package at
+`packages/agentforge/src/agentforge/templates/<name>/`, not as a
+separate Copier-compatible git repo. The in-package directory is
+not VCS-traversable as a standalone template repository — Copier
+can't `git fetch` it at a specific ref because the templates
+aren't versioned at the granularity Copier expects.
+
+This is explicitly flagged in `new_cmd.py:4-7`:
+
+> *feat-011 ships six templates inside `agentforge/templates/<name>/`
+> (see Implementation status §4.4 — local templates instead of the
+> spec's separate-repo design; migration to `agentforge-templates`
+> is a 0.4+ follow-up).*
+
+So the in-package decision (v0.2 compromise) broke the upgrade
+path. The deferred `agentforge-templates` repo migration would
+fix Part B properly.
+
+## Fix
+
+Two-part fix landing in v0.2.3:
+
+### Part A — Write `answers.yml` ourselves in `_run_new`
+
+After `_run_copier`, write the resolved Copier answers to
+`.agentforge-state/answers.yml`. Include `_template_name` and the
+four template variables (`project_name`, `project_slug`,
+`llm_provider`, `description`) so the file is sufficient for
+later upgrade.
+
+### Part B — Replace `copier update` with a custom in-package upgrade
+
+In `upgrade_cmd.py:_run_upgrade`, drop the dependency on Copier's
+`run_update`. Instead:
+
+1. Read the saved answers.
+2. Resolve the template name → its filesystem path inside the
+   current framework install (via `importlib.resources` — same
+   helper as `agentforge new`).
+3. Render the template into a temp directory using the same
+   `run_copy` we use for fresh scaffolds.
+4. For each entry in the existing `managed-files.lock`:
+   - If forked → leave alone.
+   - Else → overwrite the file in-place from the temp render and
+     refresh the hash.
+5. For any file in the temp render that's *not* in the existing
+   lock → add it (new managed file introduced by the upgrade).
+6. Re-inject the shared scaffold (`_shared/` — runbooks +
+   AI-assistant rules) with the new framework version.
+7. Write the refreshed lock.
+
+This bypasses Copier's VCS requirement entirely. The trade-off:
+no three-way merge for managed files (a user-edited managed file
+is overwritten on upgrade — that's why we have `agentforge fork`).
+This matches the actual on-disk contract: managed files are
+framework-owned, custom edits should be in
+`<!-- agentforge:custom -->` blocks or in forked files.
+
+## Verification
+
+```bash
+# Fresh scaffold writes answers.yml.
+agentforge new test-agent --template minimal --provider anthropic --no-prompts
+cat test-agent/.agentforge-state/answers.yml         # should exist + have _template_name
+
+# Upgrade actually runs.
+cd test-agent
+agentforge upgrade --to 0.2.3                        # should succeed
+# Verify managed files got refreshed:
+diff <(agentforge status) <(...)                     # all "managed", no "drifted"
+```
+
+Add regression tests in `packages/agentforge/tests/unit/test_upgrade_cmd.py`:
+
+- `test_new_writes_answers_yml` — `agentforge new` persists
+  `_template_name` + the four template variables.
+- `test_upgrade_refreshes_managed_files` — scaffold an agent,
+  modify a managed-file template variable, run upgrade, assert
+  the change propagated.
+- `test_upgrade_preserves_forked_files` — fork a file, run
+  upgrade, assert the forked file's contents are untouched.
+
+## Why this matters
+
+`agentforge upgrade` is the **only** advertised migration path
+between AgentForge versions. Without it:
+
+- Users on v0.2.1 can't pull the bug-001–006 fixes into their
+  existing scaffolds without deleting and re-scaffolding (losing
+  any local code).
+- The "AGENTFORGE-MANAGED + AGENTFORGE-FORKED" file-ownership
+  contract is meaningless if upgrades can't actually refresh
+  managed files.
+- The 21 shipped runbooks promise an upgrade path that doesn't
+  exist.
+
+The in-package fix is intentionally a v0.2.x band-aid. The
+spec-aligned solution — `agentforge-templates` as a separate
+versioned repo + restoring Copier's three-way merge — remains a
+v0.4 target.
+
+Related: [[v0-2-1-pypi-publish-in-flight]].

--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -1,0 +1,160 @@
+# AgentForge v0.2.3 — Upgrade-flow fix
+
+v0.2.2 fixed the scaffold path so fresh `agentforge new` agents
+work end-to-end. But existing v0.2.x agents had no way to pull
+those fixes — `agentforge upgrade` was non-functional. v0.2.3
+fixes the upgrade path itself.
+
+**No new features. No breaking changes.** Same 34 workspace
+packages, same shipped surface as v0.2.2.
+
+---
+
+## Highlights
+
+- **`agentforge upgrade` actually works now.** Existing agents
+  scaffolded under v0.2.1 / v0.2.2 can pull the latest template
+  fixes into their managed files via a single command:
+
+  ```bash
+  cd my-agent
+  agentforge upgrade --to 0.2.3
+  ```
+
+  Managed files refresh; forked files are preserved; any new
+  managed files the upgraded template introduced get added.
+
+- **`agentforge new` now persists `.agentforge-state/answers.yml`.**
+  Previously empty / missing on every fresh scaffold — which is
+  why upgrade was unreachable in the first place.
+
+- **End-to-end validated against `agents/code-reviewer/`.** An
+  agent scaffolded under buggy v0.2.1 templates was upgraded to
+  v0.2.3 cleanly. All six v0.2.2 scaffold fixes propagated:
+  `agentforge-anthropic[anthropic]` + `python-dotenv` in
+  `pyproject.toml`, `strategy: "react"` in `agentforge.yaml`,
+  `load_dotenv()` in `main.py`, the `[project.scripts]` entry,
+  and the updated README invocation.
+
+---
+
+## What's new
+
+### Fixed — bug-007 (both halves)
+
+- **Part A — `agentforge new` doesn't persist scaffold answers.**
+  Copier's `_answers_file` directive is supposed to write
+  `.agentforge-state/answers.yml` after rendering, but doesn't
+  reliably for in-package templates. `agentforge new` now writes
+  the file itself with `_template_name` + the four resolved
+  template variables (`project_name`, `project_slug`,
+  `llm_provider`, `description`).
+- **Part B — `agentforge upgrade` failed with "Template not
+  found".** The previous implementation called Copier's
+  `run_update`, which expects the template source to be a
+  VCS-versioned git repo. AgentForge's templates live inside the
+  framework package (v0.2 compromise; the spec-aligned
+  `agentforge-templates` separate repo is a v0.4 target). v0.2.3
+  replaces `run_update` with a custom in-package upgrade that
+  renders to a temp directory via `run_copy` and copies each
+  non-forked managed file in place. Forked entries (set via
+  `agentforge fork`) are preserved; new template files are
+  added; the shared scaffold (`_shared/` — runbooks +
+  `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / Copilot
+  instructions) is re-injected so it tracks the new framework
+  version.
+
+### Changed
+
+- **34 workspace packages bumped to `0.2.3`.** Cross-package
+  pins refreshed from `~= 0.2.2` to `~= 0.2.3`.
+
+### Added
+
+- `docs/bugs/bug-007-upgrade-non-functional.md` — full
+  reproduction + root cause analysis + fix description.
+- Three regression tests in
+  `packages/agentforge/tests/unit/test_scaffold_state.py`:
+  - `test_new_writes_answers_yml`
+  - `test_upgrade_refreshes_managed_files`
+  - `test_upgrade_preserves_forked_files`
+
+---
+
+## Breaking changes
+
+None.
+
+---
+
+## Upgrade guide
+
+### From v0.2.2 — fresh install
+
+```bash
+pip install "agentforge-py[anthropic]==0.2.3"
+```
+
+### From v0.2.2 — existing scaffolded agent
+
+```bash
+cd my-agent
+agentforge upgrade --to 0.2.3
+uv sync
+```
+
+For agents scaffolded under **v0.2.1 or earlier** that pre-date
+the bug-007 fix: `.agentforge-state/answers.yml` is missing.
+Hand-write it before upgrade:
+
+```yaml
+# .agentforge-state/answers.yml
+_template_name: minimal   # or whichever template the agent was scaffolded from
+_template_version: 0.2.1
+project_name: My Agent
+project_slug: my-agent
+llm_provider: anthropic   # or bedrock / openai
+description: An AgentForge agent.
+```
+
+Then `agentforge upgrade --to 0.2.3` works as documented.
+
+---
+
+## Coordinated release train
+
+Per ADR-0015, every release bumps every in-scope workspace
+package to the same version. v0.2.3 ships the same 34 packages
+as v0.2.2 at `0.2.3` with cross-package pins refreshed.
+
+---
+
+## Acknowledgements
+
+Thanks to **kjoshi** — designer, implementer, reviewer.
+Generated with [Claude Code](https://claude.com/claude-code)
+(Anthropic) as the primary AI co-author per the
+`Co-Authored-By:` commit trailers.
+
+---
+
+## Full changelog
+
+- [`CHANGELOG.md`](../../CHANGELOG.md) — curated notes.
+- `git log v0.2.2..v0.2.3 --oneline` — every commit.
+- Compare view:
+  [`Scaffoldic/agentforge-py/compare/v0.2.2...v0.2.3`](https://github.com/Scaffoldic/agentforge-py/compare/v0.2.2...v0.2.3).
+- PyPI:
+  [`pypi.org/project/agentforge-py/0.2.3`](https://pypi.org/project/agentforge-py/0.2.3/).
+
+---
+
+## What's next
+
+v0.3 backlog unchanged — see
+[`docs/roadmap.md`](../roadmap.md). v0.4 candidate: the
+spec-aligned `agentforge-templates` separate-repo migration that
+restores Copier's three-way merge for managed files (today's
+v0.2.3 upgrade overwrites managed files wholesale instead of
+merging — relies on the `agentforge fork` flag to preserve
+user-edited files).

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-a2a"
-version = "0.2.2"
+version = "0.2.3"
 description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-py ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-py ~= 0.2.3",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-anthropic/pyproject.toml
+++ b/packages/agentforge-anthropic/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-anthropic"
-version = "0.2.2"
+version = "0.2.3"
 description = "Anthropic native LLM provider for AgentForge — Claude with caching, extended thinking, streaming"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-anthropic/src/agentforge_anthropic/__init__.py
+++ b/packages/agentforge-anthropic/src/agentforge_anthropic/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from agentforge_anthropic._runner import AnthropicRunner
 from agentforge_anthropic.client import AnthropicClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "AnthropicClient",

--- a/packages/agentforge-bedrock/pyproject.toml
+++ b/packages/agentforge-bedrock/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-bedrock"
-version = "0.2.2"
+version = "0.2.3"
 description = "AWS Bedrock provider for AgentForge — Anthropic, Titan, Cohere on Bedrock"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "aioboto3>=13.0",
     "botocore>=1.35",
 ]

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/__init__.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from agentforge_bedrock.client import BedrockClient, accumulate_stream
 from agentforge_bedrock.embedding import BedrockEmbeddingClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "BedrockClient",

--- a/packages/agentforge-chat-history-postgres/pyproject.toml
+++ b/packages/agentforge-chat-history-postgres/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-history-postgres"
-version = "0.2.2"
+version = "0.2.3"
 description = "Postgres-backed ChatHistoryStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "asyncpg>=0.30",
 ]
 

--- a/packages/agentforge-chat-history-redis/pyproject.toml
+++ b/packages/agentforge-chat-history-redis/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-chat-history-redis"
-version = "0.2.2"
+version = "0.2.3"
 description = "Redis-backed ChatHistoryStore and SessionLock for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-chat ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-chat ~= 0.2.3",
     "redis>=5.0",
 ]
 

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-chat-http"
-version = "0.2.2"
+version = "0.2.3"
 description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,9 +24,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-py ~= 0.2.2",
-    "agentforge-chat ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-py ~= 0.2.3",
+    "agentforge-chat ~= 0.2.3",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-chat-slack/pyproject.toml
+++ b/packages/agentforge-chat-slack/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-slack"
-version = "0.2.2"
+version = "0.2.3"
 description = "Slack reference channel adapter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-chat ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-chat ~= 0.2.3",
     "slack-bolt>=1.20",
     "slack-sdk>=3.30",
 ]

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-chat"
-version = "0.2.2"
+version = "0.2.3"
 description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-py ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-py ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-core"
-version = "0.2.2"
+version = "0.2.3"
 description = "AgentForge core — stable contracts (ABCs, value types) for the agentic framework"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -124,7 +124,7 @@ from agentforge_core.values import (
     VectorMatch,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "OBSERVABILITY_SCOPE_NAME",

--- a/packages/agentforge-eval-geval/pyproject.toml
+++ b/packages/agentforge-eval-geval/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-eval-geval"
-version = "0.2.2"
+version = "0.2.3"
 description = "LLM-judge evaluators (G-Eval) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "PyYAML>=6.0",
 ]
 

--- a/packages/agentforge-evidently/pyproject.toml
+++ b/packages/agentforge-evidently/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-evidently"
-version = "0.2.2"
+version = "0.2.3"
 description = "Evidently AI metrics + drift hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-guard-llamaguard/pyproject.toml
+++ b/packages/agentforge-guard-llamaguard/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-llamaguard"
-version = "0.2.2"
+version = "0.2.3"
 description = "Llama Guard 3 classifier for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.2"]
+dependencies = ["agentforge-core ~= 0.2.3"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-llmguard/pyproject.toml
+++ b/packages/agentforge-guard-llmguard/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-llmguard"
-version = "0.2.2"
+version = "0.2.3"
 description = "LLM Guard scanners for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.urls]

--- a/packages/agentforge-guard-nemo/pyproject.toml
+++ b/packages/agentforge-guard-nemo/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-nemo"
-version = "0.2.2"
+version = "0.2.3"
 description = "NeMo Guardrails programmable rails for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.2"]
+dependencies = ["agentforge-core ~= 0.2.3"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-presidio/pyproject.toml
+++ b/packages/agentforge-guard-presidio/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-presidio"
-version = "0.2.2"
+version = "0.2.3"
 description = "Microsoft Presidio PII detector for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.urls]

--- a/packages/agentforge-langfuse/pyproject.toml
+++ b/packages/agentforge-langfuse/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-langfuse"
-version = "0.2.2"
+version = "0.2.3"
 description = "Langfuse trace dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/pyproject.toml
+++ b/packages/agentforge-litellm/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-litellm"
-version = "0.2.2"
+version = "0.2.3"
 description = "LiteLLM router-based LLM provider for AgentForge — 100+ underlying providers through one interface"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/src/agentforge_litellm/__init__.py
+++ b/packages/agentforge-litellm/src/agentforge_litellm/__init__.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 from agentforge_litellm._runner import LiteLLMRunner
 from agentforge_litellm.client import LiteLLMClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["LiteLLMClient", "LiteLLMRunner", "__version__"]

--- a/packages/agentforge-mcp/pyproject.toml
+++ b/packages/agentforge-mcp/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "Model Context Protocol integration for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 # feat-013 v0.2: the `mcp` SDK is required only for the production

--- a/packages/agentforge-memory-neo4j/pyproject.toml
+++ b/packages/agentforge-memory-neo4j/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-memory-neo4j"
-version = "0.2.2"
+version = "0.2.3"
 description = "Neo4j-backed MemoryStore and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "neo4j>=5.20",
 ]
 

--- a/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/__init__.py
+++ b/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/__init__.py
@@ -13,7 +13,7 @@ from agentforge_memory_neo4j.graph import Neo4jGraphStore
 from agentforge_memory_neo4j.memory import Neo4jMemoryStore
 from agentforge_memory_neo4j.vector import Neo4jVectorStore
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "Neo4jGraphStore",

--- a/packages/agentforge-memory-postgres/pyproject.toml
+++ b/packages/agentforge-memory-postgres/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "agentforge-memory-postgres"
-version = "0.2.2"
+version = "0.2.3"
 description = "Postgres + pgvector-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "asyncpg>=0.30",
     "pgvector>=0.3",
 ]

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/__init__.py
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/__init__.py
@@ -14,6 +14,6 @@ from __future__ import annotations
 from agentforge_memory_postgres.memory import PostgresMemoryStore
 from agentforge_memory_postgres.vector import PostgresVectorStore
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["PostgresMemoryStore", "PostgresVectorStore", "__version__"]

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-memory-sqlite"
-version = "0.2.2"
+version = "0.2.3"
 description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "aiosqlite>=0.20",
 ]
 

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/__init__.py
@@ -12,6 +12,6 @@ from __future__ import annotations
 from agentforge_memory_sqlite.memory import SqliteMemoryStore
 from agentforge_memory_sqlite.vector import SqliteVectorStore
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["SqliteMemoryStore", "SqliteVectorStore", "__version__"]

--- a/packages/agentforge-memory-surrealdb/pyproject.toml
+++ b/packages/agentforge-memory-surrealdb/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "agentforge-memory-surrealdb"
-version = "0.2.2"
+version = "0.2.3"
 description = "SurrealDB-backed MemoryStore, VectorStore, and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "surrealdb>=1.0",
 ]
 

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/__init__.py
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/__init__.py
@@ -12,7 +12,7 @@ from agentforge_memory_surrealdb.graph import SurrealGraphStore
 from agentforge_memory_surrealdb.memory import SurrealMemoryStore
 from agentforge_memory_surrealdb.vector import SurrealVectorStore
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "SurrealGraphStore",

--- a/packages/agentforge-ollama/pyproject.toml
+++ b/packages/agentforge-ollama/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-ollama"
-version = "0.2.2"
+version = "0.2.3"
 description = "Ollama local LLM + embedding provider for AgentForge — llama / mistral / qwen / mxbai-embed on localhost"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-ollama/src/agentforge_ollama/__init__.py
+++ b/packages/agentforge-ollama/src/agentforge_ollama/__init__.py
@@ -6,7 +6,7 @@ from agentforge_ollama._runner import OllamaRunner
 from agentforge_ollama.client import OllamaClient
 from agentforge_ollama.embedding import OllamaEmbeddingClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "OllamaClient",

--- a/packages/agentforge-openai/pyproject.toml
+++ b/packages/agentforge-openai/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-openai"
-version = "0.2.2"
+version = "0.2.3"
 description = "OpenAI LLM + embeddings provider for AgentForge — gpt-4o / o-series + text-embedding-3-*"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-openai/src/agentforge_openai/__init__.py
+++ b/packages/agentforge-openai/src/agentforge_openai/__init__.py
@@ -6,7 +6,7 @@ from agentforge_openai._runner import OpenAIRunner
 from agentforge_openai.client import OpenAIClient
 from agentforge_openai.embedding import OpenAIEmbeddingClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "OpenAIClient",

--- a/packages/agentforge-otel/pyproject.toml
+++ b/packages/agentforge-otel/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-otel"
-version = "0.2.2"
+version = "0.2.3"
 description = "OpenTelemetry tracing + metrics emitter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-grpc>=1.27",
 ]

--- a/packages/agentforge-phoenix/pyproject.toml
+++ b/packages/agentforge-phoenix/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-phoenix"
-version = "0.2.2"
+version = "0.2.3"
 description = "Arize Phoenix dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-cohere/pyproject.toml
+++ b/packages/agentforge-reranker-cohere/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-reranker-cohere"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cohere managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-mixedbread/pyproject.toml
+++ b/packages/agentforge-reranker-mixedbread/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.2"
+version = "0.2.3"
 description = "Mixedbread AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-sentence-transformers/pyproject.toml
+++ b/packages/agentforge-reranker-sentence-transformers/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.2"
+version = "0.2.3"
 description = "SentenceTransformers cross-encoder reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-voyage/pyproject.toml
+++ b/packages/agentforge-reranker-voyage/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-voyage"
-version = "0.2.2"
+version = "0.2.3"
 description = "Voyage AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-statsd/pyproject.toml
+++ b/packages/agentforge-statsd/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-statsd"
-version = "0.2.2"
+version = "0.2.3"
 description = "StatsD metrics emitter hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-testing/pyproject.toml
+++ b/packages/agentforge-testing/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-testing"
-version = "0.2.2"
+version = "0.2.3"
 description = "Richer test helpers for AgentForge (golden-set runner, snapshot, recording analysis)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
-    "agentforge-py ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
+    "agentforge-py ~= 0.2.3",
 ]
 
 [project.urls]

--- a/packages/agentforge-voyage/pyproject.toml
+++ b/packages/agentforge-voyage/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-voyage"
-version = "0.2.2"
+version = "0.2.3"
 description = "Voyage AI embedding provider for AgentForge — voyage-3 / voyage-large / voyage-code"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-voyage/src/agentforge_voyage/__init__.py
+++ b/packages/agentforge-voyage/src/agentforge_voyage/__init__.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 from agentforge_voyage._runner import VoyageRunner
 from agentforge_voyage.embedding import VoyageEmbeddingClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["VoyageEmbeddingClient", "VoyageRunner", "__version__"]

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "agentforge-py"
-version = "0.2.2"
+version = "0.2.3"
 description = "AgentForge — open-source plug-and-play framework for production AI agents"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.2",
+    "agentforge-core ~= 0.2.3",
     "pydantic>=2.10",
     "pyyaml>=6.0",
     "typer>=0.15",
@@ -60,93 +60,93 @@ dependencies = [
 # `pip install "agentforge-py[<provider>]"` lands both the framework
 # wrapper AND the underlying SDK. ollama / litellm bundle their SDK
 # as a hard dep, so no `[<sdk>]` extra is needed.
-anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.2"]
-openai = ["agentforge-openai[openai] ~= 0.2.2"]
-bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.2"]
-ollama = ["agentforge-ollama ~= 0.2.2"]
-litellm = ["agentforge-litellm ~= 0.2.2"]
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.3"]
+openai = ["agentforge-openai[openai] ~= 0.2.3"]
+bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.3"]
+ollama = ["agentforge-ollama ~= 0.2.3"]
+litellm = ["agentforge-litellm ~= 0.2.3"]
 
 # Embeddings
-voyage = ["agentforge-voyage ~= 0.2.2"]
+voyage = ["agentforge-voyage ~= 0.2.3"]
 
 # Memory backends
-memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.2"]
-memory-postgres = ["agentforge-memory-postgres ~= 0.2.2"]
-memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.2"]
-memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.2"]
+memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.3"]
+memory-postgres = ["agentforge-memory-postgres ~= 0.2.3"]
+memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.3"]
+memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.3"]
 
 # Chat surface
-chat = ["agentforge-chat ~= 0.2.2"]
-chat-http = ["agentforge-chat-http ~= 0.2.2"]
-chat-slack = ["agentforge-chat-slack ~= 0.2.2"]
-chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.2"]
-chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.2"]
+chat = ["agentforge-chat ~= 0.2.3"]
+chat-http = ["agentforge-chat-http ~= 0.2.3"]
+chat-slack = ["agentforge-chat-slack ~= 0.2.3"]
+chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.3"]
+chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.3"]
 
 # Rerankers
-reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.2"]
-reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.2"]
-reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.2"]
-reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.2"]
+reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.3"]
+reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.3"]
+reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.3"]
+reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.3"]
 
 # Guardrails
-guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.2"]
-guard-presidio = ["agentforge-guard-presidio ~= 0.2.2"]
-guard-nemo = ["agentforge-guard-nemo ~= 0.2.2"]
-guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.2"]
+guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.3"]
+guard-presidio = ["agentforge-guard-presidio ~= 0.2.3"]
+guard-nemo = ["agentforge-guard-nemo ~= 0.2.3"]
+guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.3"]
 
 # Observability
-langfuse = ["agentforge-langfuse ~= 0.2.2"]
-phoenix = ["agentforge-phoenix ~= 0.2.2"]
-otel = ["agentforge-otel ~= 0.2.2"]
-statsd = ["agentforge-statsd ~= 0.2.2"]
-evidently = ["agentforge-evidently ~= 0.2.2"]
+langfuse = ["agentforge-langfuse ~= 0.2.3"]
+phoenix = ["agentforge-phoenix ~= 0.2.3"]
+otel = ["agentforge-otel ~= 0.2.3"]
+statsd = ["agentforge-statsd ~= 0.2.3"]
+evidently = ["agentforge-evidently ~= 0.2.3"]
 
 # Protocols
-mcp = ["agentforge-mcp ~= 0.2.2"]
-a2a = ["agentforge-a2a ~= 0.2.2"]
+mcp = ["agentforge-mcp ~= 0.2.3"]
+a2a = ["agentforge-a2a ~= 0.2.3"]
 
 # Eval
-eval = ["agentforge-eval-geval ~= 0.2.2"]
+eval = ["agentforge-eval-geval ~= 0.2.3"]
 
 # Testing
-testing = ["agentforge-testing ~= 0.2.2"]
+testing = ["agentforge-testing ~= 0.2.3"]
 
 # Everything (development / docs / smoke-test convenience — not
 # recommended for production deploys; pick the actual integrations
 # you use to keep the dependency tree small).
 all = [
-    "agentforge-anthropic ~= 0.2.2",
-    "agentforge-openai ~= 0.2.2",
-    "agentforge-bedrock ~= 0.2.2",
-    "agentforge-ollama ~= 0.2.2",
-    "agentforge-litellm ~= 0.2.2",
-    "agentforge-voyage ~= 0.2.2",
-    "agentforge-memory-sqlite ~= 0.2.2",
-    "agentforge-memory-postgres ~= 0.2.2",
-    "agentforge-memory-neo4j ~= 0.2.2",
-    "agentforge-memory-surrealdb ~= 0.2.2",
-    "agentforge-chat ~= 0.2.2",
-    "agentforge-chat-http ~= 0.2.2",
-    "agentforge-chat-slack ~= 0.2.2",
-    "agentforge-chat-history-postgres ~= 0.2.2",
-    "agentforge-chat-history-redis ~= 0.2.2",
-    "agentforge-reranker-cohere ~= 0.2.2",
-    "agentforge-reranker-voyage ~= 0.2.2",
-    "agentforge-reranker-mixedbread ~= 0.2.2",
-    "agentforge-reranker-sentence-transformers ~= 0.2.2",
-    "agentforge-guard-llmguard ~= 0.2.2",
-    "agentforge-guard-presidio ~= 0.2.2",
-    "agentforge-guard-nemo ~= 0.2.2",
-    "agentforge-guard-llamaguard ~= 0.2.2",
-    "agentforge-langfuse ~= 0.2.2",
-    "agentforge-phoenix ~= 0.2.2",
-    "agentforge-otel ~= 0.2.2",
-    "agentforge-statsd ~= 0.2.2",
-    "agentforge-evidently ~= 0.2.2",
-    "agentforge-mcp ~= 0.2.2",
-    "agentforge-a2a ~= 0.2.2",
-    "agentforge-eval-geval ~= 0.2.2",
-    "agentforge-testing ~= 0.2.2",
+    "agentforge-anthropic ~= 0.2.3",
+    "agentforge-openai ~= 0.2.3",
+    "agentforge-bedrock ~= 0.2.3",
+    "agentforge-ollama ~= 0.2.3",
+    "agentforge-litellm ~= 0.2.3",
+    "agentforge-voyage ~= 0.2.3",
+    "agentforge-memory-sqlite ~= 0.2.3",
+    "agentforge-memory-postgres ~= 0.2.3",
+    "agentforge-memory-neo4j ~= 0.2.3",
+    "agentforge-memory-surrealdb ~= 0.2.3",
+    "agentforge-chat ~= 0.2.3",
+    "agentforge-chat-http ~= 0.2.3",
+    "agentforge-chat-slack ~= 0.2.3",
+    "agentforge-chat-history-postgres ~= 0.2.3",
+    "agentforge-chat-history-redis ~= 0.2.3",
+    "agentforge-reranker-cohere ~= 0.2.3",
+    "agentforge-reranker-voyage ~= 0.2.3",
+    "agentforge-reranker-mixedbread ~= 0.2.3",
+    "agentforge-reranker-sentence-transformers ~= 0.2.3",
+    "agentforge-guard-llmguard ~= 0.2.3",
+    "agentforge-guard-presidio ~= 0.2.3",
+    "agentforge-guard-nemo ~= 0.2.3",
+    "agentforge-guard-llamaguard ~= 0.2.3",
+    "agentforge-langfuse ~= 0.2.3",
+    "agentforge-phoenix ~= 0.2.3",
+    "agentforge-otel ~= 0.2.3",
+    "agentforge-statsd ~= 0.2.3",
+    "agentforge-evidently ~= 0.2.3",
+    "agentforge-mcp ~= 0.2.3",
+    "agentforge-a2a ~= 0.2.3",
+    "agentforge-eval-geval ~= 0.2.3",
+    "agentforge-testing ~= 0.2.3",
 ]
 
 [project.scripts]

--- a/packages/agentforge/src/agentforge/__init__.py
+++ b/packages/agentforge/src/agentforge/__init__.py
@@ -69,7 +69,7 @@ from agentforge.strategies import (
     get_runtime,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "RUNTIME_KEY",

--- a/packages/agentforge/src/agentforge/cli/new_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/new_cmd.py
@@ -17,9 +17,11 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+import yaml
 from agentforge_core.production.exceptions import ModuleError
 
 from agentforge.cli._scaffold_state import (
+    answers_path,
     prepend_markers,
     write_managed_files_lock,
 )
@@ -98,6 +100,19 @@ def _run_new(args: argparse.Namespace) -> int:
     )
     prepend_markers(dst, template_name=args.template, template_version=template_version)
 
+    # bug-007 fix: persist the resolved scaffold answers ourselves.
+    # Copier's `_answers_file` directive doesn't write reliably for
+    # in-package templates; without `answers.yml`, `agentforge upgrade`
+    # has nothing to re-render from. Must precede inject_shared_scaffold
+    # because that step reads answers.yml for its Jinja context.
+    _write_answers_file(
+        dst,
+        template_name=args.template,
+        template_version=template_version,
+        project_slug=args.project_slug,
+        llm_provider=args.provider,
+    )
+
     # feat-019: inject shared runbooks + AGENTS.md / CLAUDE.md /
     # .cursorrules / .github/copilot-instructions.md into every
     # scaffolded agent.
@@ -111,6 +126,43 @@ def _run_new(args: argparse.Namespace) -> int:
 
     sys.stdout.write(f"  → done. Next: cd {args.project_slug} && uv sync\n")
     return 0
+
+
+def _write_answers_file(
+    dst: Path,
+    *,
+    template_name: str,
+    template_version: str,
+    project_slug: str,
+    llm_provider: str | None,
+) -> None:
+    """Persist scaffold answers for `agentforge upgrade` to re-render.
+
+    Copier's `_answers_file` directive in `copier.yml` is supposed to
+    write this automatically, but doesn't reliably for in-package
+    templates (bug-007). We write it ourselves with the minimum
+    fields the upgrade path needs: `_template_name` so we can resolve
+    the template root again, plus the four Copier variables
+    (`project_name`, `project_slug`, `llm_provider`, `description`)
+    so the re-render produces the same shape.
+    """
+    target = answers_path(dst)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    project_name = " ".join(word.capitalize() for word in project_slug.split("-"))
+    payload: dict[str, object] = {
+        "_template_name": template_name,
+        "_template_version": template_version,
+        "project_name": project_name,
+        "project_slug": project_slug,
+        "llm_provider": llm_provider or "bedrock",
+        "description": f"An AgentForge agent ({template_name}).",
+    }
+    target.write_text(
+        "# AgentForge scaffold answers — DO NOT EDIT MANUALLY.\n"
+        "# Used by `agentforge upgrade` to re-render managed template files.\n"
+        + yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
 
 
 def _template_version() -> str:

--- a/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import argparse
 import sys
+import tempfile
 from pathlib import Path
 
 import yaml
 from agentforge_core.production.exceptions import ModuleError
 
 from agentforge.cli._scaffold_state import (
+    _HASH_PREFIX_LEN,
+    _strip_marker_for_hash,
     answers_path,
     file_status,
     hash_content,
@@ -70,11 +73,18 @@ def _run_upgrade(
     *,
     cwd: Path | None = None,
 ) -> int:
-    """Run `copier update` against the linked template + refresh lock.
+    """Refresh framework-managed files from the current template.
 
-    Copier handles the three-way merge against the answer file's
-    recorded template-version. We only handle the lock refresh
-    afterwards.
+    The v0.2.x templates ship inside the framework package
+    (`agentforge/templates/<name>/`), not as a separate Copier-
+    versioned repo, so `copier update` can't do its usual VCS-driven
+    three-way merge (see bug-007). Instead we render the current
+    template into a temp directory with `run_copy`, then per the
+    existing `managed-files.lock` overwrite each non-forked managed
+    file in place. Forked files (via `agentforge fork`) are
+    preserved. New files introduced by the upgraded template are
+    added. The shared scaffold (`_shared/`) is re-injected so
+    runbooks + AI-assistant rules track the new framework version.
     """
     work_dir = cwd if cwd is not None else Path.cwd()
     if not answers_path(work_dir).exists():
@@ -84,55 +94,181 @@ def _run_upgrade(
         )
         return 1
 
+    answers = _read_answers(work_dir)
+    template_name = answers.pop("_template_name", None)
+    if not isinstance(template_name, str) or not template_name:
+        sys.stderr.write(
+            "answers.yml is missing `_template_name`. The file may pre-date the "
+            "bug-007 fix (v0.2.3) or have been hand-edited. Re-scaffold to "
+            "regenerate or add the field manually.\n"
+        )
+        return 1
+
+    from agentforge.cli.new_cmd import (  # noqa: PLC0415
+        _TEMPLATES,
+        _template_root,
+        _template_version,
+    )
+
+    template_root = _template_root(template_name)
+    if template_root is None:
+        sys.stderr.write(
+            f"Template {template_name!r} not shipped with this install. "
+            f"Known: {', '.join(_TEMPLATES)}.\n"
+        )
+        return 1
+
     if args.dry_run:
-        sys.stdout.write("  → dry-run: not actually running copier update\n")
+        sys.stdout.write(
+            f"  → dry-run: would re-render template {template_name!r} into this "
+            f"directory and refresh every non-forked managed file.\n"
+        )
         return 0
 
+    template_version = args.to if args.to else _template_version()
     try:
-        _run_copier_update(work_dir, to=args.to)
+        return _do_upgrade(
+            work_dir,
+            template_name=template_name,
+            template_root=template_root,
+            template_version=template_version,
+            answers=answers,
+        )
     except ModuleError as exc:
         sys.stderr.write(f"upgrade failed: {exc}\n")
         return 1
 
-    # Refresh the lock: re-hash every still-managed file against its
-    # new content. Forked entries stay flagged.
-    lock = read_lock(work_dir)
-    new_lock: dict[str, dict[str, object]] = {}
-    for rel, entry in lock.items():
-        path = work_dir / rel
-        if not path.exists():
-            continue
-        if entry.get("forked"):
-            new_lock[rel] = entry
-            continue
-        try:
-            content = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError):
-            new_lock[rel] = entry
-            continue
-        # Strip marker before hashing.
-        from agentforge.cli._scaffold_state import _strip_marker_for_hash  # noqa: PLC0415
 
-        body = _strip_marker_for_hash(content)
-        new_lock[rel] = {**entry, "hash": hash_content(body)}
+def _read_answers(work_dir: Path) -> dict[str, object]:
+    raw = yaml.safe_load(answers_path(work_dir).read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ModuleError("answers.yml must be a top-level mapping.")
+    return {str(k): v for k, v in raw.items()}
+
+
+def _do_upgrade(
+    work_dir: Path,
+    *,
+    template_name: str,
+    template_root: Path,
+    template_version: str,
+    answers: dict[str, object],
+) -> int:
+    """Render template → temp; copy each non-forked managed file
+    into work_dir; refresh lock; re-inject shared scaffold."""
+    from agentforge.cli._shared_scaffold import inject_shared_scaffold  # noqa: PLC0415
+    from agentforge.cli.new_cmd import _run_copier  # noqa: PLC0415
+
+    # Drop the leading-underscore Copier metadata keys from the answers
+    # we pass back to Copier — `_template_name` / `_template_version`
+    # are ours, not Copier's, and Copier rejects unknown leading-`_`
+    # keys.
+    copier_answers: dict[str, object] = {k: v for k, v in answers.items() if not k.startswith("_")}
+
+    old_lock = read_lock(work_dir)
+    new_lock: dict[str, dict[str, object]] = {}
+    refreshed: list[str] = []
+    forked_kept: list[str] = []
+    new_files: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="agentforge-upgrade-") as temp_str:
+        temp = Path(temp_str)
+        _run_copier(str(template_root), str(temp), copier_answers, defaults=True)
+
+        # Pass 1: refresh every file in the old lock.
+        for rel, entry in old_lock.items():
+            if entry.get("forked"):
+                new_lock[rel] = entry
+                forked_kept.append(rel)
+                continue
+            src = temp / rel
+            dst = work_dir / rel
+            if not src.exists():
+                # File was in scaffold but isn't in current template.
+                # Drop it from the new lock — `agentforge upgrade`
+                # treats template removals as "no longer managed".
+                continue
+            _write_with_marker(
+                dst,
+                src.read_text(encoding="utf-8"),
+                source_module=str(entry.get("source_module", f"template:{template_name}")),
+                source_version=template_version,
+            )
+            new_lock[rel] = {
+                **entry,
+                "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
+                "source_version": template_version,
+            }
+            refreshed.append(rel)
+
+        # Pass 2: add files in the new template that weren't in the
+        # old lock (template grew). Skip the state dir.
+        for src in temp.rglob("*"):
+            if not src.is_file():
+                continue
+            rel = str(src.relative_to(temp)).replace("\\", "/")
+            if rel in old_lock:
+                continue
+            if rel.startswith(".agentforge-state/"):
+                continue
+            dst = work_dir / rel
+            _write_with_marker(
+                dst,
+                src.read_text(encoding="utf-8"),
+                source_module=f"template:{template_name}",
+                source_version=template_version,
+            )
+            new_lock[rel] = {
+                "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
+                "source_module": f"template:{template_name}",
+                "source_version": template_version,
+                "forked": False,
+            }
+            new_files.append(rel)
+
     write_lock(work_dir, new_lock)
+
+    # Re-inject the shared scaffold (runbooks + AGENTS.md / CLAUDE.md /
+    # .cursorrules / copilot-instructions) so they track the new
+    # framework version.
+    shared = inject_shared_scaffold(
+        work_dir,
+        template_name=template_name,
+        template_version=template_version,
+    )
+
+    sys.stdout.write(
+        f"  → refreshed {len(refreshed)} managed files; preserved {len(forked_kept)} forked.\n"
+    )
+    if new_files:
+        max_preview = 3
+        preview = ", ".join(new_files[:max_preview])
+        if len(new_files) > max_preview:
+            preview += "…"
+        sys.stdout.write(f"  → added {len(new_files)} new managed files: {preview}\n")
+    sys.stdout.write(f"  → re-injected {shared} shared scaffold files.\n")
     sys.stdout.write("  → upgrade complete; lock refreshed.\n")
     return 0
 
 
-def _run_copier_update(cwd: Path, *, to: str | None) -> None:
-    from copier import run_update  # noqa: PLC0415
-
-    try:
-        run_update(
-            dst_path=str(cwd),
-            vcs_ref=to or "HEAD",
-            defaults=True,
-            overwrite=True,
-            quiet=False,
-        )
-    except Exception as exc:
-        raise ModuleError(f"copier update failed: {exc}") from exc
+def _write_with_marker(
+    dst: Path,
+    content: str,
+    *,
+    source_module: str,
+    source_version: str,
+) -> None:
+    """Write `content` to `dst`, prepending the AGENTFORGE-MANAGED
+    marker for the file's extension when applicable."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    marker = marker_for(
+        dst.suffix,
+        source_module,
+        source_version,
+        hash_content(content)[:_HASH_PREFIX_LEN],
+    )
+    body = (marker + "\n" + content) if marker else content
+    dst.write_text(body, encoding="utf-8")
 
 
 # ----------------------------------------------------------------------

--- a/packages/agentforge/tests/unit/test_scaffold_state.py
+++ b/packages/agentforge/tests/unit/test_scaffold_state.py
@@ -286,6 +286,9 @@ def test_status_empty_repo_handled(tmp_path: Path, capsys):
 
 
 def test_upgrade_dry_run_returns_zero(tmp_path: Path, capsys):
+    """`agentforge new` writes answers.yml (bug-007 fix), so dry-run
+    upgrade now works without the manual hand-write workaround the
+    test previously needed."""
     dst = tmp_path / "agent"
     _run_new(
         argparse.Namespace(
@@ -296,15 +299,101 @@ def test_upgrade_dry_run_returns_zero(tmp_path: Path, capsys):
             dst=dst,
         )
     )
-    # Write an answers.yml manually since Copier's auto-write isn't
-    # reliable for local-path templates.
-    (dst / ".agentforge-state").mkdir(parents=True, exist_ok=True)
-    (dst / ".agentforge-state" / "answers.yml").write_text(
-        yaml.safe_dump({"_src_path": "fake", "project_slug": "agent"})
-    )
     code = _run_upgrade(argparse.Namespace(to=None, dry_run=True), cwd=dst)
     assert code == 0
     assert "dry-run" in capsys.readouterr().out
+
+
+def test_new_writes_answers_yml(tmp_path: Path):
+    """Regression for bug-007 Part A — `agentforge new` must persist
+    `.agentforge-state/answers.yml` with the resolved template
+    answers, including `_template_name`, so `agentforge upgrade`
+    can re-render against the same template."""
+    dst = tmp_path / "agent"
+    _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="code-reviewer",
+            provider="anthropic",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+    answers_file = dst / ".agentforge-state" / "answers.yml"
+    assert answers_file.exists(), "answers.yml must be written by `agentforge new`"
+    answers = yaml.safe_load(answers_file.read_text())
+    assert answers["_template_name"] == "code-reviewer"
+    assert answers["project_slug"] == "agent"
+    assert answers["llm_provider"] == "anthropic"
+    assert "project_name" in answers
+    assert "description" in answers
+
+
+def test_upgrade_refreshes_managed_files(tmp_path: Path, capsys):
+    """Regression for bug-007 Part B — `agentforge upgrade` must
+    re-render the template and overwrite managed files in place.
+    We simulate a "drifted" managed file (user edited a managed
+    file), run upgrade, and assert the file is restored to its
+    template-rendered content."""
+    dst = tmp_path / "agent"
+    _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="minimal",
+            provider="anthropic",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+    # Drift: append junk to a managed file.
+    main_py = dst / "src" / "agent" / "main.py"
+    original = main_py.read_text()
+    main_py.write_text(original + "\n# user-added drift\n")
+    assert "drift" in main_py.read_text()
+
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+    assert code == 0, capsys.readouterr().err
+
+    # Drift was overwritten by the re-rendered template content.
+    assert "drift" not in main_py.read_text(), "upgrade must overwrite drifted managed files"
+    out = capsys.readouterr().out
+    assert "refreshed" in out
+    assert "upgrade complete" in out
+
+
+def test_upgrade_preserves_forked_files(tmp_path: Path):
+    """Regression for bug-007 Part B — `agentforge fork` flags a file
+    as developer-owned. `agentforge upgrade` must leave forked files
+    untouched, even if the template content would otherwise change."""
+    dst = tmp_path / "agent"
+    _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="minimal",
+            provider="anthropic",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+    main_py = dst / "src" / "agent" / "main.py"
+    custom = "# I forked this file; the framework must not touch it.\n"
+    # Flag the file as forked in the lock, then write custom content.
+    from agentforge.cli._scaffold_state import read_lock as _read_lock  # noqa: PLC0415
+    from agentforge.cli._scaffold_state import write_lock as _write_lock  # noqa: PLC0415
+
+    lock = _read_lock(dst)
+    rel = "src/agent/main.py"
+    assert rel in lock
+    lock[rel] = {**lock[rel], "forked": True}
+    _write_lock(dst, lock)
+    main_py.write_text(custom)
+
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+    assert code == 0
+
+    assert main_py.read_text() == custom, "forked file must survive upgrade"
+    lock_after = _read_lock(dst)
+    assert lock_after[rel].get("forked") is True, "forked flag must persist"
 
 
 def test_upgrade_without_answers_file_errors(tmp_path: Path, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ members = [
 
 [[package]]
 name = "agentforge-a2a"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-a2a" }
 dependencies = [
     { name = "agentforge-core" },
@@ -72,7 +72,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-anthropic"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-anthropic" }
 dependencies = [
     { name = "agentforge-core" },
@@ -92,7 +92,7 @@ provides-extras = ["anthropic"]
 
 [[package]]
 name = "agentforge-bedrock"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-bedrock" }
 dependencies = [
     { name = "agentforge-core" },
@@ -109,7 +109,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge-core" },
@@ -131,7 +131,7 @@ provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-chat-history-postgres"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-chat-history-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -146,7 +146,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-history-redis"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-chat-history-redis" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -163,7 +163,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-http"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-chat-http" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -186,7 +186,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-slack"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-chat-slack" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -205,7 +205,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-core"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-core" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -222,7 +222,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-eval-geval"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-eval-geval" }
 dependencies = [
     { name = "agentforge-core" },
@@ -237,7 +237,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-evidently"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-evidently" }
 dependencies = [
     { name = "agentforge-core" },
@@ -257,7 +257,7 @@ provides-extras = ["evidently"]
 
 [[package]]
 name = "agentforge-guard-llamaguard"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-guard-llamaguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -268,7 +268,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llmguard"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-guard-llmguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -279,7 +279,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-nemo"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-guard-nemo" }
 dependencies = [
     { name = "agentforge-core" },
@@ -290,7 +290,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-presidio"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-guard-presidio" }
 dependencies = [
     { name = "agentforge-core" },
@@ -301,7 +301,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-langfuse"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-langfuse" }
 dependencies = [
     { name = "agentforge-core" },
@@ -321,7 +321,7 @@ provides-extras = ["langfuse"]
 
 [[package]]
 name = "agentforge-litellm"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-litellm" }
 dependencies = [
     { name = "agentforge-core" },
@@ -341,7 +341,7 @@ provides-extras = ["litellm"]
 
 [[package]]
 name = "agentforge-mcp"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-mcp" }
 dependencies = [
     { name = "agentforge-core" },
@@ -361,7 +361,7 @@ provides-extras = ["mcp"]
 
 [[package]]
 name = "agentforge-memory-neo4j"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-memory-neo4j" }
 dependencies = [
     { name = "agentforge-core" },
@@ -376,7 +376,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-postgres"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-memory-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -393,7 +393,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-sqlite"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-memory-sqlite" }
 dependencies = [
     { name = "agentforge-core" },
@@ -408,7 +408,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-surrealdb"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-memory-surrealdb" }
 dependencies = [
     { name = "agentforge-core" },
@@ -423,7 +423,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-ollama"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-ollama" }
 dependencies = [
     { name = "agentforge-core" },
@@ -443,7 +443,7 @@ provides-extras = ["ollama"]
 
 [[package]]
 name = "agentforge-openai"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-openai" }
 dependencies = [
     { name = "agentforge-core" },
@@ -463,7 +463,7 @@ provides-extras = ["openai"]
 
 [[package]]
 name = "agentforge-otel"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-otel" }
 dependencies = [
     { name = "agentforge-core" },
@@ -480,7 +480,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-phoenix"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-phoenix" }
 dependencies = [
     { name = "agentforge-core" },
@@ -500,7 +500,7 @@ provides-extras = ["phoenix"]
 
 [[package]]
 name = "agentforge-py"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge" }
 dependencies = [
     { name = "agentforge-core" },
@@ -718,7 +718,7 @@ provides-extras = ["anthropic", "openai", "bedrock", "ollama", "litellm", "voyag
 
 [[package]]
 name = "agentforge-reranker-cohere"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-reranker-cohere" }
 dependencies = [
     { name = "agentforge-core" },
@@ -738,7 +738,7 @@ provides-extras = ["cohere"]
 
 [[package]]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-reranker-mixedbread" }
 dependencies = [
     { name = "agentforge-core" },
@@ -758,7 +758,7 @@ provides-extras = ["mixedbread"]
 
 [[package]]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-reranker-sentence-transformers" }
 dependencies = [
     { name = "agentforge-core" },
@@ -778,7 +778,7 @@ provides-extras = ["sentence-transformers"]
 
 [[package]]
 name = "agentforge-reranker-voyage"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-reranker-voyage" }
 dependencies = [
     { name = "agentforge-core" },
@@ -798,7 +798,7 @@ provides-extras = ["voyage"]
 
 [[package]]
 name = "agentforge-statsd"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-statsd" }
 dependencies = [
     { name = "agentforge-core" },
@@ -818,7 +818,7 @@ provides-extras = ["statsd"]
 
 [[package]]
 name = "agentforge-testing"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-testing" }
 dependencies = [
     { name = "agentforge-core" },
@@ -833,7 +833,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-voyage"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/agentforge-voyage" }
 dependencies = [
     { name = "agentforge-core" },


### PR DESCRIPTION
## Summary

Fixes **bug-007** — `agentforge upgrade` was non-functional in v0.2.x — and bumps the coordinated release train to **v0.2.3**.

**End-to-end validated** against `agents/code-reviewer/` (an agent scaffolded under buggy v0.2.1 templates). `agentforge upgrade --to 0.2.3` cleanly pulled every v0.2.2 scaffold fix into the existing agent — without touching forked files or `<!-- agentforge:custom -->` blocks.

## The bug (two-part, both P0)

| | Symptom | Root cause |
|---|---|---|
| **A** | `No .agentforge-state/answers.yml; this directory wasn't scaffolded by agentforge new` (even right after `agentforge new`) | Copier's `_answers_file` directive doesn't write reliably for in-package templates; `agentforge new` never persisted the file itself |
| **B** | `upgrade failed: copier update failed: Template not found` (even with a hand-written answers.yml) | `upgrade_cmd` called Copier's `run_update`, which requires the template source to be a VCS-versioned git repo. AgentForge ships templates inside the package — not Copier-compatible for updates |

Both halves discussed in `docs/bugs/bug-007-upgrade-non-functional.md`.

## The fix

- **`new_cmd._run_new`** now writes `.agentforge-state/answers.yml` itself after Copier renders. Includes `_template_name` + the four resolved Copier variables (`project_name`, `project_slug`, `llm_provider`, `description`).
- **`upgrade_cmd._run_upgrade`** replaces `run_update` with a custom in-package upgrade:
  1. Render template → temp dir via `run_copy`.
  2. For each entry in `managed-files.lock`: forked → leave alone; else → overwrite from temp.
  3. Add new template files not in the lock.
  4. Re-inject `_shared/` so runbooks + AI rules track the new framework version.

**Trade-off:** managed files are overwritten wholesale, not three-way-merged. That's why `agentforge fork` exists — flag a file as developer-owned. v0.4's planned `agentforge-templates` separate-repo migration will restore proper Copier three-way merging.

## Coordinated release train bump

- 34 packages: `version = "0.2.2"` → `"0.2.3"`
- 12 `__version__` constants refreshed
- Every `~= 0.2.2` cross-package pin → `~= 0.2.3`
- The extras chain (PR #53) carried through: `agentforge-anthropic[anthropic] ~= 0.2.3`
- `uv.lock` re-resolved
- `CHANGELOG.md` v0.2.3 section + `docs/releases/v0.2.3.md` shipped

## Test plan

- [x] **Three new regression tests** in `test_scaffold_state.py` (`test_new_writes_answers_yml`, `test_upgrade_refreshes_managed_files`, `test_upgrade_preserves_forked_files`).
- [x] **Existing dry-run test** simplified — the manual answers.yml workaround is no longer needed.
- [x] **Pre-commit gate** green (ruff + mypy --strict + bandit + pytest + ≥ 90 % cov).
- [x] **End-to-end upgrade** against `agents/code-reviewer/`: `agentforge upgrade --to 0.2.3` refreshed 7 managed files, re-injected 27 shared scaffold files, all 6 v0.2.2 scaffold fixes propagated into the existing agent. `uv run code-reviewer "hi"` then reached the Anthropic SDK auth check — no `ModuleError` anywhere.
- [ ] After merge: manually upload v0.2.3 wheels for the 8 already-on-PyPI packages (same one-by-one drip as v0.2.2 since the 26 remaining packages are still gated by the new-project quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)