### PR TITLE
fix: round-trip tool_calls end-to-end (bug-009 P0 + bug-010)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -23,8 +23,8 @@ Both shipped together on a single branch because they're two
 halves of the same problem: bug-009 round-trips `tool_calls`
 in-flight (LLM history within one agent run), bug-010 round-trips
 them across runs (chat history persisted to disk). External
-adopter `a downstream consumer` surfaced both during
-a Generative-UI integration design review on 2026-05-27.
+downstream consumer surfaced both during a Generative-UI
+integration design review on 2026-05-27.
 
 **Branch:** `fix/bug-009-react-loop-drops-tool-calls` (off main @ `97eb35a`). Pushed.
 

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,32 +1,67 @@
 ---
-feature: bug-009 (ReAct + provider clients must round-trip tool_calls)
-state: in-progress
+feature: bug-009 + bug-010 (tool_calls round-trip end-to-end)
+state: pr-pending
 branch: fix/bug-009-react-loop-drops-tool-calls
 started_at: 2026-05-27
 last_milestone_at: 2026-05-27
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007) — PR #55 merged 2026-05-21; tag v0.2.3 pushed; GitHub Release published. 32 of 34 packages live on PyPI (presidio/nemo/llamaguard/evidently added 2026-05-27; phoenix + statsd remain).
 blocker: null
 flags_for_user:
-  - "32 of 34 packages live on PyPI at v0.2.3 (phoenix + statsd pending — final drip window 2026-05-28)."
-  - "bug-009 in flight: P0 reported by a downstream consumer 2026-05-27. ReAct drops response.tool_calls when re-feeding assistant turns; Bedrock Converse rejects every tool-using prompt on iteration 2. Fix touches core + ReAct + bedrock/openai/anthropic clients; targets v0.2.4."
-  - "bug-008 also queued for v0.2.4: `version(\"agentforge\")` should be `version(\"agentforge-py\")` in cli/new_cmd.py and cli/_shared_scaffold.py. ~5 lines. Could fold into the v0.2.4 train or ship in a separate PR."
+  - "PR NOT OPENED YET. Branch fix/bug-009-react-loop-drops-tool-calls pushed with 6 green commits covering bug-009 + bug-010. URL: https://github.com/Scaffoldic/agentforge-py/pull/new/fix/bug-009-react-loop-drops-tool-calls. Suggested title: \"fix: round-trip tool_calls end-to-end (bug-009 + bug-010)\"."
+  - "9 NEW untracked bug docs filed by user in parallel during this session: bug-012 through bug-020 in docs/bugs/. Not reviewed or committed yet — user WIP. (The earlier bug-011 collision was self-resolved: the runtime-doesnt-wire-mcp-bridge content is now at bug-020.)"
+  - "32 of 34 packages live on PyPI at v0.2.3 (phoenix + statsd pending — final drip window 2026-05-28 ≈ 11:05 UTC)."
+  - "bug-008 also queued for v0.2.4 (NOT IN THIS BRANCH): `version(\"agentforge\")` should be `version(\"agentforge-py\")` in cli/new_cmd.py and cli/_shared_scaffold.py. ~5 lines. Either fold into the v0.2.4 train (add a 7th commit) or ship as a separate small PR before tagging v0.2.4."
   - "v0.2.2 git tag is local-only (intentional — v0.2.3 supersedes). Pushing it burns a quota window without landing anything new."
   - "Production PyPI token still sitting in `~/.pypirc [pypi]` (one-time rescue path from 2026-05-20). Should be revoked on PyPI's web UI when convenient."
 ---
 
 ## Active feature
 
-**bug-009 — ReAct + provider clients must round-trip `tool_calls`.**
+**bug-009 + bug-010 — tool_calls round-trip end-to-end.**
 
-Plan approved 2026-05-27. Targeting v0.2.4. Six implementation
-chunks: (1) core `Message.tool_calls` field, (2) ReActLoop run +
-stream populate, (3) `_message_to_<provider>` branches for bedrock /
-openai / anthropic, (4) regression tests per layer, (5) docs +
-release plumbing, (6) file bug-010 follow-up for the conformance-
-harness gap.
+Both shipped together on a single branch because they're two
+halves of the same problem: bug-009 round-trips `tool_calls`
+in-flight (LLM history within one agent run), bug-010 round-trips
+them across runs (chat history persisted to disk). External
+adopter `a downstream consumer` surfaced both during
+a Generative-UI integration design review on 2026-05-27.
 
-Plan file: `/Users/khemchandjoshi/.claude/plans/cosmic-puzzling-shell.md`.
-Branch: `fix/bug-009-react-loop-drops-tool-calls` (off main @ 97eb35a).
+**Branch:** `fix/bug-009-react-loop-drops-tool-calls` (off main @ `97eb35a`). Pushed.
+
+**6 commits, all green through full pre-commit:**
+
+| # | Commit | Bug | Scope |
+|---|---|---|---|
+| 1 | `294ab12` | 009 | core `Message.tool_calls` + ReActLoop populate + tests |
+| 2 | `23be0e0` | 009 | bedrock/openai/anthropic `_message_to_<provider>` + tests |
+| 3 | `638700a` | 009 | bug-009 status → fixed, new bug-011 (provider-conformance-harness) follow-up, CHANGELOG |
+| 4 | `a53d68d` | 009 | workspace bump 0.2.3 → 0.2.4 (34 pyprojects + uv.lock + state/current.md) |
+| 5 | `74e02eb` | 010 | `persist_steps` schema + helpers + StreamingEvent metadata enrichment + ChatResponse.tool_calls population |
+| 6 | `f25b7f8` | 010 | 4 regression tests + bug-010 doc → fixed + CHANGELOG amend |
+
+**Test count:** 1318 → 1332 (+14 regression tests across both bugs).
+
+**Plan file:** `/Users/khemchandjoshi/.claude/plans/cosmic-puzzling-shell.md`.
+
+## Pickup on resume (2026-05-28)
+
+1. **Triage the 9 new bug docs (bug-012 … bug-020).** They appeared
+   untracked during this session. Review each, decide which need
+   fixes in v0.2.4 vs deferred, commit the doc files in a `docs:`
+   chunk (likely a separate PR from the bug-009+010 branch). At
+   minimum bug-020 (runtime-doesnt-wire-mcp-bridge) was previously
+   colliding with the bug-011 slot and is now resolved.
+2. **Decide bug-008 inclusion.** ~5-line fix
+   (`version("agentforge")` → `version("agentforge-py")` in
+   `cli/new_cmd.py` + `cli/_shared_scaffold.py`). Either fold into
+   this branch as a 7th commit, or ship as a separate small PR before
+   tagging v0.2.4.
+3. **Open the PR.** `gh pr create` against main with the title above.
+4. **Drip-publish phoenix + statsd at v0.2.3.** Final two packages.
+   Window opens ≈ 2026-05-28 11:05 UTC. See `PYPI_PUBLISH_TRACKER.md`.
+5. **After v0.2.3 drip completes AND bug-009+010 PR merges:** tag
+   `v0.2.4`, push, run `release.yml`. 34 packages already version-
+   bumped on this branch.
 
 ## Last shipped
 

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,24 +1,32 @@
 ---
-feature: null
-state: idle
-branch: main
-started_at: null
-last_milestone_at: 2026-05-21
-last_shipped: v0.2.3 — Upgrade-flow fix (bug-007) — PR #55 merged 2026-05-21; tag v0.2.3 pushed; GitHub Release published. 8 of 34 packages live on PyPI.
+feature: bug-009 (ReAct + provider clients must round-trip tool_calls)
+state: in-progress
+branch: fix/bug-009-react-loop-drops-tool-calls
+started_at: 2026-05-27
+last_milestone_at: 2026-05-27
+last_shipped: v0.2.3 — Upgrade-flow fix (bug-007) — PR #55 merged 2026-05-21; tag v0.2.3 pushed; GitHub Release published. 32 of 34 packages live on PyPI (presidio/nemo/llamaguard/evidently added 2026-05-27; phoenix + statsd remain).
 blocker: null
 flags_for_user:
-  - "26 of 34 packages still pending PyPI publish at v0.2.3 (blocked by daily new-project quota). Run `gh workflow run release.yml --ref v0.2.3` once per day until they all land, or until admin@pypi.org grants the quota-increase request."
-  - "v0.2.2 git tag is local-only (intentional — v0.2.3 supersedes). If a complete GitHub Releases history matters, push `git push origin v0.2.2` + `gh release create v0.2.2 --notes-file docs/releases/v0.2.2.md`. Note: pushing the tag triggers another `release.yml` run that burns a daily quota window without landing anything new."
-  - "PR #56 (docs only — bug-008 + pre-release tag callout) is open and ready to merge."
-  - "bug-008 queued for v0.2.4: `_template_version()` renders `0.0.0+unknown` because `importlib.metadata.version()` looks up the import name (`agentforge`) instead of the PyPI distribution name (`agentforge-py`). Cosmetic — affects marker headers and answers.yml, not functionality."
+  - "32 of 34 packages live on PyPI at v0.2.3 (phoenix + statsd pending — final drip window 2026-05-28)."
+  - "bug-009 in flight: P0 reported by a downstream consumer 2026-05-27. ReAct drops response.tool_calls when re-feeding assistant turns; Bedrock Converse rejects every tool-using prompt on iteration 2. Fix touches core + ReAct + bedrock/openai/anthropic clients; targets v0.2.4."
+  - "bug-008 also queued for v0.2.4: `version(\"agentforge\")` should be `version(\"agentforge-py\")` in cli/new_cmd.py and cli/_shared_scaffold.py. ~5 lines. Could fold into the v0.2.4 train or ship in a separate PR."
+  - "v0.2.2 git tag is local-only (intentional — v0.2.3 supersedes). Pushing it burns a quota window without landing anything new."
   - "Production PyPI token still sitting in `~/.pypirc [pypi]` (one-time rescue path from 2026-05-20). Should be revoked on PyPI's web UI when convenient."
 ---
 
 ## Active feature
 
-**None.** v0.2.3 shipped 2026-05-21. Pick the next item when
-ready — either drip the 26 pending packages, land bug-008 →
-v0.2.4, or move to the v0.3 backlog.
+**bug-009 — ReAct + provider clients must round-trip `tool_calls`.**
+
+Plan approved 2026-05-27. Targeting v0.2.4. Six implementation
+chunks: (1) core `Message.tool_calls` field, (2) ReActLoop run +
+stream populate, (3) `_message_to_<provider>` branches for bedrock /
+openai / anthropic, (4) regression tests per layer, (5) docs +
+release plumbing, (6) file bug-010 follow-up for the conformance-
+harness gap.
+
+Plan file: `/Users/khemchandjoshi/.claude/plans/cosmic-puzzling-shell.md`.
+Branch: `fix/bug-009-react-loop-drops-tool-calls` (off main @ 97eb35a).
 
 ## Last shipped
 

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2809,9 +2809,9 @@ fear was misplaced.
 
 ## 2026-05-27T22:00 — bug-009 + bug-010 fix landed on a single branch (PR pending)
 
