### PR TITLE
fix: wire modules.protocols → MCP runtime (bug-020 P0 + bug-014 P1)

### DIFF
--- a/.claude/state/README.md
+++ b/.claude/state/README.md
@@ -32,8 +32,20 @@ ended.
   description; the user will see it on next session resume.
 - **When you find a bug from a previous feature.** Append a
   `[BUG-CARRIED]` entry to `log.md` under the active feature.
+- **At session end / when pausing mid-feature.** Update `current.md`
+  (`state:`, a `resume:` marker, and a concrete pickup list with open
+  PR URLs + branch names), append a dated `log.md` milestone, then
+  **commit and push both** on the current branch. Never leave
+  `current.md` / `log.md` as a local-only working-tree change — unpushed
+  state is invisible to a resume from another clone and silently drifts.
+  Rule of thumb: if someone else pulled right now, could they continue?
 
 ## Pre-commit enforcement
+
+> **Note:** the `check_state_updated.py` hook described below is not
+> currently wired into `.pre-commit-config.yaml` (aspirational). State
+> currency is maintained by the "When to write" discipline above until
+> the hook lands.
 
 `scripts/check_state_updated.py` runs on every commit and verifies:
 

--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,67 +1,67 @@
 ---
-feature: bug-009 + bug-010 (tool_calls round-trip end-to-end)
+feature: v0.2.4 MCP/chat/config cluster — bug-020 + bug-014 (MCP runtime wiring)
 state: pr-pending
-branch: fix/bug-009-react-loop-drops-tool-calls
-started_at: 2026-05-27
-last_milestone_at: 2026-05-27
-last_shipped: v0.2.3 — Upgrade-flow fix (bug-007) — PR #55 merged 2026-05-21; tag v0.2.3 pushed; GitHub Release published. 32 of 34 packages live on PyPI (presidio/nemo/llamaguard/evidently added 2026-05-27; phoenix + statsd remain).
+branch: fix/bug-020-mcp-runtime-wiring
+started_at: 2026-06-02
+last_milestone_at: 2026-06-02
+last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
+resume: evening IST 2026-06-02
 flags_for_user:
-  - "PR NOT OPENED YET. Branch fix/bug-009-react-loop-drops-tool-calls pushed with 6 green commits covering bug-009 + bug-010. URL: https://github.com/Scaffoldic/agentforge-py/pull/new/fix/bug-009-react-loop-drops-tool-calls. Suggested title: \"fix: round-trip tool_calls end-to-end (bug-009 + bug-010)\"."
-  - "9 NEW untracked bug docs filed by user in parallel during this session: bug-012 through bug-020 in docs/bugs/. Not reviewed or committed yet — user WIP. (The earlier bug-011 collision was self-resolved: the runtime-doesnt-wire-mcp-bridge content is now at bug-020.)"
-  - "32 of 34 packages live on PyPI at v0.2.3 (phoenix + statsd pending — final drip window 2026-05-28 ≈ 11:05 UTC)."
-  - "bug-008 also queued for v0.2.4 (NOT IN THIS BRANCH): `version(\"agentforge\")` should be `version(\"agentforge-py\")` in cli/new_cmd.py and cli/_shared_scaffold.py. ~5 lines. Either fold into the v0.2.4 train (add a 7th commit) or ship as a separate small PR before tagging v0.2.4."
-  - "v0.2.2 git tag is local-only (intentional — v0.2.3 supersedes). Pushing it burns a quota window without landing anything new."
-  - "Production PyPI token still sitting in `~/.pypirc [pypi]` (one-time rescue path from 2026-05-20). Should be revoked on PyPI's web UI when convenient."
+  - "PR #59 OPEN (fix/bug-020-mcp-runtime-wiring): bug-020 P0 + bug-014 P1. 2 commits (9282000, 25a43bb), full gate green, pushed. https://github.com/Scaffoldic/agentforge-py/pull/59 — awaiting merge."
+  - "PRs #57 (docs triage) + #58 (bug-009/010 fix) MERGED to main. main at version 0.2.4."
+  - "REMAINING v0.2.4 cluster (not started), suggested order: bug-012 (adapter .→_ separator) → bug-017 (Bedrock tool-name validator + docs) → bug-015 (meta extra chain agentforge-py[mcp]→agentforge-mcp[mcp] + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
+  - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
+  - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
+  - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
 ---
 
 ## Active feature
 
