### PR TITLE
docs: triage MCP/chat/config cluster (bug-012–020) + reclassify 016→enh-001

### DIFF
--- a/docs/bugs/bug-012-mcp-adapter-dot-separator-breaks-bedrock.md
+++ b/docs/bugs/bug-012-mcp-adapter-dot-separator-breaks-bedrock.md
@@ -1,0 +1,77 @@
+---
+status: open
+severity: P0
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-012 — `MCPToolAdapter` qualified name uses `.` separator → Bedrock rejects every MCP tool
+
+## Symptom
+
+Every Bedrock-backed agent with an MCP server attached fails on the first
+LLM call with `toolConfig.tools[i].member.toolSpec.name` validation error:
+
+```
+Bedrock validation: Value 'myserver.my_tool' at
+'toolConfig.tools.8.member.toolSpec.name' failed to satisfy constraint:
+Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
+```
+
+## Root cause
+
+`agentforge_mcp/adapter.py::build_adapter` (lines 33-46):
+
+```python
+qualified_name = f"{server_name}.{descriptor.name}"
+```
+
+The dot is illegal in Bedrock Converse tool names (regex
+`[a-zA-Z0-9_-]+`). Pattern bites every consumer using `bedrock:` provider.
+
+## Fix proposal
+
+Use a Bedrock-safe separator. Two options:
+
+1. `"__"` (double underscore) — keeps the disambiguation between
+   servers, stays legal under Bedrock + OpenAI tool-name rules.
+2. Single underscore (`"_"`) — simpler; risks collision if tools
+   already use `_`.
+
+Recommend option 1. Update the docstring and any callers that parse
+the qualified name.
+
+## Workaround
+
+Downstream consumers can monkey-patch `build_adapter` (and the cached
+re-export in `agentforge_mcp.client`) to drop or replace the separator.
+downstream consumers ship such a patch.
+
+## Framework-level vs derived-agent-level
+
+**Framework.** `build_adapter` is framework code that *owns* the
+construction of the public tool name, and it is the framework's own
+provider clients (`agentforge-{anthropic,openai,bedrock}/client.py`,
+which all emit `"name": t.name` verbatim — verified) that ship that name
+to provider APIs with a known charset constraint.
+
+- **Derived-agent test:** a consumer *cannot* fix this without
+  monkey-patching `build_adapter` and the cached re-export in
+  `agentforge_mcp.client` — i.e. reaching into framework internals. Fails
+  the test → framework defect.
+- **How the fix helps derived agents:** every consumer using `bedrock:`
+  (or any provider enforcing `[a-zA-Z0-9_-]`) gets working MCP tools with
+  zero monkey-patching, and the framework keeps its vendor-agnostic
+  promise — a name that works on one provider works on all of them.
+
+## Notes
+
+- See related **bug-020** (runtime doesn't wire the MCP bridge at all).
+  With bug-020 fixed but bug-012 unfixed, MCP is still unusable on
+  Bedrock. (The "bug-011" in an earlier draft referred to the wiring bug
+  before it was renumbered to bug-020.)
+- **Verified** to affect OpenAI / Anthropic-direct the same way — all
+  three provider clients pass `t.name` straight to the wire and each API
+  validates `^[a-zA-Z0-9_-]{1,64}$`. Bedrock is just where consumers hit
+  it first. See bug-017 for the cross-provider validator that catches
+  this class locally.

--- a/docs/bugs/bug-013-mcpserver-from-stdio-doesnt-auto-register-tools.md
+++ b/docs/bugs/bug-013-mcpserver-from-stdio-doesnt-auto-register-tools.md
@@ -1,0 +1,94 @@
+---
+status: open
+severity: P2
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+> **Severity revised P0 → P2 after source verification (2026-06-02).** The
+> orchestrated path is *not* affected: `MCPBridge.start()` already calls
+> `self._server.register_tools()` before serving (`bridge.py:77-79`). The
+> gap is only on the *raw factory* surface — a consumer who calls
+> `MCPServer.from_stdio(...)` directly (as the reporter did, building a
+> standalone MCP server) must call `register_tools()` themselves. This is
+> an API-ergonomics / docstring defect, not a broken behaviour.
+
+# bug-013 — `MCPServer.from_stdio` / `from_http` don't auto-call `register_tools` → `ListTools` returns empty
+
+## Symptom
+
+Server side: `MCPServer.from_stdio(tools=[...])` constructs the server
+holding the tool list internally (`self._tools`), but the underlying
+MCP runner is never told about them. Subsequent `ListToolsRequest`
+from any connected client returns an empty list.
+
+Symptom from the consumer's view (e.g. a downstream consumer MCP bridge):
+
+```
+[DEBUG mcp] bridge_tools=[] per_client={'<server>': []}
+```
+
+Even though our `mcp_server/server.py` constructs the server with 7
+tools (and logs `mcp_server_serve`).
+
+## Reproduction
+
+```python
+from agentforge_mcp import MCPServer
+from my_tools import build_all_tools  # returns a list of 7 Tool subclasses
+
+server = MCPServer.from_stdio(tools=build_all_tools(), server_name="my-mcp")
+await server.serve()
+# Connect a client; ListToolsRequest returns [].
+```
+
+## Root cause
+
+`agentforge_mcp/server.py`:
+
+- `from_stdio(...)` → `cls(tools=tools, runner=runner, allowed=allowed)`
+  → `__init__` does `self._tools = list(tools)`. **`runner.register_tool(...)` is never called.**
+- `register_tools()` is a separate public method on `MCPServer` that
+  walks `self._tools` and registers each via the runner. The consumer
+  must call it explicitly before `serve()`.
+
+This is undocumented in `from_stdio`'s docstring; the example pattern in
+tests and template `server.py` files spells out
+`server = MCPServer.from_stdio(tools=...); await server.serve()`,
+which silently produces a zero-tool server. (Note: there is no "runbook
+09" in the docs tree — docs are organised as `feat-NNN` specs; the
+reporter's reference to runbooks is from an assumed doc layout that does
+not exist here.)
+
+## Fix proposal
+
+Call `self.register_tools()` from the end of `from_stdio` / `from_http`
+classmethods, before returning the instance. `register_tools()` is
+already documented as allowlist-aware (skips disallowed names), so the
+call is safe to fold into construction.
+
+Or: rename the public method to `register_pending()` and call it from
+the constructor, leaving the explicit form for advanced use only.
+
+## Workaround
+
+After `MCPServer.from_stdio(...)`, call `server.register_tools()`
+manually before `await server.serve()`. the MCP server does this
+explicitly with a comment pointing at this bug.
+
+## Framework-level vs derived-agent-level
+
+**Framework (low severity).** The two-step factory contract is framework
+API shape, so the consumer can't make the public surface less
+foot-gunny without forking it. But the impact is bounded: anyone driving
+MCP through `MCPBridge` (the supported path) is unaffected because
+`start()` already registers tools.
+
+- **Derived-agent test:** the *workaround* (call `register_tools()`
+  yourself) is a one-liner in consumer code and doesn't touch framework
+  internals — which is why this is P2, not P0. The framework-level fix is
+  about removing the foot-gun, not unblocking a broken path.
+- **How the fix helps derived agents:** folding `register_tools()` into
+  `from_stdio`/`from_http` deletes a silent zero-tool-server failure mode
+  for every consumer who builds a standalone MCP server from the factory,
+  and aligns the raw-factory path with the bridge path's behaviour.

--- a/docs/bugs/bug-014-mcpbridge-fromconfig-asyncio-run-inside-loop.md
+++ b/docs/bugs/bug-014-mcpbridge-fromconfig-asyncio-run-inside-loop.md
@@ -1,0 +1,99 @@
+---
+status: open
+severity: P1
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-014 — `MCPBridge.from_config` uses `asyncio.run` internally → fails inside a running event loop
+
+## Symptom
+
+Calling `MCPBridge.from_config(...)` from inside an existing event
+loop (e.g. FastAPI's `lifespan`, an `asynccontextmanager`, or any
+async startup hook) raises:
+
+```
+RuntimeError: this event loop is already running.
+```
+
+Stack trace bottoms out at:
+
+```
+File ".../agentforge_mcp/bridge.py", line 147, in _await_sync
+    raise RuntimeError('this event loop is already running.')
+```
+
+## Root cause
+
+`MCPBridge.from_config` is a synchronous classmethod (`bridge.py:47`)
+that builds each `MCPServerClient` by calling the async
+`from_stdio` / `from_http` / `from_sse` classmethod and awaiting the
+result via `_await_sync`. **Verified:** `_await_sync` (`bridge.py:145`)
+is `asyncio.get_event_loop().run_until_complete(coro)` — not
+`asyncio.run` as the stack-trace excerpt above suggested, but it fails
+identically: `run_until_complete` raises `RuntimeError: this event loop
+is already running` whenever a loop is active on the thread. The whole
+sync path is `# pragma: no cover`, so it ships untested. (The bridge's
+own comment at `bridge.py:50-55` claims construction is "async-friendly"
+because the client factories "return synchronously" — they don't; they
+are `async def`.)
+
+The natural place to call `MCPBridge.from_config(...)` is during app
+startup. For any async runtime (FastAPI, Starlette, Litestar, AnyIO
+task groups, etc.), the startup hook itself runs inside the event loop —
+so `from_config` is unusable from the documented integration site.
+
+## Fix proposal
+
+Convert `MCPBridge.from_config` to an async classmethod:
+
+```python
+@classmethod
+async def from_config(cls, config: dict[str, Any]) -> MCPBridge:
+    clients = []
+    for entry in config.get("servers", []) or []:
+        clients.append(await _client_from_entry_async(entry))
+    server = _build_server_from_config(config) if config.get("expose") else None
+    return cls(clients=clients, server=server)
+```
+
+Or: keep `from_config` synchronous, but provide an
+`MCPBridge.from_config_async(...)` companion that's safe to call from
+inside a running loop. Less ergonomic but backwards-compatible.
+
+## Workaround
+
+Consumers build clients themselves via `await MCPServerClient.from_stdio(...)`
+inside their async startup hook, then pass them to `MCPBridge(clients=[...])`
+(the constructor is plain). a downstream consumer does this in
+`agent_factory.startup()`.
+
+## Framework-level vs derived-agent-level
+
+**Framework.** `from_config` is the framework's config-driven
+construction entry point, intended to be called from the (async) agent
+runtime once bug-020 wires it in. Driving a bridge from config while a
+loop is running will reliably raise.
+
+- **Derived-agent test:** the consumer's workaround (build clients
+  manually, pass to the plain `MCPBridge(clients=[...])` constructor)
+  works but bypasses the documented `from_config` entry point — i.e. it
+  only works *because* they're re-implementing the framework's job. Once
+  bug-020 lands, the framework itself would hit this, so it cannot be
+  pushed to consumers. Framework defect.
+- **How the fix helps derived agents:** an async `from_config` (or an
+  `await`-able lifecycle inside `start()`) lets every consumer wire MCP
+  by config from inside their existing async startup hook (FastAPI
+  `lifespan`, etc.) with no hand-rolled client construction.
+
+## Notes
+
+- **Couples with bug-020** (runtime doesn't wire `modules.protocols.mcp`).
+  Once bug-020 is fixed, the framework's own wiring is the first victim of
+  this bug — so 014 must be fixed *as part of* the 020 wiring, with bridge
+  construction async end-to-end. (Earlier drafts called the wiring bug
+  "bug-011" before it was renumbered to bug-020.)
+- Also affects `_client_from_entry` which does `str(entry["command"])`
+  on a list-typed YAML command — minor cosmetic, folding into the same
+  fix.

--- a/docs/bugs/bug-015-agentforge-mcp-missing-mcp-sdk-dependency.md
+++ b/docs/bugs/bug-015-agentforge-mcp-missing-mcp-sdk-dependency.md
@@ -1,0 +1,108 @@
+---
+status: open
+severity: P2
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-015 — `agentforge-py[mcp]` does not pull the `mcp` SDK (broken extra chain)
+
+> **Root cause corrected after source verification (2026-06-02).** The
+> original title ("`agentforge-mcp` does not declare the `mcp` SDK")
+> is **wrong**: `agentforge-mcp` *does* declare it — as the optional
+> `[mcp]` extra (`packages/agentforge-mcp/pyproject.toml:38`,
+> `mcp = ["mcp>=1.0,<2"]`), behind lazy imports by deliberate design (the
+> standard vendor-SDK lazy-import pattern; fakes inject runners in tests).
+> The real defect is the **meta-package extra chain** — see Root cause.
+
+## Symptom
+
+After `pip install agentforge-py[mcp]` or `pip install agentforge-mcp`,
+calling `MCPServerClient.from_stdio(...)` raises:
+
+```
+agentforge_core.production.exceptions.ModuleError:
+  mcp SDK is not installed. Install via `pip install mcp` to consume MCP servers.
+```
+
+The user followed runbook 09 to the letter; the install completed
+successfully; the framework's own `agentforge_mcp/client.py:137` does:
+
+```python
+from mcp import ClientSession  # ModuleNotFoundError: No module named 'mcp'
+```
+
+## Reproduction
+
+```bash
+uv venv .venv --python 3.13
+uv pip install "agentforge-py[mcp]"
+.venv/bin/python -c "from agentforge_mcp import MCPServerClient; import asyncio; \
+  asyncio.run(MCPServerClient.from_stdio(name='x', command='cat'))"
+# → ModuleError: mcp SDK is not installed
+```
+
+## Root cause
+
+The `mcp` SDK *is* declared, but as an extra on the leaf package
+(`agentforge-mcp[mcp]`). The meta-package's own `mcp` extra does **not**
+chain it:
+
+```toml
+# packages/agentforge/pyproject.toml:105
+mcp = ["agentforge-mcp ~= 0.2.4"]          # ← pulls the package, NOT its [mcp] extra
+```
+
+So `pip install agentforge-py[mcp]` installs `agentforge-mcp` *without*
+its `[mcp]` extra, the upstream `mcp` SDK never lands, and the lazy
+import in `client.py:137` raises the friendly `ModuleError` at runtime.
+The error message itself points at `pip install mcp` rather than the
+canonical `agentforge-mcp[mcp]`, compounding the confusion. (There is no
+"runbook 09"; docs are `feat-NNN` specs.)
+
+## Fix proposal
+
+One-line fix in the meta package — chain the extra so the SDK installs
+with the documented one-liner:
+
+```toml
+# packages/agentforge/pyproject.toml
+mcp = ["agentforge-mcp[mcp] ~= 0.2.4"]
+```
+
+Also update the `ModuleError` text in `_build_stdio_runner` /
+`client.py` to recommend `pip install "agentforge-mcp[mcp]"` (or
+`agentforge-py[mcp]` once chained) instead of bare `pip install mcp`.
+Do **not** make `mcp` a hard dependency of `agentforge-mcp` — the lazy
+optional-extra design is intentional and lets the test suite inject fake
+runners without the SDK.
+
+## Workaround
+
+Consumers install `agentforge-mcp[mcp]` explicitly (or add `mcp >= 1.0`
+to their own `pyproject.toml`). a downstream consumer ships this with a
+comment pointing at this bug.
+
+## Framework-level vs derived-agent-level
+
+**Framework (packaging).** The framework *documents* and *advertises*
+the `agentforge-py[mcp]` install path, so the framework owns making that
+path actually deliver a working MCP runtime.
+
+- **Derived-agent test:** a consumer can work around it in one line, but
+  they shouldn't have to discover that the framework's own advertised
+  extra is incomplete. The fix lives in framework `pyproject.toml`, not
+  consumer code → framework defect.
+- **How the fix helps derived agents:** `pip install
+  "agentforge-py[mcp]"` works as documented — the plug-and-play install
+  promise holds instead of failing at first MCP call.
+
+## Notes
+
+- The friendly `ModuleError` is good and should stay — only its
+  suggested command needs updating to `agentforge-mcp[mcp]`.
+- **Audit the other vendor-SDK modules** for the same broken-chain
+  pattern: any meta-package extra of the form `X = ["agentforge-X ~= ..."]`
+  that should be `["agentforge-X[vendor] ~= ..."]`. Candidates with
+  optional SDK extras: `agentforge-langfuse`, `agentforge-phoenix`,
+  `agentforge-a2a`, etc. Worth a one-pass sweep during the fix.

--- a/docs/bugs/bug-017-bedrock-tool-name-regex-undocumented.md
+++ b/docs/bugs/bug-017-bedrock-tool-name-regex-undocumented.md
@@ -1,0 +1,105 @@
+---
+status: open
+severity: P2
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-017 — Bedrock's tool-name regex `[a-zA-Z0-9_-]+` is undocumented in the framework
+
+## Symptom
+
+Naming tools or MCP servers with dots, slashes, colons, or any
+character outside `[a-zA-Z0-9_-]` produces a runtime validation error
+from Bedrock on the first LLM call:
+
+```
+ProviderError: Bedrock validation: Value 'kb.search' at
+'toolConfig.tools.<i>.member.toolSpec.name' failed to satisfy
+constraint: Member must satisfy regular expression pattern:
+[a-zA-Z0-9_-]+
+```
+
+The constraint comes from AWS Bedrock Converse, not the framework —
+but no docstring, no runbook, no template README mentions it. Every
+consumer who picks expressive tool names (`kb.search`, `metadata.list`,
+`questions.generate`) hits this on day 1 with the Bedrock provider.
+
+## Why this is a framework concern (not just AWS docs)
+
+- The framework's MCP adapter joins server + tool with `.` (bug-012),
+  which is silently illegal on Bedrock. Consumers who follow runbook
+  09 with the Bedrock provider hit this without writing any
+  illegally-named tool themselves.
+- Other providers may not validate as strictly. Tools that work in
+  CI tests (mocked LLM client) and prod with Anthropic-direct will
+  break the moment a consumer swaps `model:` to `bedrock:`. Silent
+  vendor-swap regression is exactly what "vendor-agnostic providers"
+  is supposed to prevent.
+
+## Fix proposal
+
+Two layers of defense:
+
+1. **Document the regex.** (Note: the runbooks the original draft
+   referenced — "02 Add a tool", "09 Add MCP servers", "13 multi-provider"
+   — **do not exist**; the docs tree is organised as `feat-NNN` specs,
+   ADRs, and design docs, with no runbook directory.) Document the
+   constraint where tool/provider naming actually lives:
+   - feat-004 (tools system) spec + the `@tool` decorator docstring
+   - feat-003 (LLM provider abstraction) spec, as a cross-provider gotcha
+   - feat-013 (MCP) spec, since server + tool names both feed the
+     qualified name (bug-012)
+   - the scaffold templates' README where tool naming is shown
+2. **Add a defensive validator** in the framework's Bedrock provider:
+   when constructing `_build_converse_request`, scan all tool specs
+   and raise a clear `BedrockToolNameInvalid("name 'X' does not match
+   pattern [a-zA-Z0-9_-]+; valid sample: 'kb_search'")` error before
+   the request leaves the process. That converts a remote validation
+   error into a local one with a useful message and a fix suggestion.
+
+The same pattern likely applies to other strict providers; the
+framework's vendor-agnostic story works best when "valid on provider
+A, valid on provider B" is enforced at the framework's name-check
+boundary.
+
+## Workaround
+
+- Use only `[a-zA-Z0-9_-]+` in tool names and MCP server names.
+- For the framework-generated MCP adapter naming, see bug-012.
+
+## Framework-level vs derived-agent-level
+
+**Framework.** The framework's selling point is vendor-agnostic
+providers: the same `ToolSpec` flowing to any `model:` string. That
+promise makes the framework responsible for surfacing cross-provider
+name-legality at its own boundary.
+
+- **Derived-agent test:** a name that's legal on the mocked CI client
+  and Anthropic-direct but illegal on Bedrock is a regression the
+  consumer *cannot see* until runtime on one specific vendor. They can't
+  defend against an undocumented AWS regex they don't know exists →
+  framework owns it. (This is the weaker of the two layers — naming
+  tools legally is partly on the consumer — but converting a remote error
+  into a local, actionable one is squarely the provider adapter's job.)
+- **How the fix helps derived agents:** a local
+  `BedrockToolNameInvalid("name 'kb.search' invalid; try 'kb_search'")`
+  raised before the request leaves the process turns a cryptic remote
+  `ProviderError` into an actionable, pre-flight error — and the same
+  validator catches bug-012's adapter-generated names as a side effect.
+
+## Notes
+
+- **Verified:** no provider or core code validates tool names against any
+  regex today (`agentforge-bedrock/client.py:339-342` passes `t.name`
+  verbatim; `ToolSpec.name` and the `@tool` decorator have no name
+  validator). The constraint appears in no docstring, spec, or template.
+- P2 on its own (the remote message is at least specific). P0s elsewhere
+  catch the immediate impact (bug-012 for MCP, bug-009 for ReAct).
+- **Overlaps bug-012:** a Bedrock-side validator would catch bug-012's
+  dotted names even before the separator fix lands — complementary, not
+  duplicate. bug-012 fixes the framework's *own* name generation; bug-017
+  adds the defensive net + docs for *all* (incl. consumer-authored) names.
+- Discovered when a downstream consumer renamed 13 tools from dotted
+  (`kb.search`) to underscored (`kb_search`) form — mechanical but
+  unexpected mid-implementation.

--- a/docs/bugs/bug-018-sqlitechathistory-update-metadata-fails-on-lazy-row.md
+++ b/docs/bugs/bug-018-sqlitechathistory-update-metadata-fails-on-lazy-row.md
@@ -1,0 +1,118 @@
+---
+status: open
+severity: P0
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-018 — `SqliteChatHistory.update_session_metadata` raises on the row `_create_session` will create
+
+## Symptom
+
+Every `POST /chat/sessions` (the documented session-creation route on
+`ChatServer`) returns **500 Internal Server Error** with:
+
+```
+agentforge_core.production.exceptions.ModuleError:
+  Cannot update metadata for unknown session '<session_id>'
+```
+
+So no chat session can be created on a fresh process when using the
+shipped SQLite chat-history driver.
+
+## Reproduction
+
+```python
+from agentforge_chat import SqliteChatHistory
+from agentforge_chat_http import ChatServer
+
+history = await SqliteChatHistory.from_path("c.db")
+server = ChatServer(agent_factory=..., history_store=history, auth=...)
+# In any HTTP client: POST /chat/sessions {} → 500
+```
+
+Or directly:
+
+```python
+await history.update_session_metadata("brand-new-id", {"owner": "x"})
+# → ModuleError: Cannot update metadata for unknown session 'brand-new-id'
+```
+
+## Root cause
+
+Two interacting points:
+
+1. `SqliteChatHistory._upsert_session` is lazy — it only inserts the
+   `chat_sessions` row on the **first `append(turn)`**, not at
+   construction time. Until a turn is appended, the row doesn't exist.
+2. `ChatServer._create_session` (agentforge_chat_http/server.py:286)
+   constructs the `ChatSession` object and immediately calls
+   `history.update_session_metadata(session.session_id, {"owner": ...})`
+   — **before** any turn is appended. The row doesn't exist yet, so
+   `update_session_metadata` (line 209) raises.
+
+So the framework's own `ChatServer` flow violates the `SqliteChatHistory`
+contract. Symmetric bug: either the chat-history needs an explicit
+`create_session` step, or `update_session_metadata` should upsert.
+
+## Fix proposal
+
+Pick one:
+
+1. **`update_session_metadata` upserts the row** if missing. Trivial
+   change in `SqliteChatHistory.update_session_metadata`:
+
+   ```python
+   await self._db.execute(
+       """INSERT INTO chat_sessions (id, owner, created_at, last_active_at, metadata)
+          VALUES (?, NULL, ?, ?, ?)
+          ON CONFLICT(id) DO NOTHING""",
+       (session_id, now_iso, now_iso, "{}"),
+   )
+   # then existing UPDATE
+   ```
+
+2. **Add `ChatHistoryStore.create_session()`** to the ABC and call it
+   from `ChatServer._create_session` before `update_session_metadata`.
+   Cleaner contract but requires updating every driver
+   (sqlite, postgres, redis, in-memory).
+
+Option 1 is the minimum patch. Option 2 is the right long-term shape.
+
+## Workaround
+
+Downstream consumers can subclass `SqliteChatHistory` and override
+`update_session_metadata` to upsert first. downstream consumers ship
+`CustomChatHistory` in `a custom ChatHistory subclass`
+with this exact pattern.
+
+## Framework-level vs derived-agent-level
+
+**Framework.** Both halves of the contract violation are
+framework-shipped: the caller (`ChatServer._create_session`,
+`agentforge-chat-http`) and the store (`SqliteChatHistory`,
+`agentforge-chat`). The `ChatHistoryStore` ABC docstring promises
+"merge metadata into the session's metadata dict" with no precondition
+that the session already exist — so the framework's own server violates
+its own store's contract on the very first request.
+
+- **Derived-agent test:** the consumer's only workaround is to subclass
+  the framework's store and override a method to patch over a framework
+  contract bug. That's monkey-patching framework behaviour → framework
+  defect, full stop.
+- **How the fix helps derived agents:** `POST /chat/sessions` works out
+  of the box with the shipped SQLite driver. Option 2 (add
+  `create_session()` to the ABC) additionally makes the create/update
+  contract explicit for *every* driver (sqlite/postgres/redis/in-memory),
+  so third-party drivers can't reintroduce the same gap.
+
+## Verification note (2026-06-02)
+
+All three sub-claims **confirmed** against source: `_upsert_session` is
+lazy (only called from `append()`, `sqlite.py:112`);
+`update_session_metadata` does SELECT-then-raise with no INSERT
+(`sqlite.py:202-209`); `_create_session` calls it before any append
+(`agentforge_chat_http/server.py:286`). Reproduced empirically — fresh
+store raises `ModuleError` on first `update_session_metadata`. The
+recommended landing is **option 1 now** (upsert; minimal, unblocks) plus
+**option 2 as the contract fix** in the same PR.

--- a/docs/bugs/bug-019-guardrail-entry-string-form-not-normalised.md
+++ b/docs/bugs/bug-019-guardrail-entry-string-form-not-normalised.md
@@ -1,0 +1,128 @@
+---
+status: open
+severity: P2
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-019 — `GuardrailEntry` string-form in YAML doesn't auto-normalise to `{name: ...}` despite docstring
+
+## Symptom
+
+The `GuardrailEntry` schema's docstring (`agentforge_core/config/schema.py`)
+documents two YAML shapes:
+
+> Two YAML shapes are valid (mirrors `EvaluatorEntry`):
+> - String form: `- prompt_injection_basic` (just the name).
+> - Mapping form: `- presidio: {entities: ["EMAIL_ADDRESS"]}`.
+>
+> Both normalise to `GuardrailEntry(name=..., config={})` before validation.
+
+The string form fails validation:
+
+```yaml
+modules:
+  guardrails:
+    tool_gates:
+      - my_role_gate   # ← string form, per docstring
+```
+
+```
+agentforge.yaml validation failed:
+  modules.guardrails.tool_gates.0: Input should be a valid dictionary
+  or instance of GuardrailEntry
+```
+
+## Reproduction
+
+```yaml
+# agentforge.yaml — minimal repro
+modules:
+  guardrails:
+    tool_gates:
+      - capability_check        # framework-shipped name
+```
+
+```
+$ agentforge config validate
+agentforge.yaml validation failed:
+  modules.guardrails.tool_gates.0: Input should be a valid dictionary
+  or instance of GuardrailEntry
+```
+
+## Root cause
+
+The promised string→mapping normaliser isn't wired anywhere — not on
+the `GuardrailEntry` field's `before` validator and not in the loader's
+pre-parse step (`loader.py:203-207` runs env interpolation then
+`model_validate` directly; both `GuardrailEntry` and `EvaluatorEntry` are
+`strict=True, extra="forbid"`).
+
+**Scope is wider than first reported — verified 2026-06-02.** The
+original draft guessed that `EvaluatorEntry` "may suffer the same gap."
+It does — `EvaluatorEntry` is **equally broken**, not a working
+reference. Three docstrings promise a string form that all fail
+validation:
+
+- `GuardrailEntry` docstring (`schema.py:226-236`)
+- `EvaluatorEntry` docstring (`schema.py:180-188`) — explicitly attributes
+  normalisation to "the loader", which does no such thing
+- the `ModulesConfig` / `GuardrailsConfig` example YAML
+  (`schema.py:369,372-374`), e.g. `evaluators: [faithfulness]` and
+  `input: [prompt_injection_basic]` — both fail
+
+So the single fix must cover `modules.evaluators` **and** guardrails'
+`input` / `output` / `tool_gates`.
+
+## Fix proposal
+
+Add a `field_validator(..., mode="before")` (or `model_validator`) on
+the parent container that converts `str` items into `{"name": str}`
+dicts before Pydantic strict validation runs:
+
+```python
+@field_validator("tool_gates", mode="before")
+@classmethod
+def _normalise_string_entries(cls, v: Any) -> Any:
+    if isinstance(v, list):
+        return [{"name": item} if isinstance(item, str) else item for item in v]
+    return v
+```
+
+Mirror to `input`, `output`, `tool_gates` lists and to
+`modules.evaluators`.
+
+## Workaround
+
+Use the mapping form everywhere:
+
+```yaml
+tool_gates:
+  - name: my_role_gate
+```
+
+Consumers use this form.
+
+## Framework-level vs derived-agent-level
+
+**Framework.** The schemas, their docstrings, the documented example
+YAML, and the loader are all `agentforge-core`. The framework documents
+a config syntax (in three places) that its own loader and `strict=True`
+models reject.
+
+- **Derived-agent test:** the consumer can use the mapping form as a
+  workaround, but the bug is that the framework *documents* the string
+  form and then rejects it — a doc-vs-code contradiction the consumer
+  can't fix. Framework defect.
+- **How the fix helps derived agents:** the documented terse syntax
+  (`- prompt_injection_basic`, `- faithfulness`) actually works, so
+  copy-pasting from the docstrings/examples doesn't produce a
+  `ValidationError`. Config ergonomics the docs already promise.
+
+## Notes
+
+- Low severity (P2): workaround is trivial and the error is specific. But
+  the fix should normalise (not just delete the docstring promise), since
+  the terse form appears in shipped example YAML across three configs.
+  Implement the `mode="before"` normaliser once and mirror it to
+  `evaluators`, `input`, `output`, `tool_gates`.

--- a/docs/bugs/bug-020-runtime-doesnt-wire-mcp-bridge.md
+++ b/docs/bugs/bug-020-runtime-doesnt-wire-mcp-bridge.md
@@ -1,0 +1,173 @@
+---
+status: open
+severity: P0
+found-in: v0.2.3
+found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
+---
+
+# bug-020 — Runtime never wires `modules.protocols.mcp` → MCPBridge → Agent.tools
+
+## Symptom
+
+Declaring an MCP server under `modules.protocols.mcp.config.servers`
+in `agentforge.yaml` (as runbook 09 instructs) is a no-op:
+
+- No subprocess (no `command:` from the `command:`) subprocess gets
+  spawned at agent boot.
+- No MCP-prefixed tools appear in the agent's tool list (the LLM
+  literally says "I don't have access to mcp:myserver.my_tool").
+- `agentforge health` reports `protocols:mcp resolvable` — the module
+  loads — but the bridge is never instantiated or started.
+
+## Reproduction
+
+```yaml
+# agentforge.yaml
+modules:
+  protocols:
+    - name: mcp
+      config:
+        servers:
+          - name: filesystem
+            transport: stdio
+            command: ["uv", "run", "filesystem-mcp"]
+            start_timeout: 10
+```
+
+```python
+async with Agent() as agent:
+    print([t.name for t in agent.tools])   # → []  (or only native tools)
+    # Even though runbook 09 §3 says: "Restart the agent. Discovered
+    # MCP tools appear in the agent's tool list automatically; the LLM
+    # sees their schemas alongside framework-native tools."
+```
+
+`ps -ef | grep filesystem-mcp` → nothing. No subprocess spawned.
+
+## Root cause
+
+A `grep -rn 'modules.protocols\|MCPBridge' .venv/lib/.../agentforge/`
+turns up **zero** runtime call sites:
+
+- `agentforge/agent.py` — no `MCPBridge` reference.
+- `agentforge/cli/_build.py::build_agent_from_config` — wires
+  memory, providers, strategy. No protocols.
+- `agentforge_mcp/bridge.py::MCPBridge.from_config` — exists and is
+  perfectly fine. **Nothing calls it.**
+- `agentforge_mcp/manifest.yaml` — declares the config block under
+  category `protocols`. The manifest is what `agentforge add module
+  mcp` reads to inject the YAML; once injected, no runtime path picks
+  it up.
+
+So the integration shape is documented (runbook 09), the bridge code
+is complete, the YAML schema accepts the config, but the runtime
+never connects `config.modules.protocols` → `MCPBridge.from_config(...)`
+→ `await bridge.start()` → `Agent(tools=[...bridge.tools()])`.
+
+## Impact
+
+- **Severity P0:** the entire MCP integration is non-functional out
+  of the box. Every consumer that follows runbook 09 reaches this
+  wall.
+- **Workaround possible but invasive:** the consumer must read the
+  protocols block from the parsed config in their `Agent` factory,
+  construct `MCPBridge.from_config(block)`, await `bridge.start()`
+  during app startup, and pass `bridge.tools()` into the
+  `Agent(tools=...)` kwarg themselves.
+- **Couples consumers to framework internals.** Bypassing the YAML
+  contract means each downstream re-implements wiring + lifecycle.
+
+## Fix proposal
+
+In `agentforge/cli/_build.py::build_agent_from_config` (or in
+`Agent.__init__` if we want it to also work when consumers build
+Agent programmatically with `config_path=`), add a step:
+
+```python
+from agentforge_mcp import MCPBridge
+
+protocols = config.modules.protocols or []
+mcp_bridges: list[MCPBridge] = []
+mcp_tools: list[Tool] = []
+for entry in protocols:
+    if entry.name != "mcp":
+        continue
+    bridge = MCPBridge.from_config(entry.config)
+    await bridge.start()
+    mcp_bridges.append(bridge)
+    mcp_tools.extend(bridge.tools())
+
+agent = Agent(
+    ...,
+    tools=[*config_native_tools, *mcp_tools],
+    _mcp_bridges=mcp_bridges,   # for proper close() on Agent.aexit
+)
+```
+
+And in `Agent.__aexit__` (or `close()`), close every bridge:
+
+```python
+for b in self._mcp_bridges:
+    await b.close()
+```
+
+A2A (the other protocol module) likely needs the same wiring; this
+fix is generic across `modules.protocols[*]` if we resolve each
+entry's name to a registered protocol-handler class.
+
+**Two coupled defects this fix must absorb:**
+
+- **bug-014** — `MCPBridge.from_config` is sync and trips
+  `RuntimeError: this event loop is already running` when driven from the
+  async runtime. The wiring above calls `from_config` + `await
+  bridge.start()` from an async context, so the wiring is the *first
+  victim* of bug-014. Make bridge construction async end-to-end as part
+  of this fix.
+- **`attach_local_tools` loose end** — `bridge.py:60-62` comments
+  reference an `attach_local_tools` method that **is not defined** on
+  `MCPBridge`. If the expose/server path needs it, it has to be
+  implemented alongside the wiring.
+
+## Test to add
+
+End-to-end: scaffold an agent with `modules.protocols.mcp.servers:
+[{name: t, transport: stdio, command: [python, -m, mcp_echo]}]`,
+where `mcp_echo` is a stub MCP server that exposes one tool.
+Assert: `[t.name for t in agent.tools]` includes the prefix
+`mcp:<server-name>.<tool>` after `Agent` construction completes.
+
+## Framework-level vs derived-agent-level
+
+**Framework — this is the root defect of the whole MCP cluster.** The
+entire point of the manifest (`manifest.yaml`) and the
+`agentforge.protocols` entry point is config-driven wiring;
+`build_agent_from_config` already wires every other module category
+(memory, providers, strategy, evaluators, retriever). Leaving
+`protocols` validated-but-never-instantiated means the documented
+`modules.protocols.mcp` config silently does nothing.
+
+- **Derived-agent test:** the only workaround is for the consumer to
+  re-implement the resolver + bridge lifecycle (`from_config` →
+  `start()` → merge `tools()` into `Agent(tools=...)` → `close()` on
+  exit) in their own `agent_factory`. That **couples every consumer to
+  framework internals** and breaks the "reference it by name in YAML"
+  promise. Hard framework defect.
+- **How the fix helps derived agents:** declaring an MCP server in YAML
+  Just Works — the subprocess spawns, tools appear in `agent.tools`, and
+  the bridge is closed on agent exit, with zero hand-rolled wiring. It
+  restores the config-driven, plug-and-play contract for the whole
+  `modules.protocols[*]` category (MCP now, A2A next). Fixing this is
+  what makes bug-012/013/014/015/017 reachable and worth fixing at all.
+
+## Notes
+
+- **Verified 2026-06-02:** exhaustive grep of `agentforge/` and
+  `agentforge_core/` finds **zero** `MCPBridge` references; `protocols`
+  is touched only by *validation* (`module_schemas.py:79-80`), never
+  instantiated; `build_tools_from_config` exists but isn't even called by
+  `build_agent_from_config`. The bug is real and central.
+- Found while implementing a consumer's tool catalog. Reported alongside
+  bug-009 and bug-010 — all surface only on live integration.
+- downstream consumers ship local wiring in `agent_factory.py` that calls
+  `MCPBridge.from_config()` manually. They'll remove the workaround when
+  the runtime adopts the fix above.

--- a/docs/enhancements/README.md
+++ b/docs/enhancements/README.md
@@ -1,0 +1,16 @@
+# Enhancements
+
+Improvements to *shipped* features (not new capabilities — those are
+`feat-NNN` specs; not defects — those are `bug-NNN` docs). Each
+`enh-NNN-*.md` follows the `enhancement.md` template:
+
+- Frontmatter-style metadata: `Status`, `Severity`/`Target version`,
+  `Improves` (the feat-NNN it builds on).
+- A mandatory **Framework-level vs derived-agent-level** section (§2.5):
+  an enhancement only belongs here if it genuinely improves framework
+  code rather than something a consumer could do in their own agent.
+
+Numbering: `enh-001`, `enh-002`, ... — never reused, never renumbered.
+
+An enhancement closes when it lands on `main` and a release ships
+containing it; `Status` flips to `shipped`.

--- a/docs/enhancements/enh-001-mcp-http-server-transport.md
+++ b/docs/enhancements/enh-001-mcp-http-server-transport.md
@@ -1,0 +1,118 @@
+# enh-001: MCP server-side HTTP transport
+
+> Improves a *shipped* feature (feat-013, MCP). Reclassified from bug-016
+> on 2026-06-02: the original report was filed as a defect, but the HTTP
+> server transport is an explicit, documented `not yet implemented` stub
+> deferred from v0.2 — a known feature gap, not a regression against
+> shipped behaviour. It therefore belongs in the enhancement track.
+
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **ID** | enh-001 |
+| **Title** | Implement server-side HTTP transport for `MCPServer` |
+| **Status** | `proposed` |
+| **Owner** | kjoshi |
+| **Created** | 2026-06-02 |
+| **Target version** | 0.2.4 (or 0.2.5 if scope slips) |
+| **Languages** | `python` |
+| **Improves** | feat-013 (MCP) |
+
+---
+
+## 1. Summary
+
+Let a Python `MCPServer` expose its tools over HTTP, not just stdio, so
+MCP servers can run as multi-instance hosted services.
+
+## 2. Motivation
+
+The client side of HTTP MCP already works (`MCPServerClient.from_http`),
+but the **server** side raises at serve time:
+
+```
+agentforge_core.production.exceptions.ModuleError:
+  MCP server transport 'http' is not yet implemented. Use transport='stdio' for v0.2.
+```
+
+Verified: `_SDKServerRunner.serve()` (`agentforge_mcp/server.py:200-209`)
+explicitly raises for any non-stdio transport; `MCPServer.from_http(...)`
+and `register_tools()` succeed, the failure is deferred to `serve()`.
+
+HTTP server transport is the only realistic production topology for a
+multi-instance ECS-style deployment. Stdio-spawn from inside a
+long-running async server also hits the upstream `mcp` SDK's anyio
+cancel-scope race across lifespan boundaries (worth a separate upstream
+filing), so HTTP is the path that unblocks hosted MCP servers.
+
+## 2.5 Framework-level vs derived-agent-level
+
+**Framework.** `MCPServer` and its transports are framework code; the
+manifest defaults `expose.transport` to `stdio`. A consumer cannot
+implement HTTP transport without reimplementing the framework's server
+protocol layer.
+
+- **Derived-agent test:** the workaround (hand-roll a FastAPI app + the
+  `mcp` SDK protocol layer) means re-implementing the protocol envelope
+  the framework is supposed to own — fails the test → framework work.
+- **How it helps derived agents:** consumers expose a production MCP
+  server with `MCPServer.from_http(...)` + `serve()` instead of
+  re-implementing the protocol, and get a deployable multi-instance
+  topology for free.
+
+## 3. Before / after
+
+| Aspect | Before | After |
+|---|---|---|
+| `from_http` server | constructs, then raises at `serve()` | serves over HTTP |
+| Prod topology | stdio-spawn only (fragile across async lifespans) | multi-instance HTTP service |
+| Consumer code | hand-rolled FastAPI + mcp protocol | `MCPServer.from_http(...)` |
+
+```python
+# after
+server = MCPServer.from_http(tools=tools, host=host, port=port)
+server.register_tools()   # or auto-registered once bug-013 lands
+await server.serve()      # serves over HTTP instead of raising
+```
+
+## 4. Backward compatibility
+
+Additive. Stdio transport is unchanged; this only makes a path that
+currently raises start working. No behaviour change for existing agents.
+
+## 5. Implementation sketch
+
+Implement the HTTP MCP server using the upstream `mcp` SDK's HTTP / SSE
+server adapter — the inverse of the client-side `_build_http_runner`.
+Two phases possible:
+
+1. HTTP-only first (the pressing transport).
+2. SSE later, once the SDK's SSE server adapter stabilises.
+
+Fail-fast improvement to fold in: `MCPServer.from_http` / the bridge's
+`_server_placeholder` should reject an unsupported transport at
+*construction* time rather than deferring the `ModuleError` to `serve()`.
+
+## 6. Test plan
+
+- Unit: `from_http` builds an HTTP runner; `serve()` no longer raises.
+- Integration: spin up an HTTP `MCPServer`, connect `MCPServerClient.from_http`,
+  assert `ListTools` returns the registered tools and a `CallTool` round-trips.
+- Combine with bug-013's auto-register fix so HTTP servers aren't
+  zero-tool.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Upstream `mcp` SDK SSE server adapter unstable | Ship HTTP-only first; defer SSE |
+| anyio cancel-scope race across lifespans | HTTP transport sidesteps the stdio-spawn race; file upstream separately |
+
+## 8. References
+
+- Improved feature: feat-013 (MCP)
+- Reclassified from: bug-016 (removed)
+- Related: bug-013 (auto-register tools), bug-020 (runtime wiring)


### PR DESCRIPTION
## What

Tracks 8 framework defects filed against v0.2.3 from the first live
Bedrock-backed MCP integration, and reclassifies one report as an
enhancement. Each doc now answers **"is this genuinely framework-level,
or should it be handled at the derived-agent level?"** with a problem
statement and how a framework fix helps every derived agent.

This is the **docs/triage PR**; the fixes follow and fold into **v0.2.4**
alongside the already-fixed bug-009/010.

## The core story

This isn't 8 independent bugs — it's **one missing integration (bug-020)
plus its fallout**. The MCP module's pieces all exist and are individually
fine, but `build_agent_from_config` never resolves the `protocols`
category, so the documented `modules.protocols.mcp` YAML is
validated-then-ignored. Everything downstream surfaced only because the
adopter had to hand-wire the bridge.

## Verdicts (all verified against source)

| Bug | Sev | Verdict | Note |
|---|---|---|---|
| bug-020 | P0 | Framework — root defect | runtime never wires `protocols.mcp`; zero `MCPBridge` refs |
| bug-012 | P0 | Framework | `.` separator in MCP tool name; illegal on Bedrock/OpenAI/Anthropic |
| bug-018 | P0 | Framework | `ChatServer` violates its own `SqliteChatHistory` contract → 500 on session create |
| bug-014 | P1 | Framework | `MCPBridge.from_config` sync-in-loop; must be absorbed into bug-020's async wiring |
| bug-015 | P2 | Framework | **corrected**: extra exists; real bug is meta extra chain `agentforge-py[mcp]` → `agentforge-mcp[mcp]` |
| bug-019 | P2 | Framework | **corrected**: EvaluatorEntry equally broken; 3 docstrings + example YAML |
| bug-017 | P2 | Framework | no local tool-name validation; protects vendor-agnostic promise; overlaps 012 |
| bug-013 | P2 | Framework (ergonomics) | **downgraded P0→P2**: bridge path already auto-registers; only raw factory affected |

bug-016 → **enh-001** (HTTP MCP server transport is a documented
"not yet implemented" stub, a feature gap not a regression).

## Why all eight are framework-level

The consistent test: *can a consumer fix this without monkey-patching
framework internals or contradicting documented behavior?* For every one,
no — the workaround re-implements the resolver/bridge lifecycle, subclasses
a shipped store to patch a contract bug, or guards against an undocumented
provider regex. Fixing at the framework deletes that workaround from every
consumer and protects the config-driven / vendor-agnostic / plug-and-play
promises.

## Template change (not in this PR)

The same framework-vs-agent triage was added to the workspace doc
templates (`.claude/templates/{bug,enhancement}.md` + README; `feature.md`
already had it) so every future feat/bug/enh answers it before leaving
`proposed`/`open`. Those templates live at the workspace root, outside
this repo's VCS, so they aren't committable here.

## Next

Implementation PR (folds into v0.2.4): MCP wiring (020+014), separator
(012), Bedrock name validator + docs (017), meta extra chain (015),
config normaliser (019), session-create upsert (018), factory
auto-register (013). enh-001 (HTTP transport) targeted same or 0.2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
