### PR TITLE
fix: use `__` separator for MCP tool names (bug-012 P0)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,16 +1,17 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-020 + bug-014 (MCP runtime wiring)
-state: pr-pending
-branch: fix/bug-020-mcp-runtime-wiring
+feature: v0.2.4 MCP/chat/config cluster — bug-012 (MCP tool-name separator)
+state: pr-raised
+branch: fix/bug-012-mcp-adapter-separator
 started_at: 2026-06-02
-last_milestone_at: 2026-06-02
+last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
-resume: evening IST 2026-06-02
+resume: null
 flags_for_user:
-  - "PR #59 OPEN (fix/bug-020-mcp-runtime-wiring): bug-020 P0 + bug-014 P1. 2 commits (9282000, 25a43bb), full gate green, pushed. https://github.com/Scaffoldic/agentforge-py/pull/59 — awaiting merge."
+  - "PR #60 OPEN (fix/bug-012-mcp-adapter-separator): bug-012 P0 — MCP tool-name separator `.`→`__` so Bedrock/OpenAI/Anthropic charset accepts MCP tools. 1 commit (87df76a), full gate green, pushed. https://github.com/Scaffoldic/agentforge-py/pull/60 — awaiting merge."
+  - "PR #59 (bug-020 + bug-014, MCP runtime wiring) MERGED to main (merge commit c2f1132). The cluster unblocker is in."
   - "PRs #57 (docs triage) + #58 (bug-009/010 fix) MERGED to main. main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (not started), suggested order: bug-012 (adapter .→_ separator) → bug-017 (Bedrock tool-name validator + docs) → bug-015 (meta extra chain agentforge-py[mcp]→agentforge-mcp[mcp] + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
+  - "REMAINING v0.2.4 cluster (after #60), suggested order: bug-017 (Bedrock tool-name validator + docs) → bug-015 (meta extra chain agentforge-py[mcp]→agentforge-mcp[mcp] + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -26,22 +27,27 @@ Each bug doc carries a "Framework-level vs derived-agent-level"
 section; all eight are framework-level. The whole cluster folds into
 **v0.2.4** (no release until it all lands).
 
-**In flight — PR #59** (`fix/bug-020-mcp-runtime-wiring`, off main):
+**Landed — PR #59 MERGED** (`fix/bug-020-mcp-runtime-wiring`, merge
+commit `c2f1132`): bug-014 (`MCPBridge.from_config` pure-data + async
+`start()` materialises clients; `attach_local_tools` + `set_tools`;
+list-form `command:`) and bug-020 (`ProtocolBridge` runtime_checkable
+contract; `Agent(protocol_bridges=)` + close on exit;
+`build_protocols_from_config` wired into `build_agent_from_config`,
+which also fixed the zero-caller native-`agent.tools` gap; `expose`
+rejected as stdio-hijack guard). The cluster unblocker is in main.
 
-| # | Commit | Bug | Scope |
-|---|---|---|---|
-| 1 | `9282000` | 014 | `MCPBridge.from_config` pure-data; async `start()` materialises deferred client specs; `_await_sync` deleted; `attach_local_tools` + `MCPServer.set_tools`; list-form `command:`. Tests. |
-| 2 | `25a43bb` | 020 | `agentforge_core.contracts.protocol_bridge.ProtocolBridge` (runtime_checkable); `Agent(protocol_bridges=)` + close on exit; `build_protocols_from_config` wired into `build_agent_from_config` (also wires native `agent.tools` — previously zero-caller gap); expose rejected (stdio-hijack guard). Tests. feat-013 §10 + CHANGELOG. |
+**In flight — PR #60** (`fix/bug-012-mcp-adapter-separator`, off main):
+bug-012 P0 — MCP tool-name separator `.`→`__` (`adapter.py:34`) so
+provider charset `^[a-zA-Z0-9_-]{1,64}$` (Bedrock/OpenAI/Anthropic)
+accepts MCP tools. Regression test locks the qualified name to that
+charset. feat-013 spec + README + CHANGELOG updated. 1 commit
+(`87df76a`), full gate green, pushed. Awaiting merge.
 
-Full pre-commit gate green on both commits. Scope: **consume path
-only**; server-side `expose` runtime-wiring deferred (with enh-001).
+## Pickup on resume
 
-## Pickup on resume (evening IST 2026-06-02)
-
-1. **Merge PR #59** (bug-020 + bug-014) once reviewed/CI-green.
+1. **Merge PR #60** (bug-012) once reviewed/CI-green.
 2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
    branch off main, folding into v0.2.4), suggested order:
