### PR TITLE
docs: bug-008 + pre-release "tag is non-skippable" callout

### DIFF
--- a/.claude/checklists/pre-release.md
+++ b/.claude/checklists/pre-release.md
@@ -119,6 +119,32 @@ ticked.
 - [ ] Verify the GitHub Release page renders the notes
       correctly; attach any binary artefacts if applicable.
 
+> **Do NOT skip the tag + GitHub Release step even when PyPI
+> publishing is partial.** A common temptation when the
+> new-project quota (see
+> [`feedback_pypi_new_project_quota`](../../../.claude/projects/...))
+> means only a subset of the 34 packages can publish: skip
+> tagging so `release.yml` doesn't fire and 429 on the
+> unpublished ones. **Wrong.** `release.yml` is idempotent
+> (`skip-existing: true` on `pypa/gh-action-pypi-publish`); a
+> partial publish leaves no broken state and re-runs cleanly via
+> `gh workflow run release.yml --ref vX.Y.Z` once the quota
+> window resets. **Always tag**, always create the GitHub
+> Release. Skipping cascades into:
+>
+> - Missing GitHub Releases page for the version.
+> - No `git log vX.Y.0..vX.Y.Z` diff view between releases.
+> - `last_shipped` in `.claude/state/current.md` drifts away
+>   from PyPI reality.
+> - Future contributors can't reproduce which commit shipped
+>   what bytes to PyPI.
+>
+> Manually-uploaded wheels live on PyPI forever once uploaded;
+> the git tag is the only durable record of "commit X became
+> version Y". Bug-007 retro (v0.2.2/v0.2.3, 2026-05-21) shipped
+> *manually* without tags for two releases — recovery required
+> back-dating tags after the fact, which loses the trigger-an-on-time-release.yml-run benefit.
+
 ## 10. Post-release
 
 - [ ] PyPI: each workspace package built and uploaded

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -3,62 +3,92 @@ feature: null
 state: idle
 branch: main
 started_at: null