-**bug-009 + bug-010 — tool_calls round-trip end-to-end.**
+**v0.2.4 MCP/chat/config cluster.** Eight framework defects + one
+enhancement filed against v0.2.3 from the first live Bedrock-backed
+MCP integration. Triaged, verified against source, and tracked in
+`docs/bugs/bug-012…020` + `docs/enhancements/enh-001` (PR #57, merged).
+Each bug doc carries a "Framework-level vs derived-agent-level"
+section; all eight are framework-level. The whole cluster folds into
+**v0.2.4** (no release until it all lands).
 
-Both shipped together on a single branch because they're two
-halves of the same problem: bug-009 round-trips `tool_calls`
-in-flight (LLM history within one agent run), bug-010 round-trips
-them across runs (chat history persisted to disk). External
-downstream consumer surfaced both during a Generative-UI
-integration design review on 2026-05-27.
-
-**Branch:** `fix/bug-009-react-loop-drops-tool-calls` (off main @ `97eb35a`). Pushed.
-
-**6 commits, all green through full pre-commit:**
+**In flight — PR #59** (`fix/bug-020-mcp-runtime-wiring`, off main):
 
 | # | Commit | Bug | Scope |
 |---|---|---|---|
-| 1 | `294ab12` | 009 | core `Message.tool_calls` + ReActLoop populate + tests |
-| 2 | `23be0e0` | 009 | bedrock/openai/anthropic `_message_to_<provider>` + tests |
-| 3 | `638700a` | 009 | bug-009 status → fixed, new bug-011 (provider-conformance-harness) follow-up, CHANGELOG |
-| 4 | `a53d68d` | 009 | workspace bump 0.2.3 → 0.2.4 (34 pyprojects + uv.lock + state/current.md) |
-| 5 | `74e02eb` | 010 | `persist_steps` schema + helpers + StreamingEvent metadata enrichment + ChatResponse.tool_calls population |
-| 6 | `f25b7f8` | 010 | 4 regression tests + bug-010 doc → fixed + CHANGELOG amend |
+| 1 | `9282000` | 014 | `MCPBridge.from_config` pure-data; async `start()` materialises deferred client specs; `_await_sync` deleted; `attach_local_tools` + `MCPServer.set_tools`; list-form `command:`. Tests. |
+| 2 | `25a43bb` | 020 | `agentforge_core.contracts.protocol_bridge.ProtocolBridge` (runtime_checkable); `Agent(protocol_bridges=)` + close on exit; `build_protocols_from_config` wired into `build_agent_from_config` (also wires native `agent.tools` — previously zero-caller gap); expose rejected (stdio-hijack guard). Tests. feat-013 §10 + CHANGELOG. |
 
-**Test count:** 1318 → 1332 (+14 regression tests across both bugs).
+Full pre-commit gate green on both commits. Scope: **consume path
+only**; server-side `expose` runtime-wiring deferred (with enh-001).
 
-**Plan file:** `/Users/khemchandjoshi/.claude/plans/cosmic-puzzling-shell.md`.
+## Pickup on resume (evening IST 2026-06-02)
 
-## Pickup on resume (2026-05-28)
-
-1. **Triage the 9 new bug docs (bug-012 … bug-020).** They appeared
-   untracked during this session. Review each, decide which need
-   fixes in v0.2.4 vs deferred, commit the doc files in a `docs:`
-   chunk (likely a separate PR from the bug-009+010 branch). At
-   minimum bug-020 (runtime-doesnt-wire-mcp-bridge) was previously
-   colliding with the bug-011 slot and is now resolved.
-2. **Decide bug-008 inclusion.** ~5-line fix
-   (`version("agentforge")` → `version("agentforge-py")` in
-   `cli/new_cmd.py` + `cli/_shared_scaffold.py`). Either fold into
-   this branch as a 7th commit, or ship as a separate small PR before
-   tagging v0.2.4.
-3. **Open the PR.** `gh pr create` against main with the title above.
-4. **Drip-publish phoenix + statsd at v0.2.3.** Final two packages.
-   Window opens ≈ 2026-05-28 11:05 UTC. See `PYPI_PUBLISH_TRACKER.md`.
-5. **After v0.2.3 drip completes AND bug-009+010 PR merges:** tag
-   `v0.2.4`, push, run `release.yml`. 34 packages already version-
-   bumped on this branch.
+1. **Merge PR #59** (bug-020 + bug-014) once reviewed/CI-green.
+2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
+   branch off main, folding into v0.2.4), suggested order:
+   - **bug-012** — adapter `.`→`_` separator (`adapter.py:34`).
+   - **bug-017** — defensive Bedrock tool-name validator
+     (`[a-zA-Z0-9_-]+`) + document the constraint (feat-004/003/013
+     specs + `@tool` docstring + templates). Backs up bug-012.
+   - **bug-015** — meta extra chain: `agentforge/pyproject.toml:105`
+     `mcp = ["agentforge-mcp ~= 0.2.4"]` → `["agentforge-mcp[mcp] ~= 0.2.4"]`;
+     fix the `ModuleError` text; audit other vendor modules for the
+     same broken chain.
+   - **bug-019** — `mode="before"` string→{name} normaliser for
+     `modules.evaluators` + guardrail `input`/`output`/`tool_gates`
+     (both EvaluatorEntry AND GuardrailEntry are broken).
+   - **bug-018** — `SqliteChatHistory.update_session_metadata` upsert
+     (option 1, minimal) + `ChatHistoryStore.create_session()` ABC
+     (option 2, contract fix) — both in one PR.
+   - **bug-013** — `from_stdio`/`from_http` auto-call `register_tools()`.
+   - **enh-001** — HTTP MCP server transport (may slip to 0.2.5).
+3. **bug-008** (~5 lines) — fold in somewhere before tagging.
+4. **Tag v0.2.4** only after the cluster lands: set CHANGELOG date,
+   push tag, run `release.yml` (34 packages already at 0.2.4 on main).
+5. **PyPI post-drip chores** (drip is 34/34 done): revoke `~/.pypirc`
+   token, Trusted Publishing conversion, delete `PYPI_PUBLISH_TRACKER.md`.
 
 ## Last shipped
 
@@ -71,9 +71,9 @@ integration design review on 2026-05-27.
 - Tag: `v0.2.3` annotated at the merge commit.
 - GitHub Release: <https://github.com/Scaffoldic/agentforge-py/releases/tag/v0.2.3>.
 - Release notes file: `docs/releases/v0.2.3.md`.
-- 34 workspace packages at `0.2.3`; **8 of those live on PyPI**
-  (`agentforge-core`, `-py`, `-anthropic`, `-bedrock`, `-chat`,
-  `-a2a`, `-memory-sqlite`, `-testing`).
+- 34 workspace packages at `0.2.3`; **ALL 34 now live on PyPI**
+  (drip-publish completed 2026-05-28 — phoenix + statsd were the
+  final two; see `PYPI_PUBLISH_TRACKER.md`).
 - Theme: `agentforge upgrade` is functional again. Bug-007
   was a P0 in two parts — `agentforge new` didn't persist
   `answers.yml`, and `agentforge upgrade` delegated to Copier's

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2892,3 +2892,32 @@ admin@pypi.org has lifted the quota by then.**
 2. Open the PR for `fix/bug-009-react-loop-drops-tool-calls`.
 3. Decide whether to fold bug-008 into the same PR or its own.
 4. Finish the v0.2.3 drip-publish (2 packages) so v0.2.4 has a clean baseline.