-   - **bug-012** — adapter `.`→`_` separator (`adapter.py:34`).
    - **bug-017** — defensive Bedrock tool-name validator
      (`[a-zA-Z0-9_-]+`) + document the constraint (feat-004/003/013
      specs + `@tool` docstring + templates). Backs up bug-012.

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2921,3 +2921,14 @@ bug-018 → bug-013 → enh-001, plus bug-008 (~5 lines). Tag v0.2.4 only
 after the cluster lands (CHANGELOG header is `[0.2.4] — unreleased`).
 PyPI post-drip chores: revoke ~/.pypirc token, Trusted Publishing,
 delete PYPI_PUBLISH_TRACKER.md.
+
+## 2026-06-03T00:00 — v0.2.4 cluster: PR #59 merged, bug-012 opened (#60)
+PR #59 (bug-020 + bug-014, MCP runtime wiring) merged to main (c2f1132) —
+the cluster unblocker. Synced main, deleted the merged branch.
+Started bug-012 on `fix/bug-012-mcp-adapter-separator`: MCP tool-name
+separator `.`→`__` so Bedrock/OpenAI/Anthropic tool-name charset
+(`^[a-zA-Z0-9_-]{1,64}$`) accepts MCP tools. adapter.py + tests (incl.
+charset regression test) + feat-013 spec + agentforge-mcp README +
+CHANGELOG; bug-012 doc → fixed in 0.2.4. Full gate green (87df76a).
+PR #60 open. Next: bug-017 → bug-015 → bug-019 → bug-018 → bug-013 →
+enh-001; bug-008 before tag; then tag v0.2.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ activity and the next chat turn's prompt lost prior tool context.
 
 ### Fixed
 
+- **bug-012 — MCP tool names used a `.` separator, which every
+  provider rejected.** `build_adapter` qualified each MCP tool as
+  `{server}.{tool}` (e.g. `myserver.my_tool`), but Bedrock Converse,
+  OpenAI, and Anthropic all validate tool names against
+  `^[a-zA-Z0-9_-]{1,64}$` — so every MCP tool failed on the first LLM
+  call. The separator is now a double underscore (`{server}__{tool}`),
+  which stays legal on all three providers while keeping the
+  server/tool boundary unambiguous. A regression test locks the
+  qualified name to the provider charset.
 - **bug-020 — runtime never wired `modules.protocols.mcp`.**
   Declaring an MCP server in `agentforge.yaml` was a no-op: no
   subprocess spawned, no MCP tools in `agent.tools`. The config was

--- a/docs/bugs/bug-012-mcp-adapter-dot-separator-breaks-bedrock.md
+++ b/docs/bugs/bug-012-mcp-adapter-dot-separator-breaks-bedrock.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P0
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)

--- a/docs/features/feat-013-mcp-integration.md
+++ b/docs/features/feat-013-mcp-integration.md
@@ -100,7 +100,7 @@ modules:
 
 ```python
 # Code is unchanged from feat-004 — tools coming from MCP look the same.
-agent = Agent(model="...", tools=["filesystem.read_file", "github.create_issue"])
+agent = Agent(model="...", tools=["filesystem__read_file", "github__create_issue"])
 result = await agent.run("Find the auth bug in src/")
 ```
 
@@ -144,10 +144,10 @@ Agent construction with modules.protocols.mcp:
      whitelisted tools via the configured transport.
 
 Tool dispatch (transparent):
-  LLM emits tool_call(name="filesystem.read_file", arguments=...)
+  LLM emits tool_call(name="filesystem__read_file", arguments=...)
        │
        ▼
-  Agent's tool catalogue: filesystem.read_file → MCPToolAdapter
+  Agent's tool catalogue: filesystem__read_file → MCPToolAdapter
        │
        ▼
   Adapter.run(**args) → MCP request to server → response → return value
@@ -220,7 +220,7 @@ Configuration identical.
 |---|---|
 | Subprocess management on Windows (signals, pipes) | Use `asyncio.subprocess` portable APIs; CI matrix covers Windows |
 | Server crashes mid-run | Adapter raises; counted toward `error_streak_limit`; agent may continue without that server's tools |
-| Tool name collision across servers | Prefix with server name (`filesystem.read_file`); collision detection at startup |
+| Tool name collision across servers | Prefix with server name (`filesystem__read_file`); collision detection at startup |
 | Version-mismatch with newer MCP protocol | Pin a protocol range; surface mismatch with upgrade guidance |
 | Should we ship our own MCP server registry? | No — community / MCP ecosystem owns that; we just consume |
 
@@ -371,7 +371,7 @@ modules:
 
 After the next `agentforge run`, the agent's tool catalogue
 will include MCP-server tools prefixed by their server name