-External adopter `a downstream consumer` surfaced two
-related defects in v0.2.3 during a Generative-UI integration
-design review. Both shipped together on
+A downstream consumer surfaced two related defects in v0.2.3
+during a Generative-UI integration design review. Both shipped
+together on
 `fix/bug-009-react-loop-drops-tool-calls` because they're two
 halves of the same problem — `tool_calls` must round-trip both
 in-flight (LLM history within a run) and across runs (chat

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2804,3 +2804,91 @@ fear was misplaced.
 - 7 bug docs landed under `docs/bugs/`.
 - Two memory updates: `project_v02_cut_in_flight.md` (full
   sign-off snapshot), `feedback_workflow.md` (tag-skip rule).
+
+---
+
+## 2026-05-27T22:00 — bug-009 + bug-010 fix landed on a single branch (PR pending)
+
+External adopter `a downstream consumer` surfaced two
+related defects in v0.2.3 during a Generative-UI integration
+design review. Both shipped together on
+`fix/bug-009-react-loop-drops-tool-calls` because they're two
+halves of the same problem — `tool_calls` must round-trip both
+in-flight (LLM history within a run) and across runs (chat
+history persisted to disk).
+
+**bug-009 — P0 — ReAct dropped `response.tool_calls`; Bedrock
+Converse rejected every tool-using prompt on iteration 2.**
+Root cause was a three-point interaction: `Message` had no
+`tool_calls` field, `ReActLoop.run`/`stream` discarded
+`response.tool_calls` when re-feeding assistant turns, and each
+provider's `_message_to_<provider>` translated messages in
+isolation (no native tool-use blocks on assistant turns).
+OpenAI and Anthropic-direct had the same latent shape; all three
+fixed.
+
+**bug-010 — P2 (arguably P1 functionally) —
+`ChatSession._persist_assistant` only wrote the final assistant
+text; intermediate `act` / `observe` steps stayed on
+`result.steps` and never reached `ChatHistoryStore`.** Generative-
+UI clients couldn't render tool activity, AND the next chat
+turn's prompt (built from `history.load()` in `_compose_task`)
+lost prior tool context entirely. Fixed via new
+`ChatSessionConfig.persist_steps: bool = True` knob + new
+`_persist_steps_from_result` / `_persist_steps_from_events`
+helpers covering both `.send()` and `.stream()`. `ChatResponse.tool_calls`
+(previously hardcoded `()`) populated from aggregated act-step
+calls. `StreamingEvent.metadata["tool_call"]` enriched additively
+so chat session can persist tool turns from the stream path
+without reaching into `AgentState`.
+
+**Branch state:**
+
+- 6 commits, all green through full pre-commit gate
+  (ruff/mypy --strict/bandit/pytest/coverage ≥ 90).
+  - `294ab12` core `Message.tool_calls` + ReActLoop populate + tests
+  - `23be0e0` bedrock/openai/anthropic providers + per-provider tests
+  - `638700a` bug-009 doc → fixed, new bug-011 follow-up, CHANGELOG
+  - `a53d68d` workspace bump 0.2.3 → 0.2.4 (34 pyprojects + uv.lock)
+  - `74e02eb` bug-010 impl (schema, session.py, build.py, _base.py)
+  - `f25b7f8` bug-010 tests + doc → fixed + CHANGELOG amend
+- Branch pushed to origin; tracking set.
+- **PR NOT opened.** Title suggestion:
+  *"fix: round-trip tool_calls end-to-end (bug-009 + bug-010)"*.
+  URL: <https://github.com/Scaffoldic/agentforge-py/pull/new/fix/bug-009-react-loop-drops-tool-calls>.
+- Test count growth: 1318 → 1332 (+14 regression tests).
+
+**Files in flight at end-of-session:**
+
+- `docs/bugs/bug-009-react-loop-drops-tool-calls-bedrock-validation.md` — committed; status fixed in 0.2.4.
+- `docs/bugs/bug-010-chatsession-drops-tool-steps.md` — committed; status fixed in 0.2.4. (Was previously untracked WIP from earlier the same day; folded into this PR.)
+- `docs/bugs/bug-011-provider-conformance-harness.md` — committed; open; v0.3 backlog.
+- `docs/bugs/bug-012-*.md` through `docs/bugs/bug-020-*.md` — 9 NEW untracked bug docs filed by the user in parallel during this session. Not reviewed or committed; user WIP. The originally-colliding `bug-011-runtime-doesnt-wire-mcp-bridge.md` was self-resolved by the user moving its content to `bug-020-runtime-doesnt-wire-mcp-bridge.md`.
+
+**v0.2.4 release queue (when this PR merges):**
+
+- All 34 `packages/*/pyproject.toml` already at `0.2.4`.
+- `uv.lock` regenerated.
+- `CHANGELOG.md` `[0.2.4]` entry covers bug-009 + bug-010 +
+  bug-011 (filed).
+- Two unrelated v0.2.4-queued items (no scope on this branch):
+  - **bug-008** — `_template_version()` looks up wrong dist name. ~5-line fix. Will need its own commit (or fold into a chore PR) before tagging v0.2.4.
+  - PR #56 — bug-008 doc + checklist callout — already merged into main (came across in today's `git pull --ff-only`, was on `docs/v0.2.3-followups-bug-008-tag-rule` branch which is no longer the current branch).
+
+**PyPI publish state (unchanged today):** 32 of 34 live at
+v0.2.3. `agentforge-phoenix` + `agentforge-statsd` remain;
+final drip-publish window 2026-05-28 ≈ 11:05 UTC. See
+`PYPI_PUBLISH_TRACKER.md` at workspace root. **v0.2.4 publish
+will be a coordinated 34-package upload AFTER the two stragglers
+land at 0.2.3, OR may be released as the first 34-at-once cut if
+admin@pypi.org has lifted the quota by then.**
+
+**Next session pick-up:**
+
+1. Triage the 9 new untracked bug docs (bug-012 through bug-020) the
+   user filed in parallel during this session. Decide which need
+   v0.2.4 fixes and commit the doc files (probably in a separate
+   `docs:` PR from the current branch).
+2. Open the PR for `fix/bug-009-react-loop-drops-tool-calls`.
+3. Decide whether to fold bug-008 into the same PR or its own.
+4. Finish the v0.2.3 drip-publish (2 packages) so v0.2.4 has a clean baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-05-27
+
+Tool-call round-trip fix. Bug-009 (P0) made every tool-using ReAct
+prompt on Bedrock fail on iteration 2 — `Message` had no
+`tool_calls` field, so `ReActLoop` dropped them when re-feeding the
+assistant turn, and provider clients emitted no native tool-use
+blocks. Converse rejected the orphaned `toolResult`. Same latent
+shape was present in OpenAI and Anthropic-direct; all three are
+fixed in this release.
+
+### Fixed
+
+- **bug-009 — ReAct dropped `tool_calls` on assistant turns; Bedrock
+  rejected every tool-using prompt on iteration 2.** Four packages
+  touched:
+  - `agentforge-core` — `Message` gains `tool_calls:
+    tuple[ToolCall, ...] = ()` (frozen, default-empty, backwards-
+    compatible with every existing call site).
+  - `agentforge` — `ReActLoop.run` and `ReActLoop.stream` populate
+    `Message.tool_calls` from `response.tool_calls` when appending
+    the assistant turn.
+  - `agentforge-bedrock` — `_message_to_bedrock` emits Converse
+    `toolUse` content blocks for assistant turns carrying
+    `tool_calls`.
+  - `agentforge-openai` — `_message_to_openai` emits the parallel
+    `tool_calls` array with JSON-encoded `arguments` per Chat
+    Completions schema.
+  - `agentforge-anthropic` — `_message_to_anthropic` emits typed
+    `tool_use` content blocks. Regression tests added per layer.
+
+### Added
+
+- **bug-011 (filed, not fixed)** — Provider conformance harness
+  testing-coverage gap. Bug-009 shipped because the unit suite uses
+  fakes that accept ANY payload; no test in the workspace hits a
+  real provider validator. Tracked for v0.3.
+
 ## [0.2.3] — 2026-05-21
 
 Upgrade-flow fix. v0.2.2's scaffold fixes only reached new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ release tag bumps every workspace member to the same minor version.
 
 ## [0.2.4] — 2026-05-27
 
-Tool-call round-trip fix. Two related bugs surfaced by external
-adopter `a downstream consumer` ship together because they're two halves
-of the same problem — tool_calls must survive both the in-flight
-LLM history (bug-009) and the persisted chat history (bug-010).
+Tool-call round-trip fix. Two related bugs surfaced by a downstream
+consumer integration ship together because they're two halves of
+the same problem — tool_calls must survive both the in-flight LLM
+history (bug-009) and the persisted chat history (bug-010).
 
 Bug-009 (P0) made every tool-using ReAct prompt on Bedrock fail on
 iteration 2 — `Message` had no `tool_calls` field, so `ReActLoop`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,44 @@ release tag bumps every workspace member to the same minor version.
 
 ## [0.2.4] — 2026-05-27
 
-Tool-call round-trip fix. Bug-009 (P0) made every tool-using ReAct
-prompt on Bedrock fail on iteration 2 — `Message` had no
-`tool_calls` field, so `ReActLoop` dropped them when re-feeding the
-assistant turn, and provider clients emitted no native tool-use
-blocks. Converse rejected the orphaned `toolResult`. Same latent
-shape was present in OpenAI and Anthropic-direct; all three are
-fixed in this release.
+Tool-call round-trip fix. Two related bugs surfaced by external
+adopter `a downstream consumer` ship together because they're two halves
+of the same problem — tool_calls must survive both the in-flight
+LLM history (bug-009) and the persisted chat history (bug-010).
+
+Bug-009 (P0) made every tool-using ReAct prompt on Bedrock fail on
+iteration 2 — `Message` had no `tool_calls` field, so `ReActLoop`
+dropped them when re-feeding the assistant turn, and provider
+clients emitted no native tool-use blocks. Converse rejected the
+orphaned `toolResult`. Same latent shape was present in OpenAI and
+Anthropic-direct; all three are fixed.
+
+Bug-010 (P2) dropped intermediate tool steps from
+`ChatHistoryStore`, so Generative-UI clients couldn't render tool
+activity and the next chat turn's prompt lost prior tool context.
 
 ### Fixed
 
+- **bug-010 — `ChatSession` dropped intermediate tool steps from
+  persisted history.** Tool-using chats stored only the user prompt
+  and final assistant text; intermediate `act` / `observe` steps
+  never reached `ChatHistoryStore`, so Generative-UI clients
+  couldn't render tool activity and the next turn's prompt lost
+  prior tool context. Fix:
+  - New `ChatSessionConfig.persist_steps: bool = True` (and matching
+    `ChatSession(persist_steps=...)` kwarg). Default-on.
+  - `ChatSession._persist_steps_from_result` walks `result.steps`
+    and persists `act` → `ChatTurn(role="assistant",
+    tool_calls=(...))` and `observe` →
+    `ChatTurn(role="tool", tool_call_id=...)`. Called in the
+    synchronous `.send()` path before the final assistant turn.
+  - `ChatSession._persist_steps_from_events` mirrors the same shape
+    on the streaming path; relies on a new `tool_call` field added
+    to `StreamingEvent.metadata` by
+    `strategies._base._events_for_new_steps` (additive,
+    backwards-compatible).
+  - `ChatResponse.tool_calls` (sync API) is now populated from the
+    aggregated act-step tool calls instead of the hardcoded `()`.
 - **bug-009 — ReAct dropped `tool_calls` on assistant turns; Bedrock
   rejected every tool-using prompt on iteration 2.** Four packages
   touched:

--- a/docs/bugs/bug-009-react-loop-drops-tool-calls-bedrock-validation.md
+++ b/docs/bugs/bug-009-react-loop-drops-tool-calls-bedrock-validation.md
@@ -1,0 +1,176 @@
+---
+status: fixed in 0.2.4
+severity: P0
+found-in: v0.2.3
+found-via: live smoke test from a downstream consumer
+---
+
+# bug-009 — ReAct loop drops `tool_calls` on assistant messages, Bedrock rejects every tool-using turn
+
+## Symptom
+
+Any tool-using prompt against the `bedrock:` provider with the `react`
+strategy fails on iteration 2:
+
+```
+agentforge_core.production.exceptions.ProviderError: Bedrock validation:
+The number of toolResult blocks at messages.2.content exceeds the number
+of toolUse blocks of previous turn.
+```
+
+Reproduced 100% of the time on first tool dispatch. Non-tool-using
+prompts (LLM answers from prior knowledge with no `tool_calls`) work
+fine, so the bug is invisible until the agent actually uses a tool.
+
+## Reproduction
+
+```python
+# After `agentforge new my-agent --template minimal --provider bedrock`
+# and adding any simple tool to the Agent, run:
+from agentforge import Agent, tool
+
+@tool
+async def list_grades() -> list[int]:
+    """Return the grades available in the bank."""
+    return [7, 8, 9]
+
+async with Agent(model="bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                 strategy="react",
+                 tools=[list_grades]) as agent:
+    await agent.run("Which grades are available?")
+```
+
+**Expected:** the LLM calls `list_grades`, sees `[7, 8, 9]`, replies with the answer.
+**Actual:** `ProviderError: Bedrock validation: The number of toolResult blocks at messages.2.content exceeds the number of toolUse blocks of previous turn.`
+
+## Root cause
+
+Three interacting points in `agentforge-py 0.2.3`:
+
+1. **`Message` has no `tool_calls` field.**
+   `agentforge_core/values/messages.py::Message` carries only
+   `role, content, name, tool_call_id`. There is nowhere on a
+   `Message(role="assistant")` to record the `tool_calls` the LLM emitted.
+
+2. **`ReActLoop.run` discards `response.tool_calls` from the message
+   history** (`agentforge/strategies/react.py:86`):
+
+   ```python
+   # Record the assistant's turn for the next iteration's context.
+   messages.append(Message(role="assistant", content=response.content))
+   ```
+
+   The `response.tool_calls` are used to dispatch tools (line 89) but
+   never recorded on the appended assistant `Message`.
+
+3. **`_message_to_bedrock` translates each Message in isolation**
+   (`agentforge_bedrock/client.py:589-616`). The assistant message becomes
+   `{"role": "assistant", "content": [{"text": <text>}]}` — no `toolUse`
+   blocks possible. The subsequent `Message(role="tool", tool_call_id=...)`
+   becomes `{"role": "user", "content": [{"toolResult": {...}}]}`.
+
+The resulting Bedrock Converse `messages` payload sent on iteration 2:
+
+```
+messages[0]  user        [text: <task>]
+messages[1]  assistant   [text: <empty or prelude>]      ← NO toolUse
+messages[2]  user        [toolResult: ...]               ← orphaned
+```
+
+Bedrock's Converse validator rejects this because `messages[2].content`
+contains `toolResult` blocks but `messages[1].content` contains zero
+`toolUse` blocks.
+
+## Impact
+
+- **Severity P0:** any tool-using agent on Bedrock is non-functional
+  with the `react` strategy. ReAct is also the framework-recommended
+  default (`runbook 04 — Pick a reasoning strategy`), so this is the
+  hot path for most scaffolds with `--provider bedrock`.
+- **Workaround feasible:** see § Fix proposal below; downstream consumers
+  can monkey-patch, but they need to know the framework's internals to
+  do it.
+- **Provider scope:** confirmed on Bedrock. OpenAI / Anthropic Direct
+  clients likely have the same latent bug — they would also need
+  `tool_calls` on the assistant message to round-trip a tool turn — but
+  may be more permissive in validation. Worth checking.
+
+## Fix proposal
+
+Three coordinated changes:
+
+1. **Add `tool_calls: tuple[ToolCall, ...] = ()` to `Message`** in
+   `agentforge_core/values/messages.py`.
+2. **Populate it in `ReActLoop`** (`strategies/react.py:86`):
+
+   ```python
+   messages.append(Message(
+       role="assistant",
+       content=response.content,
+       tool_calls=response.tool_calls,
+   ))
+   ```
+
+   Mirror the same change in any other strategy that re-feeds assistant
+   responses (plan-execute, multi-agent, tot).
+3. **Emit `toolUse` blocks in `_message_to_bedrock`**
+   (`agentforge_bedrock/client.py:589`):
+
+   ```python
+   if message.role == "assistant":
+       content: list[dict[str, Any]] = []
+       if message.content:
+           content.append({"text": message.content})
+       for tc in message.tool_calls:
+           content.append({
+               "toolUse": {
+                   "toolUseId": tc.id,
+                   "name": tc.name,
+                   "input": dict(tc.arguments),
+               }
+           })
+       return {"role": "assistant", "content": content}
+   ```
+
+The same fix shape applies to the OpenAI and Anthropic-direct clients
+(emit `tool_calls` on the assistant message in their native shapes).
+
+## Test to add (regression gate)
+
+- Provider conformance: round-trip a two-iteration ReAct flow against a
+  recorded Bedrock cassette where iteration 1 returns a `tool_use`
+  stop reason and iteration 2 must include the matching `toolUse`
+  block in `messages[1]`.
+- ReAct strategy unit test: after one iteration with a tool call,
+  assert `messages[-2].tool_calls` is non-empty and matches the prior
+  response.
+
+## Notes
+
+- Downstream consumer (a downstream consumer) is shipping a monkey-patch in
+  `src/downstream_consumer/_patches.py` that smuggles `tool_calls` through
+  the unused `Message.name` field as a JSON sentinel. They will remove
+  the patch on framework upgrade to the version that fixes this.
+- The bug is invisible in unit tests that don't actually call Bedrock
+  (the framework's `_build_converse_request` happily builds an invalid
+  payload). A provider conformance test that hits the real validator —
+  even via VCR cassette — would have caught it. Filed as bug-011 for
+  v0.3.
+
+## Fix (shipped in v0.2.4)
+
+All three sub-fixes landed together on `fix/bug-009-react-loop-drops-tool-calls`:
+
+1. **Core** — `agentforge_core.values.messages.Message` gains
+   `tool_calls: tuple[ToolCall, ...] = ()` (frozen, default-empty, so
+   every existing call site stays valid).
+2. **Strategy** — `ReActLoop.run` and `ReActLoop.stream` populate
+   the field when appending the assistant turn.
+3. **Providers** — `_message_to_bedrock` emits Converse `toolUse`
+   blocks; `_message_to_openai` emits the parallel `tool_calls`
+   array with JSON-encoded `arguments`; `_message_to_anthropic`
+   emits typed `tool_use` content blocks.
+
+Regression tests added per layer (Message round-trip, ReAct run +
+stream re-feed, Bedrock toolUseId↔toolResult pairing, OpenAI
+tool_calls shape, Anthropic tool_use blocks).

--- a/docs/bugs/bug-009-react-loop-drops-tool-calls-bedrock-validation.md
+++ b/docs/bugs/bug-009-react-loop-drops-tool-calls-bedrock-validation.md
@@ -2,7 +2,7 @@
 status: fixed in 0.2.4
 severity: P0
 found-in: v0.2.3
-found-via: live smoke test from a downstream consumer
+found-via: live integration test of a Bedrock-backed agent
 ---
 
 # bug-009 — ReAct loop drops `tool_calls` on assistant messages, Bedrock rejects every tool-using turn
@@ -148,7 +148,7 @@ The same fix shape applies to the OpenAI and Anthropic-direct clients
 ## Notes
 
 - Downstream consumer (a downstream consumer) is shipping a monkey-patch in
-  `src/downstream_consumer/_patches.py` that smuggles `tool_calls` through
+  `_patches.py` that smuggles `tool_calls` through
   the unused `Message.name` field as a JSON sentinel. They will remove
   the patch on framework upgrade to the version that fixes this.
 - The bug is invisible in unit tests that don't actually call Bedrock

--- a/docs/bugs/bug-010-chatsession-drops-tool-steps.md
+++ b/docs/bugs/bug-010-chatsession-drops-tool-steps.md
@@ -1,0 +1,157 @@
+---
+status: fixed in 0.2.4
+severity: P2
+found-in: v0.2.3
+found-via: live design review for a downstream consumer Generative-UI integration
+---
+
+# bug-010 — `ChatSession._run_turn` drops intermediate tool steps from history
+
+## Symptom
+
+When `ChatSession.send(message)` runs an agent that invokes one or
+more tools, the persisted `ChatHistoryStore` records only:
+
+- the `user` turn (the inbound message)
+- the final `assistant` turn (synthesized natural-language answer)
+
+The intermediate tool steps (`Step(kind="observe", tool_call=...)`)
+are present on the in-memory `RunResult.steps` but never written to
+the history store. `GET /sessions/{id}/messages` therefore cannot
+show what tools ran or what they returned.
+
+## Reproduction
+
+```python
+async with Agent(tools=[some_tool]) as agent:
+    server = ChatServer(agent_factory=lambda: agent, history_store=SqliteChatHistory.from_path("c.db"), auth=...)
+# POST /chat/sessions, then POST /chat/sessions/{id}/messages with a
+# prompt that triggers `some_tool`.
+# Then SELECT role, content FROM chat_turns ORDER BY timestamp:
+#   user       "<prompt>"
+#   assistant  "<final text>"
+# — no tool row, even though `some_tool` ran and its observation
+# shaped the assistant's answer.
+```
+
+## Root cause
+
+`agentforge_chat/session.py::ChatSession._run_turn` (lines 188–215):
+
+```python
+result = await self._agent.run(task)
+...
+assistant_turn = await self._persist_assistant(validated_out, result, duration_ms)
+```
+
+`_persist_assistant` appends one `ChatTurn(role="assistant")` for the
+final `validated_out` text. The framework never iterates
+`result.steps` to surface tool calls/observations.
+
+`ChatTurn` itself supports `role="tool"` and `tool_call_id` fields,
+so the persistence layer is ready — it's just not invoked.
+
+## Impact
+
+- **Generative-UI clients can't render tool outputs.** Modern chat
+  frontends (Anthropic Computer Use, OpenAI Assistants, the
+  Generative-UI pattern) dispatch UI cards per tool result by
+  fetching the message list and parsing role="tool" turns. With this
+  bug, every tool run is invisible after the turn completes — the
+  agent's reasoning is lost.
+- **Audit / replay / debug.** Without tool turns in history, it's
+  impossible to reconstruct what the agent did from chat.db alone.
+  Operators must correlate with OTel spans, which is not always
+  possible (sampled traces, retention).
+- **Severity P2** because a workaround exists (downstream patches
+  `_persist_assistant` to also persist `result.steps`), and the
+  in-memory `RunResult.steps` is intact during the run.
+
+## Fix proposal
+
+Inside `_persist_assistant`, before appending the assistant turn,
+walk `result.steps` and persist tool observations:
+
+```python
+for step in result.steps:
+    if step.kind == "observe" and step.tool_call is not None:
+        await self._history.append(ChatTurn(
+            id=uuid4().hex,
+            session_id=self._session_id,
+            role="tool",
+            content=step.content if isinstance(step.content, str) else json.dumps(step.content),
+            tool_call_id=step.tool_call.id,
+            run_id=result.run_id,
+            metadata={"tool_name": step.tool_call.name},
+        ))
+```
+
+Or, more loosely: persist `kind in ("think","act","observe")` steps
+to history under a feature flag (`chat.persist_steps: true` in
+agentforge.yaml) so consumers can opt in.
+
+## Test to add
+
+Round-trip test: `ChatSession.send(prompt_that_uses_tools)` then
+`history.load(session_id)` returns at least one `ChatTurn(role="tool")`
+whose `content` is the tool's observation string and whose
+`tool_call_id` matches a value in the prior assistant turn (once
+bug-009 is also fixed and assistant turns carry tool_calls in
+`metadata`).
+
+## Notes
+
+- Found while implementing the Generative-UI integration in
+  `a downstream consumer` ([a downstream consumer gap #3]).
+- Workaround: downstream consumers can monkey-patch
+  `ChatSession._persist_assistant` to invoke the proposal above.
+  a downstream consumer ships such a patch in
+  `src/downstream_consumer/_patches.py`; they'll remove it when this
+  bug is fixed in the framework.
+- Related to bug-009 (assistant turns also drop tool_calls). The
+  two together mean: even with bug-010 fixed, you can't tell which
+  *assistant* turn produced which tool turns without bug-009 also
+  fixed (assistant turn carries the tool_call ids). Both shipped
+  together in v0.2.4.
+
+## Fix (shipped in v0.2.4)
+
+Landed on the same branch as bug-009 (`fix/bug-009-react-loop-drops-tool-calls`)
+because the two are conceptually paired — bug-009 round-trips
+`tool_calls` *within* an agent run; bug-010 round-trips them *across*
+chat turns via the persisted `ChatHistoryStore`.
+
+Changes:
+
+1. **`ChatSessionConfig.persist_steps: bool = True`** — new schema
+   field (opt-out flag). Default-on because the previous behaviour
+   was a silent data loss, not an intentional choice.
+2. **`ChatSession.__init__(..., persist_steps: bool = True)`** —
+   matching constructor kwarg; threaded by
+   `build_chat_session_from_config` from `agentforge.yaml`'s
+   `modules.chat.session.persist_steps`.
+3. **`ChatSession._persist_steps_from_result(result)`** — walks
+   `result.steps`. For each `kind="act"` with `tool_call`, appends
+   `ChatTurn(role="assistant", tool_calls=(tool_call,),
+   content=json.dumps({"tool":..., "arguments":...}))`. For each
+   `kind="observe"` with `tool_call`, appends
+   `ChatTurn(role="tool", tool_call_id=..., content=observation)`.
+   Called from `_run_turn` BEFORE `_persist_assistant` so the final
+   answer is chronologically last.
+4. **`ChatSession._persist_steps_from_events(events, run_id=...)`**
+   — stream-path mirror. Collects `kind="step"` `StreamingEvent`s
+   during `_stream_per_token` and persists them with the same shape.
+5. **`strategies._base._events_for_new_steps`** —
+   `StreamingEvent.metadata["tool_call"]` now carries the step's
+   `tool_call.model_dump()` (when present) so the chat session can
+   reconstruct it without reaching into `AgentState`. Additive,
+   backwards-compatible.
+6. **`ChatResponse.tool_calls`** (synchronous `.send()` return value)
+   is now populated from the aggregated `act`-step tool calls instead
+   of the previously-hardcoded `()`.
+
+Regression tests (`packages/agentforge-chat/tests/unit/test_session.py`):
+- `test_persist_steps_records_act_and_observe_turns`
+- `test_response_tool_calls_populated_from_steps`
+- `test_persist_steps_false_keeps_history_lean`
+- `test_stream_persists_step_turns`

--- a/docs/bugs/bug-010-chatsession-drops-tool-steps.md
+++ b/docs/bugs/bug-010-chatsession-drops-tool-steps.md
@@ -2,7 +2,7 @@
 status: fixed in 0.2.4
 severity: P2
 found-in: v0.2.3
-found-via: live design review for a downstream consumer Generative-UI integration
+found-via: live design review for a Generative-UI integration
 ---
 
 # bug-010 — `ChatSession._run_turn` drops intermediate tool steps from history
@@ -102,11 +102,11 @@ bug-009 is also fixed and assistant turns carry tool_calls in
 ## Notes
 
 - Found while implementing the Generative-UI integration in
-  `a downstream consumer` ([a downstream consumer gap #3]).
+  `a downstream consumer` ([Generative-UI consumer gap]).
 - Workaround: downstream consumers can monkey-patch
   `ChatSession._persist_assistant` to invoke the proposal above.
-  a downstream consumer ships such a patch in
-  `src/downstream_consumer/_patches.py`; they'll remove it when this
+  downstream consumers ship such a patch in
+  `_patches.py`; they'll remove it when this
   bug is fixed in the framework.
 - Related to bug-009 (assistant turns also drop tool_calls). The
   two together mean: even with bug-010 fixed, you can't tell which

--- a/docs/bugs/bug-011-provider-conformance-harness.md
+++ b/docs/bugs/bug-011-provider-conformance-harness.md
@@ -12,7 +12,7 @@ found-via: post-fix retro
 Bug-009 (ReAct dropped `response.tool_calls` when re-feeding the
 assistant turn) shipped in v0.2.3 with a fully green unit suite. The
 real Bedrock Converse validator rejected every tool-using prompt on
-the first call once `a downstream consumer` integrated the library — but
+the first call once a downstream consumer integrated the library — but
 no test in the workspace ever exercised that path end-to-end.
 
 ## Root cause

--- a/docs/bugs/bug-011-provider-conformance-harness.md
+++ b/docs/bugs/bug-011-provider-conformance-harness.md
@@ -1,0 +1,64 @@
+---
+status: open
+severity: P2 (testing-coverage gap, not a code defect)
+found-in: surfaced by bug-009 (2026-05-27)
+found-via: post-fix retro
+---
+
+# bug-011 — No provider conformance harness; payload-shape bugs invisible to unit tests
+
+## Symptom
+
+Bug-009 (ReAct dropped `response.tool_calls` when re-feeding the
+assistant turn) shipped in v0.2.3 with a fully green unit suite. The
+real Bedrock Converse validator rejected every tool-using prompt on
+the first call once `a downstream consumer` integrated the library — but
+no test in the workspace ever exercised that path end-to-end.
+
+## Root cause
+
+- Every provider package's tests use fake clients
+  (`_FakeBedrockClient`, `FakeOpenAIRunner`, `FakeAnthropicRunner`)
+  that accept ANY payload shape. The framework's
+  `_build_converse_request` / `_message_to_<provider>` can produce
+  invalid payloads and the fakes happily return canned responses.
+- No test in the workspace exercises a multi-iteration ReAct round-
+  trip against a real provider — even via a recorded cassette.
+
+## Impact
+
+Any future bug whose symptom only surfaces at the provider's
+request validator (orphaned tool blocks, missing required fields,
+malformed enum values, payload-size limits, etc.) will ship to
+adopters before we see it. Bug-009 is the first confirmed instance.
+
+## Fix proposal (v0.3 backlog)
+
+Add a cassette-based conformance harness. Sketch:
+
+1. New test directory per provider package:
+   `tests/conformance/`. Use `pytest-recording` (or `vcrpy` directly)
+   to record one live multi-iteration tool round-trip per provider
+   against a real account. Recordings live in
+   `tests/conformance/cassettes/`.
+2. CI replays cassettes only — never re-records. Recording is a
+   manual maintainer task (`pytest --record-mode=rewrite` against
+   real creds) when a provider's wire format changes.
+3. Auth scrubbing: cassettes redact `Authorization`,
+   `x-api-key`, `x-amz-security-token`, and any account-id-shaped
+   query params before commit. Centralise the scrub list in a
+   shared `conftest.py`.
+4. Decisions deferred until implementation: per-package cassettes
+   vs. workspace-wide fixture directory; re-record cadence
+   (per-release vs. per-quarter); whether to also conform the
+   streaming paths (yes, but separate cassette).
+
+## Notes
+
+- Linked from bug-009 §Notes — that's the motivating incident.
+- This is a testing-coverage gap, not a code defect. No production
+  fix required; the deliverable is test infra + at least one
+  recorded round-trip per provider (bedrock, openai, anthropic).
+- v0.3 roadmap entry should reference this doc.
+- Should land BEFORE the v0.3.0 cut so we don't carry the same
+  blind spot into the TypeScript port (feat-024 / v0.4).

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-a2a"
-version = "0.2.3"
+version = "0.2.4"
 description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-py ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-py ~= 0.2.4",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-anthropic/pyproject.toml
+++ b/packages/agentforge-anthropic/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-anthropic"
-version = "0.2.3"
+version = "0.2.4"
 description = "Anthropic native LLM provider for AgentForge — Claude with caching, extended thinking, streaming"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-anthropic/src/agentforge_anthropic/client.py
+++ b/packages/agentforge-anthropic/src/agentforge_anthropic/client.py
@@ -343,6 +343,22 @@ def _message_to_anthropic(message: Message) -> dict[str, Any]:
     if message.role == "system":
         # Should be hoisted by the caller; defensive fallback.
         return {"role": "user", "content": message.content}
+    if message.role == "assistant" and message.tool_calls:
+        # Round-trip tool_calls into Anthropic tool_use content blocks so
+        # the next iteration's tool_result pairs by id (bug-009).
+        blocks: list[dict[str, Any]] = []
+        if message.content:
+            blocks.append({"type": "text", "text": message.content})
+        blocks.extend(
+            {
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.name,
+                "input": dict(tc.arguments),
+            }
+            for tc in message.tool_calls
+        )
+        return {"role": "assistant", "content": blocks}
     return {"role": message.role, "content": message.content}
 
 

--- a/packages/agentforge-anthropic/tests/unit/test_anthropic_client.py
+++ b/packages/agentforge-anthropic/tests/unit/test_anthropic_client.py
@@ -7,7 +7,7 @@ from agentforge_anthropic import AnthropicClient
 from agentforge_anthropic._inmem_runner import FakeAnthropicRunner
 from agentforge_anthropic._pricing import compute_cost_usd
 from agentforge_core.production.exceptions import CapabilityNotSupported
-from agentforge_core.values.messages import Message, ToolSpec
+from agentforge_core.values.messages import Message, ToolCall, ToolSpec
 
 
 def _user(text: str) -> Message:
@@ -219,6 +219,45 @@ async def test_tool_role_messages_encode_as_user_tool_result(
     assert sent["content"][0]["type"] == "tool_result"
     assert sent["content"][0]["tool_use_id"] == "toolu_xyz"
     assert sent["content"][0]["content"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_assistant_turn_with_tool_calls_emits_tool_use_blocks(
+    client: AnthropicClient,
+    fake_runner: FakeAnthropicRunner,
+) -> None:
+    """bug-009: an assistant Message carrying framework tool_calls must
+    serialise to Anthropic `tool_use` content blocks, paired by id with
+    the subsequent tool_result."""
+    fake_runner.set_response(
+        {
+            "model": "claude-sonnet-4-7",
+            "content": [{"type": "text", "text": ""}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+    )
+    await client.call(
+        system="",
+        messages=[
+            _user("ping example.com"),
+            Message(
+                role="assistant",
+                content="pinging",
+                tool_calls=(
+                    ToolCall(id="toolu_xyz", name="ping", arguments={"target": "example.com"}),
+                ),
+            ),
+            Message(role="tool", content='{"ok": true}', tool_call_id="toolu_xyz"),
+        ],
+    )
+    sent_assistant = fake_runner.create_calls[0].messages[1]
+    assert sent_assistant["role"] == "assistant"
+    tool_use_blocks = [b for b in sent_assistant["content"] if b.get("type") == "tool_use"]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["id"] == "toolu_xyz"
+    assert tool_use_blocks[0]["name"] == "ping"
+    assert tool_use_blocks[0]["input"] == {"target": "example.com"}
 
 
 # ----------------------------------------------------------------------

--- a/packages/agentforge-bedrock/pyproject.toml
+++ b/packages/agentforge-bedrock/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-bedrock"
-version = "0.2.3"
+version = "0.2.4"
 description = "AWS Bedrock provider for AgentForge — Anthropic, Titan, Cohere on Bedrock"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "aioboto3>=13.0",
     "botocore>=1.35",
 ]

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
@@ -608,6 +608,23 @@ def _message_to_bedrock(message: Message) -> dict[str, Any]:
     if message.role == "system":
         # Should be hoisted by the caller; keep a defensive fallback.
         return {"role": "user", "content": [{"text": message.content}]}
+    if message.role == "assistant" and message.tool_calls:
+        # Round-trip tool_calls into Converse toolUse blocks so the next
+        # iteration's toolResult pairs cleanly (bug-009).
+        content: list[dict[str, Any]] = []
+        if message.content:
+            content.append({"text": message.content})
+        content.extend(
+            {
+                "toolUse": {
+                    "toolUseId": tc.id,
+                    "name": tc.name,
+                    "input": dict(tc.arguments),
+                }
+            }
+            for tc in message.tool_calls
+        )
+        return {"role": "assistant", "content": content}
     return {
         "role": message.role,
         "content": [{"text": message.content}],

--- a/packages/agentforge-bedrock/tests/unit/test_client.py
+++ b/packages/agentforge-bedrock/tests/unit/test_client.py
@@ -15,7 +15,7 @@ from agentforge_core.production.exceptions import (
     ServiceError,
 )
 from agentforge_core.resolver import Resolver
-from agentforge_core.values.messages import Message, ToolSpec
+from agentforge_core.values.messages import Message, ToolCall, ToolSpec
 from botocore.exceptions import ClientError
 
 from tests.conftest import _FakeBedrockClient, _FakeSession, converse_response
@@ -186,6 +186,39 @@ async def test_call_translates_tool_messages_to_tool_results(
     # Tool result is encoded as a user message with toolResult content.
     assert sent_messages[1]["role"] == "user"
     assert sent_messages[1]["content"][0]["toolResult"]["toolUseId"] == "tu_1"
+
+
+@pytest.mark.asyncio
+async def test_call_round_trips_tool_calls_on_assistant_turn(
+    fake_bedrock: _FakeBedrockClient, fake_session: _FakeSession
+) -> None:
+    """bug-009: an assistant Message carrying tool_calls must serialise to a
+    Converse toolUse content block, paired by toolUseId with the subsequent
+    tool result. Without this, Converse rejects the request."""
+    fake_bedrock.responses.append(converse_response())
+    client = BedrockClient(model_id="anthropic.claude-3-haiku-20240307-v1:0", session=fake_session)
+    await client.call(
+        "sys",
+        [
+            Message(role="user", content="what time"),
+            Message(
+                role="assistant",
+                content="checking",
+                tool_calls=(ToolCall(id="tu_1", name="now", arguments={}),),
+            ),
+            Message(role="tool", tool_call_id="tu_1", content='{"now": "noon"}'),
+        ],
+    )
+    sent_messages = fake_bedrock.calls[0]["messages"]
+    # The assistant turn must emit a toolUse block whose toolUseId matches
+    # the subsequent toolResult's toolUseId — this is the exact invariant
+    # Converse validates.
+    assistant_blocks = sent_messages[1]["content"]
+    tool_use_blocks = [b for b in assistant_blocks if "toolUse" in b]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["toolUse"]["toolUseId"] == "tu_1"
+    assert tool_use_blocks[0]["toolUse"]["name"] == "now"
+    assert sent_messages[2]["content"][0]["toolResult"]["toolUseId"] == "tu_1"
 
 
 @pytest.mark.asyncio

--- a/packages/agentforge-chat-history-postgres/pyproject.toml
+++ b/packages/agentforge-chat-history-postgres/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-history-postgres"
-version = "0.2.3"
+version = "0.2.4"
 description = "Postgres-backed ChatHistoryStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "asyncpg>=0.30",
 ]
 

--- a/packages/agentforge-chat-history-redis/pyproject.toml
+++ b/packages/agentforge-chat-history-redis/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-chat-history-redis"
-version = "0.2.3"
+version = "0.2.4"
 description = "Redis-backed ChatHistoryStore and SessionLock for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-chat ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-chat ~= 0.2.4",
     "redis>=5.0",
 ]
 

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-chat-http"
-version = "0.2.3"
+version = "0.2.4"
 description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,9 +24,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-py ~= 0.2.3",
-    "agentforge-chat ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-py ~= 0.2.4",
+    "agentforge-chat ~= 0.2.4",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-chat-slack/pyproject.toml
+++ b/packages/agentforge-chat-slack/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-slack"
-version = "0.2.3"
+version = "0.2.4"
 description = "Slack reference channel adapter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-chat ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-chat ~= 0.2.4",
     "slack-bolt>=1.20",
     "slack-sdk>=3.30",
 ]

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-chat"
-version = "0.2.3"
+version = "0.2.4"
 description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-py ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-py ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-chat/src/agentforge_chat/build.py
+++ b/packages/agentforge-chat/src/agentforge_chat/build.py
@@ -48,6 +48,7 @@ async def build_chat_session_from_config(
     per_session = None
     idem_window = 60.0
     safety_mode: SafetyMode = "buffer-then-stream"
+    persist_steps = True
     if chat_cfg is not None:
         if chat_cfg.history is not None:
             history = await _build_history(chat_cfg.history.driver, chat_cfg.history.config)
@@ -57,6 +58,7 @@ async def build_chat_session_from_config(
         per_session = chat_cfg.session.per_session_budget_usd
         idem_window = chat_cfg.session.idempotency_window_s
         safety_mode = chat_cfg.session.safety_mode
+        persist_steps = chat_cfg.session.persist_steps
     return ChatSession(
         agent=agent,
         session_id=session_id,
@@ -68,6 +70,7 @@ async def build_chat_session_from_config(
         per_session_budget_usd=per_session,
         idempotency_window_s=idem_window,
         safety_mode=safety_mode,
+        persist_steps=persist_steps,
     )
 
 

--- a/packages/agentforge-chat/src/agentforge_chat/session.py
+++ b/packages/agentforge-chat/src/agentforge_chat/session.py
@@ -23,6 +23,7 @@ streaming work documented in feat-020 §10 deferrals.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncIterator, Callable
 from typing import Any, Literal
@@ -36,6 +37,7 @@ from agentforge_core.production.exceptions import (
     GuardrailViolation,
 )
 from agentforge_core.values.chat import ChatChunk, ChatResponse, ChatTurn, StreamingEvent
+from agentforge_core.values.messages import ToolCall
 
 from agentforge_chat._idempotency import IdempotencyCache
 from agentforge_chat._locks import (
@@ -74,6 +76,7 @@ class ChatSession:
         on_turn: OnTurnHook | None = None,
         session_lock_factory: SessionLockFactory | None = None,
         safety_mode: SafetyMode = "buffer-then-stream",
+        persist_steps: bool = True,
     ) -> None:
         self._agent = agent
         self._session_id = session_id if session_id is not None else uuid4().hex
@@ -97,6 +100,7 @@ class ChatSession:
         self._turn_count = 0
         self._closed = False
         self._safety_mode: SafetyMode = safety_mode
+        self._persist_steps = persist_steps
 
     # ------------------------------------------------------------------
     # Public properties
@@ -200,13 +204,17 @@ class ChatSession:
         result = await self._agent.run(task)
         duration_ms = int((time.monotonic() - start) * 1000)
         validated_out = await self._agent._guardrails.check_output(self._extract_text(result), ctx)
+        # Persist intermediate tool steps BEFORE the final assistant turn so
+        # the chat history reflects causal ordering (user → tool calls →
+        # tool results → final answer). bug-010.
+        tool_calls = await self._persist_steps_from_result(result)
         assistant_turn = await self._persist_assistant(validated_out, result, duration_ms)
         self._enforce_budgets(result.cost_usd)
         response = ChatResponse(
             content=validated_out,
             turn_id=assistant_turn.id,
             run_id=result.run_id,
-            tool_calls=(),
+            tool_calls=tool_calls,
             tokens_in=result.tokens_in,
             tokens_out=result.tokens_out,
             cost_usd=result.cost_usd,
@@ -253,6 +261,103 @@ class ChatSession:
         if isinstance(output, str):
             return output
         return str(output)
+
+    async def _persist_steps_from_result(self, result: Any) -> tuple[ToolCall, ...]:
+        """Persist `act` and `observe` steps from `result.steps` as
+        `ChatTurn`s ahead of the final assistant turn (bug-010).
+
+        Returns the aggregated tool_calls so the caller can attach them
+        to both the final assistant `ChatTurn.tool_calls` and the
+        synchronous `ChatResponse.tool_calls`. No-op when
+        `self._persist_steps` is False.
+        """
+        if not self._persist_steps:
+            return ()
+        tool_calls: list[ToolCall] = []
+        for step in result.steps:
+            if step.tool_call is None:
+                continue
+            if step.kind == "act":
+                tool_calls.append(step.tool_call)
+                content = (
+                    step.content if isinstance(step.content, str) else json.dumps(step.content)
+                )
+                turn = ChatTurn(
+                    id=uuid4().hex,
+                    session_id=self._session_id,
+                    role="assistant",
+                    content=content,
+                    run_id=result.run_id,
+                    tool_calls=(step.tool_call,),
+                    tokens_in=step.tokens_in,
+                    tokens_out=step.tokens_out,
+                    cost_usd=step.cost_usd,
+                )
+                await self._history.append(turn)
+                if self._on_turn is not None:
+                    self._on_turn(turn)
+            elif step.kind == "observe":
+                content = (
+                    step.content if isinstance(step.content, str) else json.dumps(step.content)
+                )
+                turn = ChatTurn(
+                    id=uuid4().hex,
+                    session_id=self._session_id,
+                    role="tool",
+                    content=content,
+                    tool_call_id=step.tool_call.id,
+                    run_id=result.run_id,
+                )
+                await self._history.append(turn)
+                if self._on_turn is not None:
+                    self._on_turn(turn)
+        return tuple(tool_calls)
+
+    async def _persist_steps_from_events(
+        self,
+        events: list[StreamingEvent],
+        *,
+        run_id: str,
+    ) -> None:
+        """Stream-path mirror of `_persist_steps_from_result` (bug-010).
+
+        Walks the buffered `kind="step"` events captured during
+        `agent.stream(...)`. `tool_call` rides on `event.metadata` as a
+        serialised dict (see `strategies._base._events_for_new_steps`)
+        so the session can persist tool turns without reaching into
+        `AgentState`.
+        """
+        if not self._persist_steps:
+            return
+        for event in events:
+            meta = event.metadata
+            kind = meta.get("kind")
+            tool_call_dict = meta.get("tool_call")
+            if kind not in ("act", "observe") or not isinstance(tool_call_dict, dict):
+                continue
+            tool_call = ToolCall.model_validate(tool_call_dict)
+            content = event.content if isinstance(event.content, str) else json.dumps(event.content)
+            if kind == "act":
+                turn = ChatTurn(
+                    id=uuid4().hex,
+                    session_id=self._session_id,
+                    role="assistant",
+                    content=content,
+                    run_id=run_id,
+                    tool_calls=(tool_call,),
+                )
+            else:  # observe
+                turn = ChatTurn(
+                    id=uuid4().hex,
+                    session_id=self._session_id,
+                    role="tool",
+                    content=content,
+                    tool_call_id=tool_call.id,
+                    run_id=run_id,
+                )
+            await self._history.append(turn)
+            if self._on_turn is not None:
+                self._on_turn(turn)
 
     async def _persist_assistant(
         self,
@@ -343,7 +448,7 @@ class ChatSession:
             async for chunk in self._chunks_for(response):
                 yield chunk
 
-    async def _stream_per_token(  # noqa: PLR0912
+    async def _stream_per_token(  # noqa: PLR0912, PLR0915
         self,
         message: str,
         *,
@@ -370,6 +475,10 @@ class ChatSession:
         assistant_turn_id = uuid4().hex
         cumulative = ""
         run_summary: dict[str, Any] | None = None
+        # Collected step events (bug-010): persisted as ChatTurns after
+        # the stream finishes but before the final assistant turn, so
+        # tool calls + results appear in causal order on disk.
+        step_events: list[StreamingEvent] = []
         start = time.monotonic()
         buffered = self._safety_mode in ("sentence-window", "stream-then-redact")
         window = _SentenceWindowBuffer() if buffered else None
@@ -381,6 +490,8 @@ class ChatSession:
                 # event and complete naturally so `Agent.stream`'s
                 # `finally: reset_run(token)` fires deterministically.
                 continue
+            if event.kind == "step":
+                step_events.append(event)
             if event.kind == "text" and isinstance(event.content, str):
                 if window is not None:
                     for sentence in window.push(event.content):
@@ -431,6 +542,11 @@ class ChatSession:
                 else cumulative
             )
             validated_out = await self._agent._guardrails.check_output(final_text, ctx)
+        # Persist intermediate tool steps before the final assistant
+        # turn (bug-010, stream path mirror of `_persist_steps_from_result`).
+        await self._persist_steps_from_events(
+            step_events, run_id=str(run_summary.get("run_id", ""))
+        )
         assistant_turn = ChatTurn(
             id=assistant_turn_id,
             session_id=self._session_id,

--- a/packages/agentforge-chat/tests/unit/test_session.py
+++ b/packages/agentforge-chat/tests/unit/test_session.py
@@ -19,6 +19,7 @@ from agentforge_core.values.messages import (
     LLMResponse,
     Message,
     TokenUsage,
+    ToolCall,
     ToolSpec,
 )
 from agentforge_core.values.state import AgentState, Step
@@ -241,3 +242,110 @@ async def test_close_is_idempotent() -> None:
     session = _session(session_id="t14")
     await session.close()
     await session.close()
+
+
+# ----------------------------------------------------------------------
+# bug-010 — persist intermediate tool steps to history
+# ----------------------------------------------------------------------
+
+
+class _ToolUseStrategy(ReasoningStrategy):
+    """Strategy that simulates one think/act/observe iteration with a
+    tool call, then a final think with the answer. Used to exercise
+    bug-010 persistence."""
+
+    def __init__(self, *, tool_id: str = "tc-1", tool_name: str = "ping") -> None:
+        self._tool_id = tool_id
+        self._tool_name = tool_name
+
+    async def run(self, state: AgentState) -> AgentState:
+        runtime = state.metadata.get(RUNTIME_KEY)
+        if runtime is not None:
+            runtime.budget.commit(0.01)
+        tc = ToolCall(id=self._tool_id, name=self._tool_name, arguments={"target": "x"})
+        state.steps.append(Step(iteration=0, kind="think", content="planning"))
+        state.steps.append(
+            Step(
+                iteration=0,
+                kind="act",
+                content={"tool": tc.name, "arguments": dict(tc.arguments)},
+                tool_call=tc,
+                cost_usd=0.0,
+            )
+        )
+        state.steps.append(
+            Step(
+                iteration=0,
+                kind="observe",
+                content='{"ok": true}',
+                tool_call=tc,
+                cost_usd=0.0,
+            )
+        )
+        state.steps.append(
+            Step(iteration=1, kind="think", content="all good", cost_usd=0.01),
+        )
+        return state
+
+
+def _tool_session(**kwargs: Any) -> ChatSession:
+    agent = Agent(model=_FakeLLM(), strategy=_ToolUseStrategy())
+    return ChatSession(agent, history_store=InMemoryChatHistory(), **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_persist_steps_records_act_and_observe_turns() -> None:
+    """bug-010: tool steps from result.steps must persist to chat history
+    so generative-UI clients can render them and the next turn's prompt
+    sees prior tool context."""
+    session = _tool_session(session_id="t-bug010-run")
+    await session.send("do the thing")
+    turns = await session.history()
+    roles_then_ids = [(t.role, t.tool_call_id, t.tool_calls) for t in turns]
+    # Expected shape: user, assistant(act with tool_calls), tool(observation),
+    # assistant(final answer).
+    assert [r for r, _, _ in roles_then_ids] == ["user", "assistant", "tool", "assistant"]
+    _, _, act_tcs = roles_then_ids[1]
+    assert len(act_tcs) == 1
+    assert act_tcs[0].id == "tc-1"
+    assert act_tcs[0].name == "ping"
+    _, observe_tcid, _ = roles_then_ids[2]
+    assert observe_tcid == "tc-1"
+
+
+@pytest.mark.asyncio
+async def test_response_tool_calls_populated_from_steps() -> None:
+    """bug-010: ChatResponse.tool_calls aggregates the tool calls from
+    `result.steps` instead of being the previously-hardcoded empty tuple."""
+    session = _tool_session(session_id="t-bug010-resp")
+    response = await session.send("do the thing")
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].id == "tc-1"
+
+
+@pytest.mark.asyncio
+async def test_persist_steps_false_keeps_history_lean() -> None:
+    """bug-010 opt-out: setting persist_steps=False reverts to the
+    pre-fix shape (user + final assistant only). Useful when an
+    external consumer reconstructs tool history from another source."""
+    session = _tool_session(session_id="t-bug010-off", persist_steps=False)
+    response = await session.send("do the thing")
+    turns = await session.history()
+    assert [t.role for t in turns] == ["user", "assistant"]
+    # And the response still surfaces an empty tool_calls (opt-out is
+    # consistent across persistence + response).
+    assert response.tool_calls == ()
+
+
+@pytest.mark.asyncio
+async def test_stream_persists_step_turns() -> None:
+    """bug-010 stream path: `_stream_per_token` must persist tool turns
+    via `_persist_steps_from_events` so streaming and non-streaming
+    paths produce the same on-disk shape."""
+    session = _tool_session(session_id="t-bug010-stream")
+    async for _ in await session.stream("do the thing"):
+        pass
+    turns = await session.history()
+    assert [t.role for t in turns] == ["user", "assistant", "tool", "assistant"]
+    # tool turn pairs by id with the prior assistant turn's tool_calls
+    assert turns[1].tool_calls[0].id == turns[2].tool_call_id

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-core"
-version = "0.2.3"
+version = "0.2.4"
 description = "AgentForge core — stable contracts (ABCs, value types) for the agentic framework"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-core/src/agentforge_core/config/schema.py
+++ b/packages/agentforge-core/src/agentforge_core/config/schema.py
@@ -269,6 +269,14 @@ class ChatSessionConfig(BaseModel):
     per_session_budget_usd: float | None = Field(default=None, ge=0.0)
     idempotency_window_s: float = Field(default=60.0, ge=0.0)
     concurrency: Literal["queue", "reject", "replace"] = "queue"
+    persist_steps: bool = True
+    """When True (default), intermediate `act` / `observe` agent steps
+    are persisted to `ChatHistoryStore` as `role="assistant"` (with
+    `tool_calls`) and `role="tool"` (with `tool_call_id`) turns
+    respectively, in addition to the final assistant turn. Tool-using
+    chat agents need this on for the next turn's prompt to reflect
+    what tools ran. Opt out by setting to False when an external
+    consumer reconstructs history from another source (bug-010)."""
     safety_mode: Literal["buffer-then-stream", "sentence-window", "stream-then-redact"] = (
         "buffer-then-stream"
     )

--- a/packages/agentforge-core/src/agentforge_core/values/messages.py
+++ b/packages/agentforge-core/src/agentforge_core/values/messages.py
@@ -24,6 +24,16 @@ StopReason = Literal["end_turn", "tool_use", "max_tokens", "stop_sequence", "oth
 """Provider-normalised reason the LLM stopped emitting tokens."""
 
 
+class ToolCall(BaseModel):
+    """A tool invocation emitted by the LLM."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    id: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
 class Message(BaseModel):
     """One turn in the chat-completion exchange."""
 
@@ -33,16 +43,7 @@ class Message(BaseModel):
     content: str
     name: str | None = None
     tool_call_id: str | None = None
-
-
-class ToolCall(BaseModel):
-    """A tool invocation emitted by the LLM."""
-
-    model_config = ConfigDict(frozen=True, strict=True)
-
-    id: str
-    name: str
-    arguments: dict[str, Any] = Field(default_factory=dict)
+    tool_calls: tuple[ToolCall, ...] = ()
 
 
 class ToolSpec(BaseModel):

--- a/packages/agentforge-core/tests/unit/test_messages.py
+++ b/packages/agentforge-core/tests/unit/test_messages.py
@@ -39,6 +39,17 @@ def test_message_accepts_each_valid_role(role: str) -> None:
     Message(role=role, content="ok")  # type: ignore[arg-type]
 
 
+def test_message_default_tool_calls_is_empty_tuple() -> None:
+    m = Message(role="assistant", content="hi")
+    assert m.tool_calls == ()
+
+
+def test_message_carries_tool_calls() -> None:
+    tc = ToolCall(id="t-1", name="search", arguments={"q": "hi"})
+    m = Message(role="assistant", content="", tool_calls=(tc,))
+    assert m.tool_calls == (tc,)
+
+
 # ---- ToolCall ----
 
 

--- a/packages/agentforge-eval-geval/pyproject.toml
+++ b/packages/agentforge-eval-geval/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-eval-geval"
-version = "0.2.3"
+version = "0.2.4"
 description = "LLM-judge evaluators (G-Eval) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "PyYAML>=6.0",
 ]
 

--- a/packages/agentforge-evidently/pyproject.toml
+++ b/packages/agentforge-evidently/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-evidently"
-version = "0.2.3"
+version = "0.2.4"
 description = "Evidently AI metrics + drift hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-guard-llamaguard/pyproject.toml
+++ b/packages/agentforge-guard-llamaguard/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-llamaguard"
-version = "0.2.3"
+version = "0.2.4"
 description = "Llama Guard 3 classifier for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.3"]
+dependencies = ["agentforge-core ~= 0.2.4"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-llmguard/pyproject.toml
+++ b/packages/agentforge-guard-llmguard/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-llmguard"
-version = "0.2.3"
+version = "0.2.4"
 description = "LLM Guard scanners for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.urls]

--- a/packages/agentforge-guard-nemo/pyproject.toml
+++ b/packages/agentforge-guard-nemo/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-nemo"
-version = "0.2.3"
+version = "0.2.4"
 description = "NeMo Guardrails programmable rails for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.2.3"]
+dependencies = ["agentforge-core ~= 0.2.4"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-presidio/pyproject.toml
+++ b/packages/agentforge-guard-presidio/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-presidio"
-version = "0.2.3"
+version = "0.2.4"
 description = "Microsoft Presidio PII detector for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.urls]

--- a/packages/agentforge-langfuse/pyproject.toml
+++ b/packages/agentforge-langfuse/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-langfuse"
-version = "0.2.3"
+version = "0.2.4"
 description = "Langfuse trace dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/pyproject.toml
+++ b/packages/agentforge-litellm/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-litellm"
-version = "0.2.3"
+version = "0.2.4"
 description = "LiteLLM router-based LLM provider for AgentForge — 100+ underlying providers through one interface"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-mcp/pyproject.toml
+++ b/packages/agentforge-mcp/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-mcp"
-version = "0.2.3"
+version = "0.2.4"
 description = "Model Context Protocol integration for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 # feat-013 v0.2: the `mcp` SDK is required only for the production

--- a/packages/agentforge-memory-neo4j/pyproject.toml
+++ b/packages/agentforge-memory-neo4j/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-memory-neo4j"
-version = "0.2.3"
+version = "0.2.4"
 description = "Neo4j-backed MemoryStore and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "neo4j>=5.20",
 ]
 

--- a/packages/agentforge-memory-postgres/pyproject.toml
+++ b/packages/agentforge-memory-postgres/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "agentforge-memory-postgres"
-version = "0.2.3"
+version = "0.2.4"
 description = "Postgres + pgvector-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "asyncpg>=0.30",
     "pgvector>=0.3",
 ]

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-memory-sqlite"
-version = "0.2.3"
+version = "0.2.4"
 description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "aiosqlite>=0.20",
 ]
 

--- a/packages/agentforge-memory-surrealdb/pyproject.toml
+++ b/packages/agentforge-memory-surrealdb/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "agentforge-memory-surrealdb"
-version = "0.2.3"
+version = "0.2.4"
 description = "SurrealDB-backed MemoryStore, VectorStore, and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "surrealdb>=1.0",
 ]
 

--- a/packages/agentforge-ollama/pyproject.toml
+++ b/packages/agentforge-ollama/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-ollama"
-version = "0.2.3"
+version = "0.2.4"
 description = "Ollama local LLM + embedding provider for AgentForge — llama / mistral / qwen / mxbai-embed on localhost"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-openai/pyproject.toml
+++ b/packages/agentforge-openai/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-openai"
-version = "0.2.3"
+version = "0.2.4"
 description = "OpenAI LLM + embeddings provider for AgentForge — gpt-4o / o-series + text-embedding-3-*"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-openai/src/agentforge_openai/client.py
+++ b/packages/agentforge-openai/src/agentforge_openai/client.py
@@ -14,6 +14,7 @@ Finish reasons normalised:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
@@ -298,6 +299,24 @@ def _message_to_openai(message: Message) -> dict[str, Any]:
     if message.role == "system":
         # Should be hoisted by the caller; defensive passthrough.
         return {"role": "system", "content": message.content}
+    if message.role == "assistant" and message.tool_calls:
+        # Round-trip tool_calls so the subsequent role="tool" message
+        # pairs cleanly via tool_call_id (bug-009).
+        return {
+            "role": "assistant",
+            "content": message.content or None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(dict(tc.arguments)),
+                    },
+                }
+                for tc in message.tool_calls
+            ],
+        }
     return {"role": message.role, "content": message.content}
 
 

--- a/packages/agentforge-openai/tests/unit/test_openai_client.py
+++ b/packages/agentforge-openai/tests/unit/test_openai_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
-from agentforge_core.values.messages import Message, ToolSpec
+from agentforge_core.values.messages import Message, ToolCall, ToolSpec
 from agentforge_openai import OpenAIClient
 from agentforge_openai._inmem_runner import FakeOpenAIRunner
 from agentforge_openai._pricing import chat_cost_usd
@@ -225,6 +227,46 @@ async def test_tool_role_messages_pass_with_tool_call_id(
     assert sent["role"] == "tool"
     assert sent["tool_call_id"] == "call_1"
     assert sent["content"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_assistant_turn_with_tool_calls_emits_openai_tool_calls(
+    client: OpenAIClient,
+    fake_runner: FakeOpenAIRunner,
+) -> None:
+    """bug-009: an assistant Message carrying framework tool_calls must
+    serialise to OpenAI's `tool_calls` array with JSON-encoded arguments,
+    so the subsequent role="tool" message pairs cleanly via tool_call_id."""
+    fake_runner.set_chat_response(
+        {
+            "model": "gpt-4o-mini",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": ""},
+                    "finish_reason": "stop",
+                },
+            ],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        },
+    )
+    await client.call(
+        system="",
+        messages=[
+            Message(
+                role="assistant",
+                content="calling",
+                tool_calls=(ToolCall(id="call_1", name="search", arguments={"q": "x"}),),
+            ),
+            Message(role="tool", content="result", tool_call_id="call_1"),
+        ],
+    )
+    sent = fake_runner.chat_calls[0].messages[0]
+    assert sent["role"] == "assistant"
+    assert sent["tool_calls"][0]["id"] == "call_1"
+    assert sent["tool_calls"][0]["type"] == "function"
+    assert sent["tool_calls"][0]["function"]["name"] == "search"
+    assert json.loads(sent["tool_calls"][0]["function"]["arguments"]) == {"q": "x"}
 
 
 @pytest.mark.asyncio

--- a/packages/agentforge-otel/pyproject.toml
+++ b/packages/agentforge-otel/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-otel"
-version = "0.2.3"
+version = "0.2.4"
 description = "OpenTelemetry tracing + metrics emitter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-grpc>=1.27",
 ]

--- a/packages/agentforge-phoenix/pyproject.toml
+++ b/packages/agentforge-phoenix/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-phoenix"
-version = "0.2.3"
+version = "0.2.4"
 description = "Arize Phoenix dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-cohere/pyproject.toml
+++ b/packages/agentforge-reranker-cohere/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-reranker-cohere"
-version = "0.2.3"
+version = "0.2.4"
 description = "Cohere managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-mixedbread/pyproject.toml
+++ b/packages/agentforge-reranker-mixedbread/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.3"
+version = "0.2.4"
 description = "Mixedbread AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-sentence-transformers/pyproject.toml
+++ b/packages/agentforge-reranker-sentence-transformers/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.3"
+version = "0.2.4"
 description = "SentenceTransformers cross-encoder reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-voyage/pyproject.toml
+++ b/packages/agentforge-reranker-voyage/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-voyage"
-version = "0.2.3"
+version = "0.2.4"
 description = "Voyage AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-statsd/pyproject.toml
+++ b/packages/agentforge-statsd/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-statsd"
-version = "0.2.3"
+version = "0.2.4"
 description = "StatsD metrics emitter hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-testing/pyproject.toml
+++ b/packages/agentforge-testing/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-testing"
-version = "0.2.3"
+version = "0.2.4"
 description = "Richer test helpers for AgentForge (golden-set runner, snapshot, recording analysis)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
-    "agentforge-py ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
+    "agentforge-py ~= 0.2.4",
 ]
 
 [project.urls]

--- a/packages/agentforge-voyage/pyproject.toml
+++ b/packages/agentforge-voyage/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-voyage"
-version = "0.2.3"
+version = "0.2.4"
 description = "Voyage AI embedding provider for AgentForge — voyage-3 / voyage-large / voyage-code"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "agentforge-py"
-version = "0.2.3"
+version = "0.2.4"
 description = "AgentForge — open-source plug-and-play framework for production AI agents"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.2.3",
+    "agentforge-core ~= 0.2.4",
     "pydantic>=2.10",
     "pyyaml>=6.0",
     "typer>=0.15",
@@ -60,93 +60,93 @@ dependencies = [
 # `pip install "agentforge-py[<provider>]"` lands both the framework
 # wrapper AND the underlying SDK. ollama / litellm bundle their SDK
 # as a hard dep, so no `[<sdk>]` extra is needed.
-anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.3"]
-openai = ["agentforge-openai[openai] ~= 0.2.3"]
-bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.3"]
-ollama = ["agentforge-ollama ~= 0.2.3"]
-litellm = ["agentforge-litellm ~= 0.2.3"]
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.4"]
+openai = ["agentforge-openai[openai] ~= 0.2.4"]
+bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.4"]
+ollama = ["agentforge-ollama ~= 0.2.4"]
+litellm = ["agentforge-litellm ~= 0.2.4"]
 
 # Embeddings
-voyage = ["agentforge-voyage ~= 0.2.3"]
+voyage = ["agentforge-voyage ~= 0.2.4"]
 
 # Memory backends
-memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.3"]
-memory-postgres = ["agentforge-memory-postgres ~= 0.2.3"]
-memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.3"]
-memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.3"]
+memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.4"]
+memory-postgres = ["agentforge-memory-postgres ~= 0.2.4"]
+memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.4"]
+memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.4"]
 
 # Chat surface
-chat = ["agentforge-chat ~= 0.2.3"]
-chat-http = ["agentforge-chat-http ~= 0.2.3"]
-chat-slack = ["agentforge-chat-slack ~= 0.2.3"]
-chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.3"]
-chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.3"]
+chat = ["agentforge-chat ~= 0.2.4"]
+chat-http = ["agentforge-chat-http ~= 0.2.4"]
+chat-slack = ["agentforge-chat-slack ~= 0.2.4"]
+chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.4"]
+chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.4"]
 
 # Rerankers
-reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.3"]
-reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.3"]
-reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.3"]
-reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.3"]
+reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.4"]
+reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.4"]
+reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.4"]
+reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.4"]
 
 # Guardrails
-guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.3"]
-guard-presidio = ["agentforge-guard-presidio ~= 0.2.3"]
-guard-nemo = ["agentforge-guard-nemo ~= 0.2.3"]
-guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.3"]
+guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.4"]
+guard-presidio = ["agentforge-guard-presidio ~= 0.2.4"]
+guard-nemo = ["agentforge-guard-nemo ~= 0.2.4"]
+guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.4"]
 
 # Observability
-langfuse = ["agentforge-langfuse ~= 0.2.3"]
-phoenix = ["agentforge-phoenix ~= 0.2.3"]
-otel = ["agentforge-otel ~= 0.2.3"]
-statsd = ["agentforge-statsd ~= 0.2.3"]
-evidently = ["agentforge-evidently ~= 0.2.3"]
+langfuse = ["agentforge-langfuse ~= 0.2.4"]
+phoenix = ["agentforge-phoenix ~= 0.2.4"]
+otel = ["agentforge-otel ~= 0.2.4"]
+statsd = ["agentforge-statsd ~= 0.2.4"]
+evidently = ["agentforge-evidently ~= 0.2.4"]
 
 # Protocols
-mcp = ["agentforge-mcp ~= 0.2.3"]
-a2a = ["agentforge-a2a ~= 0.2.3"]
+mcp = ["agentforge-mcp ~= 0.2.4"]
+a2a = ["agentforge-a2a ~= 0.2.4"]
 
 # Eval
-eval = ["agentforge-eval-geval ~= 0.2.3"]
+eval = ["agentforge-eval-geval ~= 0.2.4"]
 
 # Testing
-testing = ["agentforge-testing ~= 0.2.3"]
+testing = ["agentforge-testing ~= 0.2.4"]
 
 # Everything (development / docs / smoke-test convenience — not
 # recommended for production deploys; pick the actual integrations
 # you use to keep the dependency tree small).
 all = [
-    "agentforge-anthropic ~= 0.2.3",
-    "agentforge-openai ~= 0.2.3",
-    "agentforge-bedrock ~= 0.2.3",
-    "agentforge-ollama ~= 0.2.3",
-    "agentforge-litellm ~= 0.2.3",
-    "agentforge-voyage ~= 0.2.3",
-    "agentforge-memory-sqlite ~= 0.2.3",
-    "agentforge-memory-postgres ~= 0.2.3",
-    "agentforge-memory-neo4j ~= 0.2.3",
-    "agentforge-memory-surrealdb ~= 0.2.3",
-    "agentforge-chat ~= 0.2.3",
-    "agentforge-chat-http ~= 0.2.3",
-    "agentforge-chat-slack ~= 0.2.3",
-    "agentforge-chat-history-postgres ~= 0.2.3",
-    "agentforge-chat-history-redis ~= 0.2.3",
-    "agentforge-reranker-cohere ~= 0.2.3",
-    "agentforge-reranker-voyage ~= 0.2.3",
-    "agentforge-reranker-mixedbread ~= 0.2.3",
-    "agentforge-reranker-sentence-transformers ~= 0.2.3",
-    "agentforge-guard-llmguard ~= 0.2.3",
-    "agentforge-guard-presidio ~= 0.2.3",
-    "agentforge-guard-nemo ~= 0.2.3",
-    "agentforge-guard-llamaguard ~= 0.2.3",
-    "agentforge-langfuse ~= 0.2.3",
-    "agentforge-phoenix ~= 0.2.3",
-    "agentforge-otel ~= 0.2.3",
-    "agentforge-statsd ~= 0.2.3",
-    "agentforge-evidently ~= 0.2.3",
-    "agentforge-mcp ~= 0.2.3",
-    "agentforge-a2a ~= 0.2.3",
-    "agentforge-eval-geval ~= 0.2.3",
-    "agentforge-testing ~= 0.2.3",
+    "agentforge-anthropic ~= 0.2.4",
+    "agentforge-openai ~= 0.2.4",
+    "agentforge-bedrock ~= 0.2.4",
+    "agentforge-ollama ~= 0.2.4",
+    "agentforge-litellm ~= 0.2.4",
+    "agentforge-voyage ~= 0.2.4",
+    "agentforge-memory-sqlite ~= 0.2.4",
+    "agentforge-memory-postgres ~= 0.2.4",
+    "agentforge-memory-neo4j ~= 0.2.4",
+    "agentforge-memory-surrealdb ~= 0.2.4",
+    "agentforge-chat ~= 0.2.4",
+    "agentforge-chat-http ~= 0.2.4",
+    "agentforge-chat-slack ~= 0.2.4",
+    "agentforge-chat-history-postgres ~= 0.2.4",
+    "agentforge-chat-history-redis ~= 0.2.4",
+    "agentforge-reranker-cohere ~= 0.2.4",
+    "agentforge-reranker-voyage ~= 0.2.4",
+    "agentforge-reranker-mixedbread ~= 0.2.4",
+    "agentforge-reranker-sentence-transformers ~= 0.2.4",
+    "agentforge-guard-llmguard ~= 0.2.4",
+    "agentforge-guard-presidio ~= 0.2.4",
+    "agentforge-guard-nemo ~= 0.2.4",
+    "agentforge-guard-llamaguard ~= 0.2.4",
+    "agentforge-langfuse ~= 0.2.4",
+    "agentforge-phoenix ~= 0.2.4",
+    "agentforge-otel ~= 0.2.4",
+    "agentforge-statsd ~= 0.2.4",
+    "agentforge-evidently ~= 0.2.4",
+    "agentforge-mcp ~= 0.2.4",
+    "agentforge-a2a ~= 0.2.4",
+    "agentforge-eval-geval ~= 0.2.4",
+    "agentforge-testing ~= 0.2.4",
 ]
 
 [project.scripts]

--- a/packages/agentforge/src/agentforge/strategies/_base.py
+++ b/packages/agentforge/src/agentforge/strategies/_base.py
@@ -54,18 +54,29 @@ log = logging.getLogger(__name__)
 def _events_for_new_steps(steps: list[Step], before: int) -> list[StreamingEvent]:
     """Build ``step`` `StreamingEvent`s for every step appended since
     the ``before`` index. Keeps the streaming-side rendering of state
-    deltas separate from the strategy's recording semantics."""
-    return [
-        StreamingEvent(
-            kind="step",
-            content=step.content,
-            metadata={
-                "iteration": step.iteration,
-                "kind": step.kind,
-            },
+    deltas separate from the strategy's recording semantics.
+
+    ``tool_call`` is mirrored into metadata as a serialised dict when
+    present, so streaming consumers (e.g. `ChatSession._stream_per_token`,
+    bug-010) can persist tool turns alongside the final assistant turn
+    without needing access to the underlying `AgentState`.
+    """
+    out: list[StreamingEvent] = []
+    for step in steps[before:]:
+        metadata: dict[str, Any] = {
+            "iteration": step.iteration,
+            "kind": step.kind,
+        }
+        if step.tool_call is not None:
+            metadata["tool_call"] = step.tool_call.model_dump()
+        out.append(
+            StreamingEvent(
+                kind="step",
+                content=step.content,
+                metadata=metadata,
+            )
         )
-        for step in steps[before:]
-    ]
+    return out
 
 
 def get_runtime(state: AgentState) -> RuntimeContext:

--- a/packages/agentforge/src/agentforge/strategies/react.py
+++ b/packages/agentforge/src/agentforge/strategies/react.py
@@ -83,7 +83,16 @@ class ReActLoop(StrategyBase):
                     break
 
                 # Record the assistant's turn for the next iteration's context.
-                messages.append(Message(role="assistant", content=response.content))
+                # `tool_calls` must round-trip so provider clients can emit
+                # native tool-use blocks matching the subsequent tool result
+                # (bug-009 — Bedrock Converse rejects orphaned toolResult).
+                messages.append(
+                    Message(
+                        role="assistant",
+                        content=response.content,
+                        tool_calls=response.tool_calls,
+                    )
+                )
 
                 # Dispatch every tool call the LLM emitted.
                 for tool_call in response.tool_calls:
@@ -174,7 +183,13 @@ class ReActLoop(StrategyBase):
                 if not response.tool_calls:
                     break
 
-                messages.append(Message(role="assistant", content=response.content))
+                messages.append(
+                    Message(
+                        role="assistant",
+                        content=response.content,
+                        tool_calls=response.tool_calls,
+                    )
+                )
 
                 for tool_call in response.tool_calls:
                     self._record_step(

--- a/packages/agentforge/tests/unit/test_react_stream.py
+++ b/packages/agentforge/tests/unit/test_react_stream.py
@@ -96,6 +96,29 @@ async def test_stream_emits_per_step_then_canonical_done() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_assistant_turn_round_trips_tool_calls() -> None:
+    """bug-009 (stream path): the assistant Message re-fed on iteration 2
+    must carry the previous iteration's tool_calls so provider clients
+    can emit matching tool-use blocks."""
+    tc = ToolCall(id="t-1", name="search", arguments={"query": "x"})
+    fake = FakeLLMClient(
+        responses=[
+            _llm_response(content="I'll search.", stop_reason="tool_use", tool_calls=(tc,)),
+            _llm_response(content="found it", stop_reason="end_turn"),
+        ],
+    )
+    agent = Agent(model=fake, tools=[_FakeSearchTool()], strategy=ReActLoop())
+
+    async for _ in agent.stream("find x"):
+        pass
+
+    _, iter2_messages, _ = fake.captured[1]
+    assistant_turns = [m for m in iter2_messages if m.role == "assistant"]
+    assert len(assistant_turns) == 1
+    assert assistant_turns[0].tool_calls == (tc,)
+
+
+@pytest.mark.asyncio
 async def test_strategy_stream_yields_strategy_level_done_when_driven_directly() -> None:
     """When a caller drives `strategy.stream(state)` directly (bypassing
     Agent.stream), the strategy's own `done` event surfaces — it carries

--- a/packages/agentforge/tests/unit/test_strategies_react.py
+++ b/packages/agentforge/tests/unit/test_strategies_react.py
@@ -138,6 +138,34 @@ async def test_dispatches_tool_call_then_finishes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_assistant_turn_round_trips_tool_calls() -> None:
+    """bug-009: the assistant Message re-fed on iteration 2 must carry
+    the previous iteration's tool_calls so provider clients can emit
+    matching tool-use blocks (Bedrock toolUse, OpenAI tool_calls,
+    Anthropic tool_use)."""
+    tc = ToolCall(id="t1", name="ping", arguments={"target": "example.com"})
+    fake = FakeLLMClient(
+        responses=[
+            _resp(
+                content="I'll ping example.com.",
+                tool_calls=(tc,),
+                stop_reason="tool_use",
+            ),
+            _resp(content="example.com is up."),
+        ]
+    )
+    state = _state_for(fake, tools=(_PingTool(),))
+
+    await ReActLoop().run(state)
+
+    # captured[1] is the iteration-2 call: (system, messages, tools).
+    _, iter2_messages, _ = fake.captured[1]
+    assistant_turns = [m for m in iter2_messages if m.role == "assistant"]
+    assert len(assistant_turns) == 1
+    assert assistant_turns[0].tool_calls == (tc,)
+
+
+@pytest.mark.asyncio
 async def test_unknown_tool_recorded_as_error_observation() -> None:
     """LLM emits a tool name that isn't in the agent's catalogue —
     recorded as observation; error_streak increments; agent continues."""

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ members = [
 
 [[package]]
 name = "agentforge-a2a"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-a2a" }
 dependencies = [
     { name = "agentforge-core" },
@@ -72,7 +72,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-anthropic"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-anthropic" }
 dependencies = [
     { name = "agentforge-core" },
@@ -92,7 +92,7 @@ provides-extras = ["anthropic"]
 
 [[package]]
 name = "agentforge-bedrock"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-bedrock" }
 dependencies = [
     { name = "agentforge-core" },
@@ -109,7 +109,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge-core" },
@@ -131,7 +131,7 @@ provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-chat-history-postgres"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-chat-history-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -146,7 +146,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-history-redis"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-chat-history-redis" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -163,7 +163,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-http"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-chat-http" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -186,7 +186,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-slack"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-chat-slack" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -205,7 +205,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-core"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-core" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -222,7 +222,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-eval-geval"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-eval-geval" }
 dependencies = [
     { name = "agentforge-core" },
@@ -237,7 +237,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-evidently"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-evidently" }
 dependencies = [
     { name = "agentforge-core" },
@@ -257,7 +257,7 @@ provides-extras = ["evidently"]
 
 [[package]]
 name = "agentforge-guard-llamaguard"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-guard-llamaguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -268,7 +268,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llmguard"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-guard-llmguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -279,7 +279,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-nemo"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-guard-nemo" }
 dependencies = [
     { name = "agentforge-core" },
@@ -290,7 +290,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-presidio"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-guard-presidio" }
 dependencies = [
     { name = "agentforge-core" },
@@ -301,7 +301,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-langfuse"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-langfuse" }
 dependencies = [
     { name = "agentforge-core" },
@@ -321,7 +321,7 @@ provides-extras = ["langfuse"]
 
 [[package]]
 name = "agentforge-litellm"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-litellm" }
 dependencies = [
     { name = "agentforge-core" },
@@ -341,7 +341,7 @@ provides-extras = ["litellm"]
 
 [[package]]
 name = "agentforge-mcp"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-mcp" }
 dependencies = [
     { name = "agentforge-core" },
@@ -361,7 +361,7 @@ provides-extras = ["mcp"]
 
 [[package]]
 name = "agentforge-memory-neo4j"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-memory-neo4j" }
 dependencies = [
     { name = "agentforge-core" },
@@ -376,7 +376,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-postgres"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-memory-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -393,7 +393,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-sqlite"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-memory-sqlite" }
 dependencies = [
     { name = "agentforge-core" },
@@ -408,7 +408,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-surrealdb"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-memory-surrealdb" }
 dependencies = [
     { name = "agentforge-core" },
@@ -423,7 +423,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-ollama"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-ollama" }
 dependencies = [
     { name = "agentforge-core" },
@@ -443,7 +443,7 @@ provides-extras = ["ollama"]
 
 [[package]]
 name = "agentforge-openai"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-openai" }
 dependencies = [
     { name = "agentforge-core" },
@@ -463,7 +463,7 @@ provides-extras = ["openai"]
 
 [[package]]
 name = "agentforge-otel"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-otel" }
 dependencies = [
     { name = "agentforge-core" },
@@ -480,7 +480,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-phoenix"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-phoenix" }
 dependencies = [
     { name = "agentforge-core" },
@@ -500,7 +500,7 @@ provides-extras = ["phoenix"]
 
 [[package]]
 name = "agentforge-py"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge" }
 dependencies = [
     { name = "agentforge-core" },
@@ -718,7 +718,7 @@ provides-extras = ["anthropic", "openai", "bedrock", "ollama", "litellm", "voyag
 
 [[package]]
 name = "agentforge-reranker-cohere"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-reranker-cohere" }
 dependencies = [
     { name = "agentforge-core" },
@@ -738,7 +738,7 @@ provides-extras = ["cohere"]
 
 [[package]]
 name = "agentforge-reranker-mixedbread"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-reranker-mixedbread" }
 dependencies = [
     { name = "agentforge-core" },
@@ -758,7 +758,7 @@ provides-extras = ["mixedbread"]
 
 [[package]]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-reranker-sentence-transformers" }
 dependencies = [
     { name = "agentforge-core" },
@@ -778,7 +778,7 @@ provides-extras = ["sentence-transformers"]
 
 [[package]]
 name = "agentforge-reranker-voyage"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-reranker-voyage" }
 dependencies = [
     { name = "agentforge-core" },
@@ -798,7 +798,7 @@ provides-extras = ["voyage"]
 
 [[package]]
 name = "agentforge-statsd"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-statsd" }
 dependencies = [
     { name = "agentforge-core" },
@@ -818,7 +818,7 @@ provides-extras = ["statsd"]
 
 [[package]]
 name = "agentforge-testing"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-testing" }
 dependencies = [
     { name = "agentforge-core" },
@@ -833,7 +833,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-voyage"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/agentforge-voyage" }
 dependencies = [
     { name = "agentforge-core" },


### PR DESCRIPTION
## What

Round-trips `tool_calls` end-to-end. Two related defects from a live
downstream integration ship together because they're two halves of one
problem — tool calls must survive **both** the in-flight LLM history
(bug-009) and the persisted chat history (bug-010).

First slice of **v0.2.4**. (The MCP/chat/config cluster triaged in #57
also folds into v0.2.4 — the CHANGELOG `[0.2.4]` entry will grow as those
fixes land.)

## bug-009 (P0) — ReAct dropped `tool_calls` on assistant turns

`Message` had no `tool_calls` field, so `ReActLoop` dropped them when
re-feeding the assistant turn, and provider clients emitted no native
tool-use blocks. Bedrock Converse rejected the orphaned `toolResult` on
iteration 2 → **every tool-using ReAct prompt on Bedrock failed**. The
same latent shape existed in OpenAI and Anthropic-direct; all three are
fixed.

- `agentforge-core`: `Message` gains `tool_calls: tuple[ToolCall, ...] = ()`
  (frozen, default-empty, backwards-compatible).
- `agentforge`: `ReActLoop.run` / `.stream` populate `Message.tool_calls`
  from `response.tool_calls` on the assistant turn.
- `agentforge-{bedrock,openai,anthropic}`: emit native tool-use blocks.

## bug-010 (P2) — `ChatSession` dropped intermediate tool steps

Tool-using chats persisted only the user prompt + final assistant text;
intermediate `act`/`observe` steps never reached `ChatHistoryStore`, so
Generative-UI clients couldn't render tool activity and the next turn's
prompt lost prior tool context.

- New opt-out `ChatSessionConfig.persist_steps: bool = True`.
- `_persist_steps_from_result` (sync) + `_persist_steps_from_events`
  (streaming) persist `act` → assistant turn w/ `tool_calls` and
  `observe` → `tool` turn.
- Additive `StreamingEvent.metadata["tool_call"]` so the stream path
  persists without reaching into `AgentState`.
- `ChatResponse.tool_calls` now populated from aggregated act-step calls
  (was hardcoded `()`).

## Tests / gate

- +14 regression tests (1318 → 1332).
- Full pre-commit gate green on every commit (ruff / mypy --strict /
  bandit / pytest unit+integration / coverage ≥ 90).
- All 34 workspace packages bumped 0.2.3 → 0.2.4 (coordinated release
  train per ADR-0015); `uv.lock` regenerated.

## Follow-ups (filed, not in this PR)

- bug-011 — provider conformance harness (motivated by bug-009 passing
  all unit tests because fakes accept any payload shape). Targeted v0.3.
- MCP/chat/config cluster (bug-012–020, enh-001) — triaged in #57, fixes
  fold into v0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