+
+## 2026-06-02T11:30 — v0.2.4 MCP cluster: triage shipped, runtime wiring opened
+
+PyPI v0.2.3 drip COMPLETE (34/34 live — phoenix + statsd landed
+2026-05-28).
+
+Triaged the 9 untracked bug docs against real source via 3 parallel
+verification agents (corrected several as-filed claims), added a
+"Framework-level vs derived-agent-level" section to each, reclassified
+bug-016 → enh-001 (HTTP transport = feature gap, not a defect). Also
+added that triage to the workspace doc templates (bug/enhancement/README).
+
+PRs:
+- **#57** docs/triage (bug-012…020 + enh-001) — MERGED.
+- **#58** fix bug-009/010 (tool_calls round-trip) — MERGED. main now at 0.2.4.
+- **#59** fix bug-020 (P0, runtime never wired modules.protocols) +
+  bug-014 (P1, from_config crashed inside a running loop) — OPEN.
+  2 commits (`9282000`, `25a43bb`), full gate green. Consume path only;
+  server-side `expose` rejected (stdio-hijack guard) — deferred with
+  enh-001. New `ProtocolBridge` core contract; `Agent(protocol_bridges=)`;
+  `build_protocols_from_config` wired into `build_agent_from_config`
+  (also fixed latent zero-caller `build_tools_from_config` gap).
+
+**Paused 2026-06-02, resuming evening IST.** Remaining v0.2.4 cluster
+(each its own branch off main): bug-012 → bug-017 → bug-015 → bug-019 →
+bug-018 → bug-013 → enh-001, plus bug-008 (~5 lines). Tag v0.2.4 only
+after the cluster lands (CHANGELOG header is `[0.2.4] — unreleased`).
+PyPI post-drip chores: revoke ~/.pypirc token, Trusted Publishing,
+delete PYPI_PUBLISH_TRACKER.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
-## [0.2.4] — 2026-05-27
+## [0.2.4] — unreleased
+
+Tool-call round-trip fix **plus the MCP runtime-wiring cluster** —
+both sets of defects surfaced from the first live Bedrock-backed MCP
+integration and ship together.
+
+MCP runtime wiring (bug-020 + bug-014): `modules.protocols.mcp` was
+validated but never instantiated, so the documented config was a
+no-op — no subprocess spawned, no MCP tools in the agent's tool
+list. `build_agent_from_config` now resolves `modules.protocols`,
+starts each handler, and merges its tools into the agent;
+`MCPBridge.from_config` no longer breaks inside a running event loop.
 
 Tool-call round-trip fix. Two related bugs surfaced by a downstream
 consumer integration ship together because they're two halves of
@@ -27,8 +38,37 @@ Bug-010 (P2) dropped intermediate tool steps from
 `ChatHistoryStore`, so Generative-UI clients couldn't render tool
 activity and the next chat turn's prompt lost prior tool context.
 
+### Added
+
+- **`agentforge_core.contracts.protocol_bridge.ProtocolBridge`** — a
+  `@runtime_checkable` Protocol (`tools` / `start` / `close`) for
+  `modules.protocols` handlers, so the runtime wires them without
+  `agentforge` importing the optional handler packages.
+- **`Agent(protocol_bridges=...)`** — additive constructor kwarg
+  (safe default); the agent closes every protocol bridge on
+  `Agent.close()`.
+- **`MCPBridge.attach_local_tools(tools)` + `MCPServer.set_tools(tools)`**
+  — inject the agent's own tools into an exposed server after
+  construction (closes a previously-undefined-method loose end).
+
 ### Fixed
 
+- **bug-020 — runtime never wired `modules.protocols.mcp`.**
+  Declaring an MCP server in `agentforge.yaml` was a no-op: no
+  subprocess spawned, no MCP tools in `agent.tools`. The config was
+  validated then ignored. `build_agent_from_config` now resolves the
+  `protocols` category, builds each handler via `from_config`, awaits
+  `start()`, merges its tools (alongside native `agent.tools`, which
+  this path also previously failed to wire) into `Agent(tools=...)`,
+  and closes the started bridges on `Agent.close()`. Server-side
+  `expose` is rejected with a clear error for now (it would hijack the
+  agent process's stdio); expose runtime-wiring is a follow-up.
+- **bug-014 — `MCPBridge.from_config` raised inside a running event
+  loop.** It eagerly built clients via
+  `get_event_loop().run_until_complete`, so any async startup hook hit
+  `RuntimeError: this event loop is already running`. `from_config` is
+  now pure data; the async `start()` materialises the clients. A
+  list-form `command:` (e.g. `["uv", "run", "x"]`) is now accepted.
 - **bug-010 — `ChatSession` dropped intermediate tool steps from
   persisted history.** Tool-using chats stored only the user prompt
   and final assistant text; intermediate `act` / `observe` steps

--- a/docs/bugs/bug-014-mcpbridge-fromconfig-asyncio-run-inside-loop.md
+++ b/docs/bugs/bug-014-mcpbridge-fromconfig-asyncio-run-inside-loop.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P1
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)

--- a/docs/bugs/bug-020-runtime-doesnt-wire-mcp-bridge.md
+++ b/docs/bugs/bug-020-runtime-doesnt-wire-mcp-bridge.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P0
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)

--- a/docs/features/feat-013-mcp-integration.md
+++ b/docs/features/feat-013-mcp-integration.md
@@ -253,17 +253,19 @@ member.
   integration test against a live MCP server lands. Every unit
   test injects a mock runner; the SDK wiring + transport
   context-manager dance is well-defined but unimplemented.
-- **`MCPBridge.from_config` runs `asyncio.run_until_complete`
-  to drive the async client factories from a synchronous code
-  path.** This is the pragmatic shape so the resolver-instantiated
-  bridge fits the `build_agent_from_config` flow; a fully-async
-  resolver hook is a v0.3 cleanup.
-- **`Agent.tools` integration is opt-in via the bridge.** A
-  follow-up commit can teach `build_agent_from_config` to call
-  `MCPBridge.from_config(...)`, `await bridge.start()`, and
-  merge `bridge.tools` into the agent's tool list. Today the
-  package ships the primitive; wiring into the Agent
-  construction path waits for a real live-test scenario.
+- **~~`MCPBridge.from_config` runs `asyncio.run_until_complete`~~**
+  — **RESOLVED in v0.2.4 (bug-014).** This raised
+  `RuntimeError: this event loop is already running` whenever
+  called from an async runtime. `from_config` is now pure data
+  (stashes server specs) and the async `start()` materialises the
+  clients, so it is safe inside a running loop. See the v0.2.4
+  table below.
+- **~~`Agent.tools` integration is opt-in via the bridge~~** —
+  **RESOLVED in v0.2.4 (bug-020).** `build_agent_from_config` now
+  resolves `modules.protocols`, builds each handler, awaits
+  `start()`, merges `bridge.tools` into the agent's tool list, and
+  closes the bridges on `Agent.close()`. The documented
+  `modules.protocols.mcp` config is no longer a no-op.
 - **TypeScript port deferred.** The protocol contract is
   language-neutral; TS port lands when the framework's TS
   scaffolding does.