-(`filesystem.read_file`, `github.create_issue`). When
+(`filesystem__read_file`, `github__create_issue`). When
 `expose.enabled` is set, the agent also runs an MCP server so
 Claude Desktop / Cursor / another AgentForge agent can call
 into `lookup_user` and `create_ticket` over MCP.
@@ -411,7 +411,7 @@ tools = await client.discover_tools()
 |---|---|---|
 | `ModuleError: mcp SDK is not installed` | upstream missing | `pip install agentforge-mcp[mcp]` (or `agentforge add module mcp` to install both) |
 | `MCP server transport 'http' is not yet implemented` | v0.2.1 polish gap | use `transport: stdio` in `modules.protocols.mcp.expose` for now; HTTP server transport lands as a v0.2.1 chore |
-| Tool name collision | two servers expose the same name | both arrive prefixed with their server name (`fs.read_file` vs `s3.read_file`) — collision avoided |
+| Tool name collision | two servers expose the same name | both arrive prefixed with their server name (`fs__read_file` vs `s3__read_file`) — collision avoided |
 | Subprocess won't terminate on agent close | `bridge.close` not called | use `async with Agent(...)` so the framework's `__aexit__` invokes the bridge close path |
 | Non-text content blocks dropped from `call_tool` result | `_SDKClientRunner` concatenates `TextContent` blocks and ignores `ImageContent` / `EmbeddedResource` for v0.2 | follow-up when a real use case justifies the wire-format change; meanwhile route binary tools through a different adapter shape |
 