-last_milestone_at: 2026-05-15
-last_shipped: v0.2.0 — Drivers (PR #49 merged 2026-05-15; tag v0.2.0 pushed; GitHub Release published)
+last_milestone_at: 2026-05-21
+last_shipped: v0.2.3 — Upgrade-flow fix (bug-007) — PR #55 merged 2026-05-21; tag v0.2.3 pushed; GitHub Release published. 8 of 34 packages live on PyPI.
 blocker: null
 flags_for_user:
-  - "Branch protection on `main` still references old job name `Test (ubuntu-latest, Python 3.13)`. Update required status checks to `Test (Linux, Python 3.13)` from the split CI workflows."
-  - "PyPI publish for the 16 new packages (5 LLM providers + 4 reranker vendors + 4 observability backends + chat-history-postgres / -redis / -slack) — uv build + twine upload, or wait for CI publish automation."
+  - "26 of 34 packages still pending PyPI publish at v0.2.3 (blocked by daily new-project quota). Run `gh workflow run release.yml --ref v0.2.3` once per day until they all land, or until admin@pypi.org grants the quota-increase request."
+  - "v0.2.2 git tag is local-only (intentional — v0.2.3 supersedes). If a complete GitHub Releases history matters, push `git push origin v0.2.2` + `gh release create v0.2.2 --notes-file docs/releases/v0.2.2.md`. Note: pushing the tag triggers another `release.yml` run that burns a daily quota window without landing anything new."
+  - "PR #56 (docs only — bug-008 + pre-release tag callout) is open and ready to merge."
+  - "bug-008 queued for v0.2.4: `_template_version()` renders `0.0.0+unknown` because `importlib.metadata.version()` looks up the import name (`agentforge`) instead of the PyPI distribution name (`agentforge-py`). Cosmetic — affects marker headers and answers.yml, not functionality."
+  - "Production PyPI token still sitting in `~/.pypirc [pypi]` (one-time rescue path from 2026-05-20). Should be revoked on PyPI's web UI when convenient."
 ---
 
 ## Active feature
 
-**None.** v0.2.0 shipped 2026-05-15. Pick the next feature from
-the v0.3 backlog when ready.
+**None.** v0.2.3 shipped 2026-05-21. Pick the next item when
+ready — either drip the 26 pending packages, land bug-008 →
+v0.2.4, or move to the v0.3 backlog.
 
 ## Last shipped
 
-**v0.2.0 — Drivers** (2026-05-15)
+**v0.2.3 — Upgrade-flow fix (bug-007)** (2026-05-21)
 
-- Merge commit: `70d79c3` (PR #49).
-- Tag: `v0.2.0` annotated at the merge commit.
-- GitHub Release: <https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.2.0>.
-- Release notes file: `docs/releases/v0.2.0.md`.
-- 34 workspace packages at `0.2.0`; 16 new sister packages
-  introduced in this cycle.
-- Theme: every locked v0.1 ABC (`LLMClient`, `EmbeddingClient`,
-  `VectorStore`, `GraphStore`, `Reranker`, `Migrator`, chat
-  history) now has at least one shipped driver in tree. MCP +
-  A2A production runners live. Vendor observability backends
-  ship. AI-assistant scaffold now includes GitHub Copilot
-  alongside Claude Code / Cursor / Aider.
+- Merge commit: `f6f4fba` (PR #55).
+- Tag: `v0.2.3` annotated at the merge commit.
+- GitHub Release: <https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.2.3>.
+- Release notes file: `docs/releases/v0.2.3.md`.
+- 34 workspace packages at `0.2.3`; **8 of those live on PyPI**
+  (`agentforge-core`, `-py`, `-anthropic`, `-bedrock`, `-chat`,
+  `-a2a`, `-memory-sqlite`, `-testing`).
+- Theme: `agentforge upgrade` is functional again. Bug-007
+  was a P0 in two parts — `agentforge new` didn't persist
+  `answers.yml`, and `agentforge upgrade` delegated to Copier's
+  `run_update` which requires VCS-versioned templates. v0.2.3
+  fixes both — `new` writes the file itself; `upgrade` uses
+  `run_copy` against a temp dir then copies non-forked managed
+  files in place. End-to-end validated against
+  `agents/code-reviewer/`.
+
+### Previously this session (2026-05-21)
+
+- **v0.2.2 — Scaffold validation fixes (PR #53 + #54).** Six
+  framework bugs found by first-scaffolding `code-reviewer`
+  against published v0.2.1 — provider extra missing,
+  `agent.strategy` missing, no console script, `.env` not
+  loaded, stale "feat-002 ships" error, import vs distribution
+  name confusion. All fixed with a regression test that locks
+  in the scaffold contract.
 
 ### Previously
 
-- feat-020 v0.3 polish — sentence-window streaming guardrails
-  (PR #48 merged 2026-05-14).
-- feat-025 — Neo4jVectorStore + SurrealDB native lexical_search
-  (PR #47).
-- feat-024 v0.3 polish — parameterized migrations (PR #46).
-- feat-024 — Schema migrations framework (PR #45).
-- feat-023 — GraphRAG hybrid retrieval (PR #44).
-- feat-022 v0.2 follow-up — native hybrid for Postgres +
-  SQLite (PR #43).
-- feat-022 — BM25 + vector hybrid search (PR #42).
+- v0.2.1 — Publishable. PR #50 + #51 merged 2026-05-20; tag
+  v0.2.1 pushed. First 4 of 34 packages live on PyPI under the
+  new `agentforge-py` distribution name; 30 blocked by the
+  hidden PyPI new-project quota at the time.
+- v0.2.0 — Drivers. PR #49 merged 2026-05-15. Every locked v0.1
+  ABC got a working driver; 16 new sister packages introduced.
 
-## Next pick candidates (v0.3+)
+## Next pick candidates
 
-From `docs/roadmap.md` backlog:
+**Path 1 — Drip the 26 remaining packages to v0.2.3 on PyPI.**
+
+```bash
+gh workflow run release.yml --ref v0.2.3
+```
+
+Re-run daily until all 34 land. Each daily window ships ~4 new
+projects before hitting the quota wall. `skip-existing: true` on
+`pypa/gh-action-pypi-publish` keeps the run idempotent.
+
+**Path 2 — Land bug-008 + cut v0.2.4.**
+
+`docs/bugs/bug-008-*.md` describes the fix: `version("agentforge")`
+→ `version("agentforge-py")` in two call sites
+(`new_cmd._template_version`, `_shared_scaffold._framework_version`).
+~5 lines + a regression test. Bump version, manual upload for
+the 8.
+
+**Path 3 — v0.3 backlog.**
+
+From `docs/roadmap.md`:
 
 - `down` migrations / schema rollback (feat-024 v0.3+).
 - Native single-Cypher / SurrealQL graph-augmented retrieval
   inside Neo4j / SurrealDB (feat-023 sister-package follow-up).
-- Multi-cluster Redlock for `RedisSessionLock`
-  (feat-020 v0.3+).
-- True streaming-aware `stream-then-redact` (regex-inline
-  redaction without buffering) (feat-020 v0.3+).
-- Evidently real-time drift dashboards via Cloud
-  (feat-009 v0.3+).
+- Multi-cluster Redlock for `RedisSessionLock` (feat-020 v0.3+).
+- True streaming-aware `stream-then-redact` (feat-020 v0.3+).
+- Evidently real-time drift dashboards via Cloud (feat-009 v0.3+).
 - Optional eval sister packages (`-ragas` / `-deepeval` /
   `-toxicity` / `-codeexec`).
 - TypeScript port of the v0.2 surface (target: v0.4).
@@ -68,4 +98,5 @@ From `docs/roadmap.md` backlog:
 1. `AGENTS.md`
 2. `.claude/CLAUDE.md`
 3. `.claude/state/current.md` (this file)
-4. `docs/roadmap.md` to pick next feature
+4. `.claude/state/log.md` — the latest entry covers today's three releases + the pipeline-rule update
+5. `docs/roadmap.md` to pick next feature

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2736,3 +2736,71 @@ publish:**
    && git push origin v0.2.1`. The tag push triggers
    `release.yml`; approve the `pypi` environment when
    prompted; PyPI uploads 34 packages.
+
+---
+
+## 2026-05-21T13:42 — v0.2.3 shipped (bug-007 upgrade-flow fix)
+
+Three coordinated releases shipped today (v0.2.1 was tagged
+2026-05-20 with 4 packages live; today brought v0.2.2 + v0.2.3
+plus 4 more packages to the live set, total 8 of 34).
+
+**Bugs found + fixed via scaffold-and-upgrade validation:**
+
+- bug-001…006 (PR #53, v0.2.2) — scaffold path bugs. `agentforge
+  new` produced an agent that couldn't run end-to-end: provider
+  package not in deps, `agent.strategy` missing, no console
+  script, `.env` not loaded, stale error strings,
+  distribution-name drift in install hints.
+- bug-007 (PR #55, v0.2.3) — upgrade path bugs.
+  `agentforge new` didn't persist
+  `.agentforge-state/answers.yml`; `agentforge upgrade`
+  delegated to Copier's VCS-required `run_update`. Fixed both:
+  `new_cmd` writes answers ourselves, `upgrade_cmd` uses
+  `run_copy` against a temp dir + per-managed-file copy.
+
+**v0.2.3 sign-off state:**
+
+- 8 packages live on PyPI: `agentforge-core`, `-py`,
+  `-anthropic`, `-bedrock`, `-chat`, `-a2a`, `-memory-sqlite`,
+  `-testing`. Each upgraded via manual `uvx twine upload` for
+  v0.2.2 and v0.2.3 (existing-project version uploads — no
+  new-project quota).
+- 26 packages still pending. `release.yml` workflow fired on
+  v0.2.3 tag push but 429'd on the first new-project creation
+  (`agentforge-chat-history-postgres`). Daily quota window
+  already exhausted; tomorrow opens fresh. Path forward:
+  `gh workflow run release.yml --ref v0.2.3` daily.
+- v0.2.3 GitHub Release page live at
+  <https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.2.3>.
+- v0.2.2 git tag exists **locally only** (intentional —
+  v0.2.3 supersedes it; pushing it would trigger a redundant
+  `release.yml` run that re-burns the daily quota window).
+- bug-008 filed for v0.2.4 (cosmetic — `_template_version`
+  always renders `0.0.0+unknown` because
+  `importlib.metadata.version()` looks up the import name
+  instead of the PyPI distribution name).
+
+**Pipeline rule update:** `.claude/checklists/pre-release.md`
+§9 + `feedback_workflow` memory rule 9 now flag tag + GitHub
+Release as **non-skippable even when PyPI publishing is
+partial.** v0.2.2 was shipped without a tag (we skipped it
+to avoid burning the daily quota); recovery required
+back-dating the tag locally and surfacing the lesson here.
+`release.yml` is idempotent (`skip-existing: true`), so the
+fear was misplaced.
+
+**Files / commits / PRs:**
+
+- PR #53 — `chore/validate-via-code-reviewer-scaffold` — bugs
+  001-006 + regression test.
+- PR #54 — `chore/v0.2.2-release` — 34-package version bump,
+  CHANGELOG, `docs/releases/v0.2.2.md`.
+- PR #55 — `chore/v0.2.3-fix-bug-007-upgrade` — bug-007 fix +
+  three new regression tests + 34-package version bump,
+  CHANGELOG, `docs/releases/v0.2.3.md`.
+- PR #56 (open) — bug-008 doc + `pre-release.md §9` tag
+  callout. Doc-only.
+- 7 bug docs landed under `docs/bugs/`.
+- Two memory updates: `project_v02_cut_in_flight.md` (full
+  sign-off snapshot), `feedback_workflow.md` (tag-skip rule).

--- a/docs/bugs/bug-008-template-version-stale-distribution-name.md
+++ b/docs/bugs/bug-008-template-version-stale-distribution-name.md
@@ -1,0 +1,137 @@
+---
+status: open
+severity: P3
+found-in: v0.2.3
+found-via: post-bug-007 validation via published CLI, 2026-05-21
+---
+
+# bug-008 — `_template_version` always renders `0.0.0+unknown`
+
+## Symptom
+
+After `agentforge new` (v0.2.3 published), the scaffolded
+`.agentforge-state/answers.yml` contains:
+
+```yaml
+_template_version: 0.0.0+unknown
+```
+
+…regardless of the actually-installed framework version. Cosmetic
+only — the upgrade flow (bug-007 Part B) does not require this
+field — but it pollutes both the answers file and the
+`AGENTFORGE-MANAGED:` marker headers that key off
+`_template_version()`, e.g.
+
+```
+# AGENTFORGE-MANAGED: template:minimal@0.0.0+unknown hash:abcdef
+```
+
+Every freshly-scaffolded agent on the public PyPI install path
+ships markers that lie about which framework version produced
+them.
+
+## Reproduction
+
+```bash
+pip install "agentforge-py[anthropic]==0.2.3"
+agentforge new bug008-test --template minimal --provider anthropic --no-prompts
+cat bug008-test/.agentforge-state/answers.yml
+# → _template_version: 0.0.0+unknown   (should be 0.2.3)
+head -1 bug008-test/pyproject.toml
+# → # AGENTFORGE-MANAGED: template:minimal@0.0.0+unknown hash:...
+```
+
+## Root cause
+
+`packages/agentforge/src/agentforge/cli/new_cmd.py:_template_version`:
+
+```python
+def _template_version() -> str:
+    """Resolve the installed `agentforge` version — used as the
+    template's `source_version` in the lock file."""
+    from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
+
+    try:
+        return version("agentforge")
+    except PackageNotFoundError:  # pragma: no cover
+        return "0.0.0+unknown"
+```
+
+`importlib.metadata.version()` expects the **PyPI distribution
+name**, not the Python import name. AgentForge's import name is
+`agentforge`, but the PyPI distribution is `agentforge-py` (this
+rename shipped in v0.2.1 to dodge the squatted `agentforge` PyPI
+name owned by `DataBassGit/AgentForge`). So
+`version("agentforge")` raises `PackageNotFoundError` on every
+PyPI-installed venv and falls through to the unknown sentinel.
+
+For workspace-developer installs, the package is registered under
+its real distribution metadata (also `agentforge-py`), so the
+same lookup fails there too — but during dev, the
+`PackageNotFoundError` is silent because the
+`# pragma: no cover` block isn't exercised in tests.
+
+`_template_version` has at least one second caller:
+`packages/agentforge/src/agentforge/cli/_shared_scaffold.py:_framework_version`
+(same incorrect lookup, same fallback). Both should be fixed
+together.
+
+## Fix
+
+Look up by distribution name:
+
+```python
+def _template_version() -> str:
+    from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
+
+    try:
+        return version("agentforge-py")    # ← distribution name, not import name
+    except PackageNotFoundError:  # pragma: no cover
+        return "0.0.0+unknown"
+```
+
+Same edit in `_shared_scaffold._framework_version`. Both spots
+worth a `noqa` comment naming the rename so the next bot doesn't
+"fix" `"agentforge-py"` back to `"agentforge"` thinking it's a typo.
+
+## Verification
+
+```bash
+# After fix lands + republish:
+pip install "agentforge-py[anthropic]==0.2.4"
+agentforge new bug008-test --template minimal --provider anthropic --no-prompts
+grep "_template_version" bug008-test/.agentforge-state/answers.yml
+# → _template_version: 0.2.4
+head -1 bug008-test/pyproject.toml
+# → # AGENTFORGE-MANAGED: template:minimal@0.2.4 hash:...
+```
+
+Add a regression test in
+`packages/agentforge/tests/unit/test_new_cmd.py`:
+
+```python
+def test_scaffold_records_real_framework_version(tmp_path):
+    dst = tmp_path / "agent"
+    _run_new(...minimal scaffold...)
+    answers = yaml.safe_load((dst / ".agentforge-state" / "answers.yml").read_text())
+    assert answers["_template_version"] != "0.0.0+unknown"
+    # And matches actual installed agentforge-py version:
+    from importlib.metadata import version
+    assert answers["_template_version"] == version("agentforge-py")
+```
+
+## Why P3 (not higher)
+
+- Functional impact: zero. The upgrade flow (bug-007 fix) ignores
+  the field; `agentforge upgrade --to <version>` works regardless.
+- The lies in `AGENTFORGE-MANAGED:` marker headers are also
+  cosmetic — the lock file's `source_version` carries the same
+  string and would be wrong in lockstep, but neither downstream
+  consumer makes decisions off them in v0.2.x.
+- Will start to matter when the v0.4 `agentforge-templates`
+  separate-repo migration (per bug-007 doc) lands: the
+  `_template_version` will discriminate which version of the
+  templates rendered a given scaffold, and Copier's actual
+  three-way merge will rely on it.
+
+Fix in v0.2.4. Not a v0.2.3 hotfix.


### PR DESCRIPTION
## Summary

Two small doc adds following yesterday's v0.2.3 ship:

1. **`docs/bugs/bug-008-template-version-stale-distribution-name.md`** — `_template_version()` looks up the import name (`agentforge`) but the PyPI distribution is `agentforge-py`. Lookup fails → falls back to `0.0.0+unknown` → pollutes `AGENTFORGE-MANAGED:` markers and `answers.yml`. Cosmetic only (P3); fix scheduled for v0.2.4.
2. **`.claude/checklists/pre-release.md` §9** — adds a "Do NOT skip tag + GitHub Release even when PyPI publishing is partial" callout. Locks in the lesson from the v0.2.2/v0.2.3 retro: `release.yml` is idempotent (`skip-existing: true`), so the temptation to skip tagging when only some of the 34 packages can publish is a trap — recovery requires back-dating tags after the fact. The corresponding workflow-conventions memory rule has been updated in parallel.

No code changes. No version bump. Pure docs.

## Test plan

- [x] Pre-commit on touched files green.
- [x] Pytest + coverage gates green (unaffected — doc-only).
- [ ] Reviewer eyeballs the rendered Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)