@@ -295,8 +297,27 @@ implementations and gated by the framework's first
 | 3 | `339753e` | `agentforge-mcp` declares `[project.optional-dependencies] mcp = ["mcp>=1.0,<2"]`. `pip install agentforge-mcp[mcp]` (or transitively via `agentforge add module mcp`) brings the SDK. |
 | 4 | `175fdfa` | Live integration test: `tests/integration/_echo_server.py` exposes one tool; `tests/integration/test_mcp_live.py` (`@pytest.mark.live`, `@pytest.mark.asyncio`) spawns the echo server as a subprocess, calls `discover_tools()` (asserts `echo.echo`), invokes the adapter's `run(text="hello mcp")`, asserts the response, closes the client. The default pre-commit / CI gate skips this via `-m "not live"`; run explicitly with `uv run pytest -m live packages/agentforge-mcp/tests/integration/`. |
 
+### v0.2.4 — runtime wiring (bug-020 + bug-014)
+
+The cluster of defects from the first live Bedrock-backed MCP
+integration. `modules.protocols.mcp` was previously
+validated-but-never-instantiated, so the documented config did
+nothing.
+
+| Chunk | What landed |
+|---|---|
+| 1 | **bug-014** — `MCPBridge.from_config` is now pure data (no event loop driven); the async `start()` materialises deferred client specs and discovers tools. `_await_sync` deleted. `_client_from_entry_async` awaits the transport factory directly and accepts a list-form `command:`. `MCPBridge.attach_local_tools` + `MCPServer.set_tools` implemented (closes the undefined-method loose end). |
+| 2 | `agentforge_core.contracts.protocol_bridge.ProtocolBridge` — a `@runtime_checkable` Protocol (`tools` / `start` / `close`) so the runtime wires protocol handlers without `agentforge` importing `agentforge-mcp`. `Agent` gains a `protocol_bridges` kwarg and closes each on `close()`. |
+| 3 | **bug-020** — `build_protocols_from_config` resolves each `modules.protocols` entry under the `protocols` category, builds it via `from_config`, awaits `start()`, and collects its tools. `build_agent_from_config` merges native `agent.tools` (previously never wired through this path) + protocol tools into `Agent(tools=...)` and passes the started bridges. Server-side `expose` is rejected with a clear error (would hijack the agent process's stdio); expose runtime-wiring is a follow-up. |
+
 ### Out-of-scope (deferred to a later v0.x follow-up)
 
+- **Server-side `expose` runtime-wiring.** Consuming MCP servers is
+  wired (v0.2.4); auto-serving the agent's own tools as an MCP
+  server from inside the agent runtime is not — it would hijack the
+  process's stdio. `build_protocols_from_config` fails loud on
+  `expose.enabled`. Tracked alongside the HTTP server transport
+  (enh-001).
 - **HTTP/SSE server transport for `_SDKServerRunner`.** The stdio
   path is wired; HTTP / SSE expose still raises
   `ModuleError("transport='http' not yet implemented")`. Needs

--- a/packages/agentforge-core/src/agentforge_core/contracts/protocol_bridge.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/protocol_bridge.py
@@ -1,0 +1,50 @@
+"""`ProtocolBridge` — the runtime contract for `modules.protocols`
+handlers (feat-013).
+
+A protocol handler turns a `modules.protocols[*]` config block into a
+set of `Tool`s the agent can call, and owns the lifecycle of whatever
+connections back that (subprocesses, sockets, sessions). The runtime
+(`build_agent_from_config`) resolves each entry's name under the
+``protocols`` resolver category, builds the handler from its config,
+`start()`s it, merges `tools` into the `Agent`, and `close()`s it on
+`Agent.close()`.
+
+The contract is a `@runtime_checkable` `Protocol` rather than an ABC so
+handlers in optional packages (`agentforge-mcp`'s `MCPBridge`, a future
+`agentforge-a2a` bridge) satisfy it structurally — `agentforge` /
+`agentforge-core` never import the handler packages.
+
+Expected construction shape (duck-typed, not part of the Protocol since
+classmethods don't express cleanly here): a classmethod
+``from_config(config: dict) -> ProtocolBridge`` that is **pure data** —
+it must not open transports or drive an event loop (do that in
+``start()``), so it is safe to call from within a running loop.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentforge_core.contracts.tool import Tool
+
+
+@runtime_checkable
+class ProtocolBridge(Protocol):
+    """Lifecycle + tool-source contract for a protocols handler."""
+
+    @property
+    def tools(self) -> list[Tool]:
+        """The tools this bridge contributes, populated by `start()`."""
+        ...
+
+    async def start(self) -> None:
+        """Open connections and populate `tools`. Safe to call inside a
+        running event loop."""
+        ...
+
+    async def close(self) -> None:
+        """Tear down every connection this bridge opened."""
+        ...
+
+
+__all__ = ["ProtocolBridge"]

--- a/packages/agentforge-mcp/src/agentforge_mcp/bridge.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/bridge.py
@@ -37,8 +37,13 @@ class MCPBridge:
         *,
         clients: Iterable[MCPServerClient] = (),
         server: MCPServer | None = None,
+        client_specs: Iterable[dict[str, Any]] = (),
     ) -> None:
         self._clients = list(clients)
+        # Deferred client entries from `from_config`. Materialised into
+        # live `MCPServerClient`s inside `start()` (async) so no event
+        # loop is driven at construction time (bug-014).
+        self._client_specs = [dict(spec) for spec in client_specs]
         self._server = server
         self._tools: list[Tool] = []
         self._serve_task: asyncio.Task[None] | None = None
@@ -48,30 +53,44 @@ class MCPBridge:
         """Build a bridge from the parsed `modules.protocols.mcp.config`
         block.
 
-        Construction is async-friendly: the clients are created via
-        their factories which return synchronously, then `start()`
-        opens transports + discovers tools. Tests typically bypass
-        this and inject pre-built clients via `__init__`.
+        Pure data — no transports are opened and no event loop is
+        driven here. The server entries are stashed as ``client_specs``
+        and materialised inside ``start()`` (which is async and safe to
+        call from within a running loop). Tests typically bypass this
+        and inject pre-built clients via ``__init__``.
         """
-        clients = [_client_from_entry(entry) for entry in config.get("servers", []) or []]
+        specs = list(config.get("servers", []) or [])
         server: MCPServer | None = None
         expose = config.get("expose") or {}
         if expose.get("enabled"):
             # The agent's own tools aren't known at config-load time;
             # call `bridge.attach_local_tools(tools)` after Agent
-            # construction. The server is built lazily so the
-            # transport spec lives here.
+            # construction. The server is built here so the transport
+            # spec lives with the bridge.
             server = _server_placeholder(expose)
-        return cls(clients=clients, server=server)
+        return cls(client_specs=specs, server=server)
 
     @property
     def tools(self) -> list[Tool]:
         """Merged Tool catalogue (populated by `start`)."""
         return list(self._tools)
 
+    def attach_local_tools(self, tools: Iterable[Tool]) -> None:
+        """Inject the agent's own tools into the exposed server.
+
+        No-op when this bridge has no `expose` server configured. Call
+        after `Agent` construction (when the tool list is known) and
+        before `start()`.
+        """
+        if self._server is not None:
+            self._server.set_tools(tools)
+
     async def start(self) -> None:
-        """Open every client, discover their tools, and (optionally)
-        start the exposed server."""
+        """Materialise deferred clients, open every client, discover
+        their tools, and (optionally) start the exposed server."""
+        for spec in self._client_specs:
+            self._clients.append(await _client_from_entry_async(spec))
+        self._client_specs = []
         for client in self._clients:
             self._tools.extend(await client.discover_tools())
         if self._server is not None:
@@ -89,41 +108,49 @@ class MCPBridge:
             await client.close()
 
 
-def _client_from_entry(entry: dict[str, Any]) -> MCPServerClient:  # pragma: no cover — live wiring
+async def _client_from_entry_async(
+    entry: dict[str, Any],
+) -> MCPServerClient:  # pragma: no cover — live wiring
     """Construct an `MCPServerClient` from a config entry.
 
-    Excluded from coverage because it depends on the upstream
-    `mcp` SDK; tests inject pre-built clients into `MCPBridge`
-    directly. The function is the documented bridge between
-    config-as-data and the live integration path.
+    Awaits the async transport factory directly, so it must be called
+    from within an event loop (it is — `start()` is async). Excluded
+    from coverage because it depends on the upstream `mcp` SDK; tests
+    inject pre-built clients into `MCPBridge` or monkeypatch this
+    function.
     """
     transport = entry.get("transport", "stdio")
     name = str(entry["name"])
     tool_filter = tuple(entry.get("tool_filter") or ())
+    timeout_s = float(entry.get("timeout_s", 30.0))
     if transport == "stdio":
-        result: MCPServerClient = _await_sync(
-            MCPServerClient.from_stdio(
-                name=name,
-                command=str(entry["command"]),
-                env=dict(entry.get("env") or {}),
-                tool_filter=tool_filter,
-                timeout_s=float(entry.get("timeout_s", 30.0)),
-            )
+        return await MCPServerClient.from_stdio(
+            name=name,
+            command=_command_str(entry["command"]),
+            env=dict(entry.get("env") or {}),
+            tool_filter=tool_filter,
+            timeout_s=timeout_s,
         )
-        return result
     if transport in {"http", "sse"}:
         factory = MCPServerClient.from_http if transport == "http" else MCPServerClient.from_sse
-        return _await_sync(  # type: ignore[no-any-return]
-            factory(
-                name=name,
-                url=str(entry["url"]),
-                headers=dict(entry.get("headers") or {}),
-                tool_filter=tool_filter,
-                timeout_s=float(entry.get("timeout_s", 30.0)),
-            )
+        return await factory(
+            name=name,
+            url=str(entry["url"]),
+            headers=dict(entry.get("headers") or {}),
+            tool_filter=tool_filter,
+            timeout_s=timeout_s,
         )
     msg = f"MCP server {name!r}: unsupported transport {transport!r}."
     raise ValueError(msg)
+
+
+def _command_str(command: Any) -> str:
+    """Normalise a `command:` entry to the shell string `from_stdio`
+    expects. YAML may give a list (``["uv", "run", "x"]``) or a plain
+    string (``"uv run x"``); both collapse to a space-joined string."""
+    if isinstance(command, (list, tuple)):
+        return " ".join(str(part) for part in command)
+    return str(command)
 
 
 def _server_placeholder(expose: dict[str, Any]) -> MCPServer:  # pragma: no cover — live wiring
@@ -140,11 +167,6 @@ def _server_placeholder(expose: dict[str, Any]) -> MCPServer:  # pragma: no cove
         return MCPServer.from_http(tools=[], allowed=allowed)
     msg = f"unsupported expose transport {transport!r}; expected 'stdio' or 'http'."
     raise ValueError(msg)
-
-
-def _await_sync(coro: Any) -> Any:  # pragma: no cover — live wiring path
-    """Run an async factory inside a synchronous `from_config`."""
-    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 class _Suppress:

--- a/packages/agentforge-mcp/src/agentforge_mcp/server.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/server.py
@@ -72,6 +72,15 @@ class MCPServer:
         )
         return cls(tools=tools, runner=runner, allowed=allowed)
 
+    def set_tools(self, tools: Iterable[Tool]) -> None:
+        """Replace the tool set to expose.
+
+        Used by `MCPBridge.attach_local_tools` to inject the agent's
+        own tools after construction (the agent's tool list isn't known
+        at config-load time). Call before `register_tools()` / `serve()`.
+        """
+        self._tools = list(tools)
+
     def register_tools(self) -> int:
         """Register each whitelisted tool with the underlying runner.
 

--- a/packages/agentforge-mcp/tests/unit/test_bridge.py
+++ b/packages/agentforge-mcp/tests/unit/test_bridge.py
@@ -130,3 +130,71 @@ async def test_bridge_starts_optional_exposed_server() -> None:
 def test_bridge_from_config_with_no_servers_returns_empty_bridge() -> None:
     bridge = MCPBridge.from_config({})
     assert bridge.tools == []
+
+
+@pytest.mark.asyncio
+async def test_from_config_is_safe_inside_running_loop() -> None:
+    """bug-014 regression: `from_config` must not drive the event loop.
+
+    This test body runs inside a live asyncio loop; the pre-fix
+    implementation called `get_event_loop().run_until_complete` here
+    and raised `RuntimeError: this event loop is already running`.
+    """
+    bridge = MCPBridge.from_config(
+        {"servers": [{"name": "x", "transport": "stdio", "command": "cat"}]}
+    )
+    # Deferred — nothing is opened until `start()`.
+    assert bridge.tools == []
+
+
+@pytest.mark.asyncio
+async def test_start_materialises_deferred_client_specs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`from_config` stashes specs; `start()` turns them into live
+    clients (here via a monkeypatched factory) and discovers tools."""
+    import agentforge_mcp.bridge as bridge_mod  # noqa: PLC0415
+
+    fake = _client("fs", ("read_file",))
+
+    async def _fake_from_entry(entry: dict[str, Any]) -> MCPServerClient:
+        assert entry["name"] == "fs"
+        return fake
+
+    monkeypatch.setattr(bridge_mod, "_client_from_entry_async", _fake_from_entry)
+
+    bridge = MCPBridge.from_config(
+        {"servers": [{"name": "fs", "transport": "stdio", "command": ["cat"]}]}
+    )
+    assert bridge.tools == []
+    await bridge.start()
+    assert sorted(type(t).name for t in bridge.tools) == ["fs.read_file"]
+
+
+@pytest.mark.asyncio
+async def test_attach_local_tools_exposes_them_on_serve() -> None:
+    """`attach_local_tools` injects the agent's tools into the exposed
+    server after construction (the loose end called out in bug-020)."""
+    server_runner = MCPFakeServerRunner()
+    server = MCPServer(tools=[], runner=server_runner, allowed=())
+    bridge = MCPBridge(server=server)
+    bridge.attach_local_tools([_Echo()])
+    await bridge.start()
+    import asyncio  # noqa: PLC0415
+
+    await asyncio.sleep(0)
+    assert {r["name"] for r in server_runner.registered} == {"echo"}
+    await bridge.close()
+
+
+def test_attach_local_tools_is_noop_without_server() -> None:
+    bridge = MCPBridge(clients=[])
+    # No exposed server configured — must not raise.
+    bridge.attach_local_tools([_Echo()])
+
+
+def test_command_str_joins_list_form() -> None:
+    from agentforge_mcp.bridge import _command_str  # noqa: PLC0415
+
+    assert _command_str(["uv", "run", "filesystem-mcp"]) == "uv run filesystem-mcp"
+    assert _command_str("uv run filesystem-mcp") == "uv run filesystem-mcp"

--- a/packages/agentforge/src/agentforge/agent.py
+++ b/packages/agentforge/src/agentforge/agent.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -37,6 +37,7 @@ from agentforge_core.contracts.guardrails import (
 )
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.protocol_bridge import ProtocolBridge
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.contracts.tool import Tool
 from agentforge_core.observability import get_tracer
@@ -119,6 +120,7 @@ class Agent:
         tool_gates: list[ToolCallGate] | None = None,
         guardrail_policy: GuardrailPolicy | None = None,
         pipeline: Pipeline | None = None,
+        protocol_bridges: Sequence[ProtocolBridge] | None = None,
     ) -> None:
         self._config: AgentForgeConfig = load_config(config_path)
 
@@ -197,6 +199,11 @@ class Agent:
         if pipeline is not None:
             self._pipeline_tool = PipelineFindingsTool()
             self._tools.append(self._pipeline_tool)
+
+        # feat-013: protocol handlers (e.g. MCP bridges) already started
+        # by the config builder. Their tools are passed in via `tools=`;
+        # the Agent only owns tearing them down on `close()`.
+        self._protocol_bridges: list[ProtocolBridge] = list(protocol_bridges or [])
 
         self._closed = False
 
@@ -677,6 +684,8 @@ class Agent:
         await self._memory.close()
         if self._graph_store is not None:
             await self._graph_store.close()
+        for bridge in self._protocol_bridges:
+            await bridge.close()
         uninstall_run_id_filter()
         uninstall_json_formatter()
 

--- a/packages/agentforge/src/agentforge/cli/_build.py
+++ b/packages/agentforge/src/agentforge/cli/_build.py
@@ -20,6 +20,7 @@ deterministic exit codes (per feat-017 §4 — config invalid → 2).
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +31,7 @@ from agentforge_core.contracts.evaluator import Evaluator
 from agentforge_core.contracts.graph_store import GraphStore
 from agentforge_core.contracts.llm import LLMClient
 from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.protocol_bridge import ProtocolBridge
 from agentforge_core.contracts.reranker import Reranker
 from agentforge_core.contracts.vector_store import VectorStore
 from agentforge_core.production.exceptions import ModuleError
@@ -82,18 +84,35 @@ async def build_agent_from_config(
     llm = _resolve_llm(config)
     strategy = config.agent.strategy if isinstance(config.agent.strategy, str) else None
 
-    return Agent(
-        model=llm,
-        memory=memory if memory is not None else InMemoryStore(),
-        evaluators=evaluators,
-        strategy=strategy,
-        retriever=retriever,
-        system_prompt=config.agent.system_prompt,
-        budget_usd=config.agent.budget.usd,
-        max_iterations=config.agent.max_iterations,
-        record_runs=memory if enable_recording and memory is not None else None,
-        pipeline=pipeline,
-    )
+    # feat-013 (bug-020): wire `modules.protocols` — resolve + start each
+    # handler (e.g. the MCP bridge), merge its tools with the native
+    # `agent.tools`, and hand the started bridges to the Agent so they're
+    # closed on `Agent.close()`. `build_protocols_from_config` has already
+    # awaited `start()` for every bridge it returns.
+    native_tools = build_tools_from_config(config)
+    mcp_tools, protocol_bridges = await build_protocols_from_config(config)
+    all_tools = [*native_tools, *mcp_tools]
+
+    try:
+        return Agent(
+            model=llm,
+            tools=all_tools or None,
+            memory=memory if memory is not None else InMemoryStore(),
+            evaluators=evaluators,
+            strategy=strategy,
+            retriever=retriever,
+            system_prompt=config.agent.system_prompt,
+            budget_usd=config.agent.budget.usd,
+            max_iterations=config.agent.max_iterations,
+            record_runs=memory if enable_recording and memory is not None else None,
+            pipeline=pipeline,
+            protocol_bridges=protocol_bridges,
+        )
+    except BaseException:
+        # Agent construction failed after bridges were started — don't
+        # leak the open transports / spawned subprocesses.
+        await _close_bridges(protocol_bridges)
+        raise
 
 
 def build_memory_from_config(config: AgentForgeConfig) -> MemoryStore | None:
@@ -259,6 +278,83 @@ def build_tools_from_config(config: AgentForgeConfig) -> list[Tool]:
     return tools
 
 
+async def build_protocols_from_config(
+    config: AgentForgeConfig,
+) -> tuple[list[Tool], list[ProtocolBridge]]:
+    """Resolve + start every `modules.protocols` handler (feat-013).
+
+    For each entry: resolve its name under the ``protocols`` resolver
+    category, build the handler via its ``from_config(config)``
+    classmethod, ``await start()`` to open connections and discover
+    tools, then collect the merged tool list. The started bridges are
+    returned so the caller can ``close()`` them on agent teardown.
+
+    Returns an empty ``([], [])`` when no protocols are configured.
+
+    Raises:
+        ModuleError: a protocol isn't registered, lacks a
+            ``from_config`` classmethod, doesn't implement
+            `ProtocolBridge`, or requests server-side ``expose`` (not
+            wired into the runtime yet — see `_reject_unsupported_expose`).
+    """
+    from agentforge_core.contracts.tool import Tool as ToolBase  # noqa: PLC0415
+
+    tools: list[ToolBase] = []
+    bridges: list[ProtocolBridge] = []
+    for entry in config.modules.protocols:
+        _reject_unsupported_expose(entry.name, entry.config)
+        cls = _resolve_class("protocols", entry.name)
+        from_config = getattr(cls, "from_config", None)
+        if not callable(from_config):
+            msg = (
+                f"Resolved protocol {entry.name!r} ({cls.__name__}) has no "
+                f"from_config(config) classmethod."
+            )
+            raise ModuleError(msg)
+        bridge = from_config(entry.config)
+        if not isinstance(bridge, ProtocolBridge):
+            msg = (
+                f"Resolved protocol {entry.name!r} ({cls.__name__}) does not "
+                f"implement ProtocolBridge (needs tools / start / close)."
+            )
+            raise ModuleError(msg)
+        try:
+            await bridge.start()
+        except BaseException:
+            # A later bridge failing must not leak earlier ones.
+            await _close_bridges(bridges)
+            raise
+        bridges.append(bridge)
+        tools.extend(bridge.tools)
+    return tools, bridges
+
+
+def _reject_unsupported_expose(name: str, cfg: dict[str, Any]) -> None:
+    """Fail loud on server-side `expose`, which the runtime can't wire yet.
+
+    Auto-serving an MCP server from inside the agent process would hijack
+    the process's stdio. Consume-only is supported; expose runtime-wiring
+    is a follow-up (tracked alongside enh-001, MCP HTTP server transport).
+    """
+    expose = cfg.get("expose") or {}
+    if expose.get("enabled"):
+        msg = (
+            f"modules.protocols[{name!r}]: server-side `expose` is not wired "
+            "into the agent runtime yet (it would hijack the agent process's "
+            "stdio). Use consume-only config for now; expose runtime-wiring is "
+            "a follow-up (see enh-001)."
+        )
+        raise ModuleError(msg)
+
+
+async def _close_bridges(bridges: list[ProtocolBridge]) -> None:
+    """Close every started bridge, swallowing teardown errors so one bad
+    close doesn't mask the original failure."""
+    for bridge in bridges:
+        with contextlib.suppress(Exception):
+            await bridge.close()
+
+
 def _resolve_llm(config: AgentForgeConfig) -> LLMClient | str | None:
     """Pick the LLM definition out of `config.agent.model` /
     `config.providers["default"]`.
@@ -317,6 +413,7 @@ __all__ = [
     "build_evaluators_from_config",
     "build_memory_from_config",
     "build_pipeline_from_config",
+    "build_protocols_from_config",
     "build_retriever_from_config",
     "build_tools_from_config",
     "load_and_build",

--- a/packages/agentforge/tests/unit/test_cli_build.py
+++ b/packages/agentforge/tests/unit/test_cli_build.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from agentforge import Agent, InMemoryStore
@@ -12,6 +12,7 @@ from agentforge.cli._build import (
     build_agent_from_config,
     build_evaluators_from_config,
     build_memory_from_config,
+    build_protocols_from_config,
     load_and_build,
 )
 from agentforge_core.config.schema import (
@@ -20,13 +21,18 @@ from agentforge_core.config.schema import (
     EvaluatorEntry,
     MemoryModuleConfig,
     ModulesConfig,
+    ObservabilityEntry,
     ProviderConfig,
 )
 from agentforge_core.contracts.evaluator import EvalResult, Evaluator
 from agentforge_core.contracts.memory import MemoryStore
+from agentforge_core.contracts.strategy import ReasoningStrategy
+from agentforge_core.contracts.tool import Tool
 from agentforge_core.production.exceptions import ModuleError
 from agentforge_core.resolver import Resolver, register
 from agentforge_core.values.claim import Claim
+from agentforge_core.values.state import AgentState
+from pydantic import BaseModel
 
 
 class _FakeMemory(MemoryStore):
@@ -225,3 +231,135 @@ async def test_in_memory_store_used_when_no_module_section() -> None:
 def _silence_unused() -> Agent | Resolver:
     """Keep Agent/Resolver imports live for ruff (used implicitly)."""
     raise NotImplementedError
+
+
+# ----------------------------------------------------------------------
+# feat-013 / bug-020 — modules.protocols wiring
+# ----------------------------------------------------------------------
+
+
+class _ProtoInput(BaseModel):
+    pass
+
+
+class _ProtoTool(Tool):
+    name = "proto.echo"
+    description = "Tool contributed by a protocol bridge."
+    input_schema = _ProtoInput
+
+    async def run(self, **kwargs: Any) -> str:
+        del kwargs
+        return "ok"
+
+
+class _FakeBridge:
+    """Structurally satisfies `ProtocolBridge` (tools / start / close)."""
+
+    built: ClassVar[list[_FakeBridge]] = []
+
+    def __init__(self) -> None:
+        self._tools: list[Tool] = []
+        self.started = False
+        self.closed = False
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> _FakeBridge:
+        del config
+        inst = cls()
+        cls.built.append(inst)
+        return inst
+
+    @property
+    def tools(self) -> list[Tool]:
+        return list(self._tools)
+
+    async def start(self) -> None:
+        self.started = True
+        self._tools = [_ProtoTool()]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _NotABridge:
+    """Resolves but doesn't implement the ProtocolBridge surface."""
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> _NotABridge:
+        del config
+        return cls()
+
+
+class _NoopStrategy(ReasoningStrategy):
+    async def run(self, state: AgentState) -> AgentState:
+        return state
+
+
+@pytest.mark.asyncio
+async def test_build_protocols_resolves_starts_and_collects_tools() -> None:
+    register("protocols", "build-fake-proto")(_FakeBridge)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        modules=ModulesConfig(protocols=[ObservabilityEntry(name="build-fake-proto")]),
+    )
+    tools, bridges = await build_protocols_from_config(cfg)
+    assert [type(t).name for t in tools] == ["proto.echo"]
+    assert len(bridges) == 1
+    assert bridges[0].started is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_build_protocols_empty_when_none_configured() -> None:
+    cfg = AgentForgeConfig(agent=AgentConfig(), modules=ModulesConfig())
+    tools, bridges = await build_protocols_from_config(cfg)
+    assert tools == []
+    assert bridges == []
+
+
+@pytest.mark.asyncio
+async def test_build_protocols_rejects_server_side_expose() -> None:
+    register("protocols", "build-expose-proto")(_FakeBridge)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        modules=ModulesConfig(
+            protocols=[
+                ObservabilityEntry(
+                    name="build-expose-proto",
+                    config={"expose": {"enabled": True}},
+                )
+            ]
+        ),
+    )
+    with pytest.raises(ModuleError, match="expose"):
+        await build_protocols_from_config(cfg)
+
+
+@pytest.mark.asyncio
+async def test_build_protocols_errors_when_not_a_bridge() -> None:
+    register("protocols", "build-not-a-bridge")(_NotABridge)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        modules=ModulesConfig(protocols=[ObservabilityEntry(name="build-not-a-bridge")]),
+    )
+    with pytest.raises(ModuleError, match="does not implement ProtocolBridge"):
+        await build_protocols_from_config(cfg)
+
+
+@pytest.mark.asyncio
+async def test_build_agent_wires_protocol_tools_and_closes_bridges() -> None:
+    _FakeBridge.built.clear()
+    register("protocols", "build-agent-proto")(_FakeBridge)
+    register("strategies", "build-noop-strat")(_NoopStrategy)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(strategy="build-noop-strat"),
+        modules=ModulesConfig(protocols=[ObservabilityEntry(name="build-agent-proto")]),
+    )
+    agent = await build_agent_from_config(cfg)
+    # The bridge's tool is merged into the agent's tool list.
+    assert "proto.echo" in [type(t).name for t in agent.tools]
+    # Bridge was started by the builder and is closed on agent.close().
+    bridge = _FakeBridge.built[-1]
+    assert bridge.started is True
+    assert bridge.closed is False
+    await agent.close()
+    assert bridge.closed is True