--- a/packages/agentforge-mcp/README.md
+++ b/packages/agentforge-mcp/README.md
@@ -33,7 +33,9 @@ agentforge add module mcp
 ```
 
 Each consumed MCP server's tools land in `agent.tools` with a
-server-name prefix (`filesystem.read_file`,
-`github.create_issue`). When `expose.enabled` is set, the agent
+server-name prefix (`filesystem__read_file`,
+`github__create_issue`). The separator is a double underscore so
+the name stays legal under every provider's tool-name charset
+(`^[a-zA-Z0-9_-]{1,64}$`). When `expose.enabled` is set, the agent
 runs an MCP server alongside; other agents (Claude Desktop,
 Cursor, LangChain) can call into it.

--- a/packages/agentforge-mcp/src/agentforge_mcp/adapter.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/adapter.py
@@ -29,9 +29,16 @@ def build_adapter(
 
     Tool names are prefixed with the server name so two MCP
     servers exposing `read_file` don't collide:
-    `filesystem.read_file` vs `s3.read_file`.
+    `filesystem__read_file` vs `s3__read_file`.
+
+    The separator is a double underscore, not a dot: provider
+    tool-name charsets (Bedrock Converse, OpenAI, Anthropic all
+    enforce ``^[a-zA-Z0-9_-]{1,64}$``) reject ``.``. A dotted name
+    made every MCP tool fail provider validation on the first LLM
+    call (bug-012). ``__`` stays legal everywhere and keeps the
+    server/tool boundary unambiguous.
     """
-    qualified_name = f"{server_name}.{descriptor.name}"
+    qualified_name = f"{server_name}__{descriptor.name}"
     schema_cls = _build_input_schema(qualified_name, descriptor.input_schema)
 
     class _Adapter(MCPToolAdapter):

--- a/packages/agentforge-mcp/tests/integration/test_mcp_live.py
+++ b/packages/agentforge-mcp/tests/integration/test_mcp_live.py
@@ -32,8 +32,9 @@ async def test_stdio_roundtrip_against_real_mcp_server() -> None:
         tools = await client.discover_tools()
         assert len(tools) == 1
         tool = tools[0]
-        # Tools come back with server-name-prefixed names.
-        assert type(tool).name == "echo.echo"
+        # Tools come back with server-name-prefixed names (double-underscore
+        # separator — legal under every provider's tool-name charset).
+        assert type(tool).name == "echo__echo"
         # Invoke through the adapter — the runner routes to the
         # subprocess and the echo server returns the input unchanged.
         result = await tool.run(text="hello mcp")

--- a/packages/agentforge-mcp/tests/unit/test_adapter.py
+++ b/packages/agentforge-mcp/tests/unit/test_adapter.py
@@ -44,8 +44,20 @@ def _descriptor(name: str = "read_file") -> MCPToolDescriptor:
 def test_adapter_qualifies_name_with_server_prefix() -> None:
     runner = MCPFakeClientRunner()
     adapter = build_adapter(runner, _descriptor(), server_name="fs")
-    assert type(adapter).name == "fs.read_file"
+    assert type(adapter).name == "fs__read_file"
     assert "Reads a file" in type(adapter).description
+
+
+def test_adapter_name_satisfies_provider_tool_name_charset() -> None:
+    """Bedrock/OpenAI/Anthropic all enforce ``^[a-zA-Z0-9_-]{1,64}$``
+    on tool names. The server-prefix separator must stay inside that
+    charset — a dotted name (bug-012) failed provider validation on
+    the first LLM call."""
+    import re  # noqa: PLC0415
+
+    runner = MCPFakeClientRunner()
+    adapter = build_adapter(runner, _descriptor(), server_name="myserver")
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", type(adapter).name)
 
 
 def test_adapter_has_pydantic_input_schema() -> None:
@@ -67,7 +79,7 @@ async def test_adapter_run_round_trips_through_runner() -> None:
 @pytest.mark.asyncio
 async def test_adapter_strips_server_prefix_when_calling_mcp() -> None:
     """The runner should receive the bare MCP-side name
-    (`read_file`), not the qualified `fs.read_file`."""
+    (`read_file`), not the qualified `fs__read_file`."""
     runner = MCPFakeClientRunner(responses={"read_file": "ok"})
     adapter = build_adapter(runner, _descriptor(), server_name="fs")
     await adapter.run(path="/tmp")

--- a/packages/agentforge-mcp/tests/unit/test_bridge.py
+++ b/packages/agentforge-mcp/tests/unit/test_bridge.py
@@ -92,7 +92,7 @@ async def test_bridge_aggregates_tools_from_every_client() -> None:
     )
     await bridge.start()
     names = sorted(type(t).name for t in bridge.tools)
-    assert names == ["fs.read_file", "fs.write_file", "github.create_issue"]
+    assert names == ["fs__read_file", "fs__write_file", "github__create_issue"]
 
 
 @pytest.mark.asyncio
@@ -168,7 +168,7 @@ async def test_start_materialises_deferred_client_specs(
     )
     assert bridge.tools == []
     await bridge.start()
-    assert sorted(type(t).name for t in bridge.tools) == ["fs.read_file"]
+    assert sorted(type(t).name for t in bridge.tools) == ["fs__read_file"]
 
 
 @pytest.mark.asyncio

--- a/packages/agentforge-mcp/tests/unit/test_client.py
+++ b/packages/agentforge-mcp/tests/unit/test_client.py
@@ -61,7 +61,7 @@ async def test_discover_tools_returns_all_when_no_filter() -> None:
     tools = await client.discover_tools()
     assert len(tools) == 3
     names = sorted(type(t).name for t in tools)
-    assert names == ["fs.list_directory", "fs.read_file", "fs.write_file"]
+    assert names == ["fs__list_directory", "fs__read_file", "fs__write_file"]
 
 
 @pytest.mark.asyncio
@@ -70,7 +70,7 @@ async def test_tool_filter_restricts_imported_tools() -> None:
     client = MCPServerClient(name="fs", runner=runner, tool_filter=("read_file", "list_directory"))
     tools = await client.discover_tools()
     names = sorted(type(t).name for t in tools)
-    assert names == ["fs.list_directory", "fs.read_file"]
+    assert names == ["fs__list_directory", "fs__read_file"]
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_discovered_tool_round_trips_through_runner() -> None:
         responses={"read_file": "<body>"},
     )
     client = MCPServerClient(name="fs", runner=runner)
-    [read_file] = (t for t in await client.discover_tools() if type(t).name == "fs.read_file")
+    [read_file] = (t for t in await client.discover_tools() if type(t).name == "fs__read_file")
     result = await read_file.run(path="/etc/hosts")
     assert result == "<body>"
     # The runner sees the bare name, not the prefixed one.


### PR DESCRIPTION
## bug-012 — `MCPToolAdapter` qualified name used `.` → providers reject every MCP tool

`build_adapter` qualified each MCP tool as `{server}.{tool}` (e.g. `myserver.my_tool`). Bedrock Converse, OpenAI, and Anthropic all validate tool names against `^[a-zA-Z0-9_-]{1,64}$`, so the dot made **every** MCP tool fail on the first LLM call:

```
Bedrock validation: Value 'myserver.my_tool' ... failed to satisfy
constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

## Fix

Switch the server-prefix separator from `.` to `__` (double underscore) — legal under all three providers' charsets, server/tool boundary still unambiguous (`fs__read_file` vs `s3__read_file`).

- `adapter.py`: `.` → `__`; docstring explains the constraint.
- Tests: assert the `__` form; **new regression test** locks the qualified name to `^[a-zA-Z0-9_-]{1,64}$` so any future separator change that breaks provider validation fails CI.
- Docs: feat-013 spec + `agentforge-mcp` README updated to the `__` form.
- CHANGELOG: bug-012 entry under `[0.2.4]`.
- bug-012 doc: status → `fixed in 0.2.4`.

Consume-path only; part of the v0.2.4 MCP/chat/config cluster. Full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)