### PR DESCRIPTION
## What

Makes `modules.protocols.mcp` actually work. Fixes **bug-020 (P0)** and
its coupled blocker **bug-014 (P1)** — the unblocker for the rest of the
MCP cluster. Folds into **v0.2.4**.

## The problem (verified in source)

Declaring an MCP server in `agentforge.yaml` was a **no-op**:
`build_agent_from_config` wired memory/llm/strategy but **never** read
`config.modules.protocols`, never referenced `MCPBridge`, and never
passed `tools=` at all. Validation resolved `protocols` but only checked
the config schema — never instantiated. Net: no subprocess spawned, no
MCP tools in `agent.tools`. And `MCPBridge.from_config` would have raised
`RuntimeError: this event loop is already running` the moment the (async)
runtime tried to drive it.

## Changes

**bug-014 — async-safe bridge** (`agentforge-mcp`)
- `from_config` is now **pure data** (stashes server specs); the async
  `start()` materialises clients + discovers tools. `_await_sync` deleted.
- `_client_from_entry_async` awaits the factory directly; accepts
  list-form `command:` (`["uv","run","x"]`).
- Implemented `MCPBridge.attach_local_tools` + `MCPServer.set_tools` —
  closes the undefined-method loose end the bug-020 doc flagged.

**bug-020 — runtime wiring** (`agentforge-core`, `agentforge`)
- New `agentforge_core.contracts.protocol_bridge.ProtocolBridge` —
  `@runtime_checkable` Protocol (`tools`/`start`/`close`) so the runtime
  wires handlers **without** `agentforge` importing `agentforge-mcp`.
- `Agent` gains `protocol_bridges=` (additive, safe default per ADR-0007);
  closes each on `Agent.close()`.
- `build_protocols_from_config` resolves → `from_config` → `await start()`
  → collect tools. `build_agent_from_config` merges native `agent.tools`
  (also previously never wired via this path — `build_tools_from_config`
  had zero callers) + protocol tools into `Agent(tools=...)`, and closes
  bridges if construction fails.

## Scope calls

- **Consume path only.** Server-side `expose` is rejected with a clear
  error — auto-serving from inside the agent process would hijack stdio.
  Expose runtime-wiring is a follow-up (tracked with enh-001).
- Tool naming (`<server>.<tool>` separator) is **bug-012's** concern —
  tests assert membership without hardcoding the separator.

## Tests / gate

- bug-014: from_config safe inside a running loop (regression); start()
  materialises deferred specs; attach_local_tools; list-form command.
- bug-020: build_protocols resolves/starts/collects; empty when none;
  rejects expose; errors on non-ProtocolBridge; e2e through
  build_agent_from_config (tool in `agent.tools`, bridge closed on
  `agent.close()`).
- Full pre-commit gate green on both commits (ruff / mypy --strict /
  bandit / pytest unit+integration / coverage ≥ 90).

## Docs

bug-014 + bug-020 → `fixed in 0.2.4`; feat-013 Implementation status
deviations marked resolved + v0.2.4 chunk table; CHANGELOG `[0.2.4]`.

## Next in the cluster

bug-012 (separator), bug-017 (Bedrock name validator), bug-015 (extra
chain), bug-019 (config normaliser), bug-018 (session upsert), bug-013
(factory auto-register), enh-001 (HTTP transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
