### PR TITLE
fix: validate tool-name charset at provider boundary (bug-017 P2)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,17 +1,16 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-012 (MCP tool-name separator)
+feature: v0.2.4 MCP/chat/config cluster — bug-017 (tool-name charset validator)
 state: pr-raised
-branch: fix/bug-012-mcp-adapter-separator
+branch: fix/bug-017-tool-name-validator
 started_at: 2026-06-02
 last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
 resume: null
 flags_for_user:
-  - "PR #60 OPEN (fix/bug-012-mcp-adapter-separator): bug-012 P0 — MCP tool-name separator `.`→`__` so Bedrock/OpenAI/Anthropic charset accepts MCP tools. 1 commit (87df76a), full gate green, pushed. https://github.com/Scaffoldic/agentforge-py/pull/60 — awaiting merge."
-  - "PR #59 (bug-020 + bug-014, MCP runtime wiring) MERGED to main (merge commit c2f1132). The cluster unblocker is in."
-  - "PRs #57 (docs triage) + #58 (bug-009/010 fix) MERGED to main. main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (after #60), suggested order: bug-017 (Bedrock tool-name validator + docs) → bug-015 (meta extra chain agentforge-py[mcp]→agentforge-mcp[mcp] + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
+  - "PR #61 OPEN (fix/bug-017-tool-name-validator): bug-017 P2 — validate tool-name charset `^[a-zA-Z0-9_-]{1,64}$` at all 3 provider boundaries (validate_tool_name + ToolNameInvalidError in core; NOT auto-enforced on ToolSpec) + docs (feat-003/004/013, @tool docstring, scaffold runbook). 1 commit (3131f92), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/61 — awaiting merge."
+  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014 MCP runtime wiring, c2f1132), #60 (bug-012 MCP `.`→`__` separator, 3cf2bdc). main at version 0.2.4."
+  - "REMAINING v0.2.4 cluster (after #61), suggested order: bug-015 (meta extra chain agentforge/pyproject.toml:105 `agentforge-mcp ~=0.2.4`→`agentforge-mcp[mcp] ~=0.2.4` + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -36,21 +35,25 @@ contract; `Agent(protocol_bridges=)` + close on exit;
 which also fixed the zero-caller native-`agent.tools` gap; `expose`
 rejected as stdio-hijack guard). The cluster unblocker is in main.
 
-**In flight — PR #60** (`fix/bug-012-mcp-adapter-separator`, off main):
-bug-012 P0 — MCP tool-name separator `.`→`__` (`adapter.py:34`) so
-provider charset `^[a-zA-Z0-9_-]{1,64}$` (Bedrock/OpenAI/Anthropic)
-accepts MCP tools. Regression test locks the qualified name to that
-charset. feat-013 spec + README + CHANGELOG updated. 1 commit
-(`87df76a`), full gate green, pushed. Awaiting merge.
+**Merged — PR #60** (`fix/bug-012-mcp-adapter-separator`, merge commit
+`3cf2bdc`): MCP tool-name separator `.`→`__`. CI Live job initially
+failed (env-gated `test_mcp_live.py` asserted the old `echo.echo`;
+local pre-commit doesn't run live tests) — fixed in commit `0bc8386`.
+
+**In flight — PR #61** (`fix/bug-017-tool-name-validator`, off main):
+bug-017 P2 — `validate_tool_name` + `ToolNameInvalidError(ProviderError)`
+in core, invoked at the request-build boundary of all three providers
+(Bedrock/OpenAI/Anthropic); core `ToolSpec` deliberately NOT
+auto-validated (neutral representation; charset is a per-provider wire
+constraint). Docs in feat-003/004/013 + `@tool` docstring + scaffold
+`02-add-a-tool` runbook. 1 commit (`3131f92`), full gate + Live CI
+green. Awaiting merge.
 
 ## Pickup on resume
 
-1. **Merge PR #60** (bug-012) once reviewed/CI-green.
+1. **Merge PR #61** (bug-017) once reviewed/CI-green.
 2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
    branch off main, folding into v0.2.4), suggested order:
-   - **bug-017** — defensive Bedrock tool-name validator
-     (`[a-zA-Z0-9_-]+`) + document the constraint (feat-004/003/013
-     specs + `@tool` docstring + templates). Backs up bug-012.
    - **bug-015** — meta extra chain: `agentforge/pyproject.toml:105`
      `mcp = ["agentforge-mcp ~= 0.2.4"]` → `["agentforge-mcp[mcp] ~= 0.2.4"]`;
      fix the `ModuleError` text; audit other vendor modules for the

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2932,3 +2932,19 @@ charset regression test) + feat-013 spec + agentforge-mcp README +
 CHANGELOG; bug-012 doc → fixed in 0.2.4. Full gate green (87df76a).
 PR #60 open. Next: bug-017 → bug-015 → bug-019 → bug-018 → bug-013 →
 enh-001; bug-008 before tag; then tag v0.2.4.
+
+## 2026-06-03T01:30 — v0.2.4 cluster: bug-012 merged (#60), bug-017 opened (#61)
+PR #60 (bug-012, MCP `.`→`__` separator) merged to main (3cf2bdc). Its CI
+Live job first failed — env-gated `test_mcp_live.py` still asserted
+`echo.echo`; local pre-commit skips live tests, so the rename slipped past.
+Fixed in 0bc8386. LESSON: any MCP adapter/client/bridge naming change must
+be checked against packages/agentforge-mcp/tests/integration (live job only).
+Started bug-017 on `fix/bug-017-tool-name-validator`: validate tool-name
+charset `^[a-zA-Z0-9_-]{1,64}$` at all 3 provider request-build boundaries.
+Design decision (user asked "best approach at framework level"): shared
+`validate_tool_name` + `ToolNameInvalidError(ProviderError)` in core, invoked
+per-provider; core `ToolSpec` deliberately NOT auto-validated (neutral
+representation, charset is a per-provider wire constraint that merely
+coincides today). Docs: feat-003/004/013, @tool docstring, scaffold
+02-add-a-tool runbook. Full gate + Live CI green (3131f92). PR #61 open.
+Next: bug-015 → bug-019 → bug-018 → bug-013 → enh-001; bug-008 before tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,26 @@ activity and the next chat turn's prompt lost prior tool context.
 - **`MCPBridge.attach_local_tools(tools)` + `MCPServer.set_tools(tools)`**
   — inject the agent's own tools into an exposed server after
   construction (closes a previously-undefined-method loose end).
+- **`agentforge_core.contracts.tool.validate_tool_name` +
+  `ToolNameInvalidError`** — a portable tool-name validator
+  (`^[a-zA-Z0-9_-]{1,64}$`) and its error type. The Bedrock, OpenAI,
+  and Anthropic drivers call it at request-build time so an illegal
+  name fails locally with an actionable message instead of as a
+  remote provider error (bug-017).
 
 ### Fixed
 
+- **bug-017 — provider tool-name charset was undocumented and
+  unchecked.** Every major provider enforces `^[a-zA-Z0-9_-]{1,64}$`
+  on tool names, but nothing in the framework documented or validated
+  it: a name like `kb.search` worked in mocked CI and on one provider
+  yet failed remotely the moment you swapped `model:` to Bedrock. The
+  three built-in providers now validate each tool name at
+  request-build time (raising `ToolNameInvalidError` with a suggested
+  rewrite), and the constraint is documented in feat-003/004/013, the
+  `@tool` docstring, and the scaffold's add-a-tool runbook. The
+  validator lives in core but is invoked per-provider — `ToolSpec`
+  stays a neutral representation rather than policing a wire charset.
 - **bug-012 — MCP tool names used a `.` separator, which every
   provider rejected.** `build_adapter` qualified each MCP tool as
   `{server}.{tool}` (e.g. `myserver.my_tool`), but Bedrock Converse,

--- a/docs/bugs/bug-017-bedrock-tool-name-regex-undocumented.md
+++ b/docs/bugs/bug-017-bedrock-tool-name-regex-undocumented.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P2
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
@@ -103,3 +103,28 @@ name-legality at its own boundary.
 - Discovered when a downstream consumer renamed 13 tools from dotted
   (`kb.search`) to underscored (`kb_search`) form — mechanical but
   unexpected mid-implementation.
+
+## Resolution (v0.2.4)
+
+Both layers shipped, and the validator was applied **more broadly than
+the original Bedrock-only layer-2 proposal**:
+
+- **Validator (layer 2)** — `validate_tool_name(name)` +
+  `ToolNameInvalidError(ProviderError)` added to `agentforge-core`
+  (`contracts/tool.py`, `production/exceptions.py`). It is invoked at
+  the request-build boundary of **all three** built-in providers
+  (Bedrock, OpenAI, Anthropic), not just Bedrock — they share the
+  `^[a-zA-Z0-9_-]{1,64}$` charset, and validating everywhere is what
+  makes the vendor-agnostic promise ("valid on one → valid on all")
+  actually hold. The error message suggests a legal rewrite
+  (`kb.search` → `kb_search`).
+- **Deliberately NOT enforced in core `ToolSpec`.** Core stays a
+  neutral representation; the charset is a per-provider wire constraint
+  (they merely coincide today), so each provider opts in by calling the
+  shared helper. A future lax/local provider simply doesn't call it.
+- **Docs (layer 1)** — constraint documented in feat-003 (custom-provider
+  runbook), feat-004 (§4.6), feat-013 (MCP prefix note), the `@tool`
+  decorator docstring, and the scaffold's `02-add-a-tool` runbook.
+- **Tests** — core: accept/reject parametrised cases + `ProviderError`
+  subclassing + suggestion-in-message; each provider: a dotted name
+  raises locally and nothing leaves the process.

--- a/docs/features/feat-003-llm-provider-abstraction.md
+++ b/docs/features/feat-003-llm-provider-abstraction.md
@@ -586,6 +586,13 @@ class MyCorpClient(LLMClient):
         return {"tools"}
 ```
 
+If your provider validates tool names, call
+`agentforge_core.contracts.tool.validate_tool_name(t.name)` for each
+tool while building the request — it raises `ToolNameInvalidError`
+(a `ProviderError`) for any name outside `^[a-zA-Z0-9_-]{1,64}$`, the
+charset the built-in providers share. This keeps the vendor-agnostic
+promise: a tool that works on one provider works on yours.
+
 Now `Agent(model="mycorp:foo-bar")` resolves to your class. For
 distribution, expose the import via a `agentforge.providers.mycorp`
 entry-point in `pyproject.toml`; feat-010's resolver auto-loads

--- a/docs/features/feat-004-tools-system.md
+++ b/docs/features/feat-004-tools-system.md
@@ -224,6 +224,26 @@ agent:
     on_error: "observe"   # "observe" (default) | "raise"
 ```
 
+### 4.6 Tool-name charset (portability constraint)
+
+A tool's `name` is what the LLM sees and what every provider validates.
+Bedrock Converse, OpenAI function calling, and Anthropic tool use all
+enforce the same pattern — `^[a-zA-Z0-9_-]{1,64}$`. A name outside that
+charset (dots, colons, spaces, non-ASCII, or >64 chars) is rejected by
+the provider on the first LLM call.
+
+To keep the vendor-agnostic promise honest — "a name valid on one
+provider is valid on all" — the framework validates names at each
+provider's request-build boundary via
+`agentforge_core.contracts.tool.validate_tool_name`, raising
+`ToolNameInvalidError` *locally* (with a suggested legal rewrite, e.g.
+`kb.search` → `kb_search`) before the request leaves the process. This
+turns a cryptic remote validation error into a pre-flight, actionable
+one (bug-017). MCP-imported tools are prefixed `{server}__{tool}` for
+the same reason (bug-012). Core does not auto-enforce the charset on
+`ToolSpec` — it stays a neutral representation; the check lives at the
+provider boundary where the wire constraint actually applies.
+
 ## 5. Plug-and-play & upgrade story
 
 A new tool package: `pip install agentforge-tools-aws`, then add `aws_s3_get`,

--- a/docs/features/feat-013-mcp-integration.md
+++ b/docs/features/feat-013-mcp-integration.md
@@ -371,10 +371,16 @@ modules:
 
 After the next `agentforge run`, the agent's tool catalogue
 will include MCP-server tools prefixed by their server name
-(`filesystem__read_file`, `github__create_issue`). When
-`expose.enabled` is set, the agent also runs an MCP server so
-Claude Desktop / Cursor / another AgentForge agent can call
-into `lookup_user` and `create_ticket` over MCP.
+(`filesystem__read_file`, `github__create_issue`). The `__`
+separator (not `.`) keeps the qualified name inside the
+`^[a-zA-Z0-9_-]{1,64}$` charset every provider enforces (bug-012);
+provider drivers also validate it at request-build time via
+`validate_tool_name`, so an illegal server or tool name fails
+locally with `ToolNameInvalidError` rather than as a remote error
+on the first LLM call (bug-017). When `expose.enabled` is set, the
+agent also runs an MCP server so Claude Desktop / Cursor / another
+AgentForge agent can call into `lookup_user` and `create_ticket`
+over MCP.
 
 ### Filter what's imported from a server
 

--- a/packages/agentforge-anthropic/src/agentforge_anthropic/client.py
+++ b/packages/agentforge-anthropic/src/agentforge_anthropic/client.py
@@ -20,6 +20,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.tool import validate_tool_name
 from agentforge_core.production.exceptions import ModuleError
 from agentforge_core.resolver import register_provider
 from agentforge_core.values.messages import (
@@ -365,6 +366,8 @@ def _message_to_anthropic(message: Message) -> dict[str, Any]:
 def _tools_to_anthropic(tools: list[ToolSpec] | None) -> list[dict[str, Any]] | None:
     if not tools:
         return None
+    for t in tools:
+        validate_tool_name(t.name)
     return [
         {
             "name": t.name,

--- a/packages/agentforge-anthropic/tests/unit/test_anthropic_client.py
+++ b/packages/agentforge-anthropic/tests/unit/test_anthropic_client.py
@@ -6,7 +6,7 @@ import pytest
 from agentforge_anthropic import AnthropicClient
 from agentforge_anthropic._inmem_runner import FakeAnthropicRunner
 from agentforge_anthropic._pricing import compute_cost_usd
-from agentforge_core.production.exceptions import CapabilityNotSupported
+from agentforge_core.production.exceptions import CapabilityNotSupported, ToolNameInvalidError
 from agentforge_core.values.messages import Message, ToolCall, ToolSpec
 
 
@@ -158,6 +158,21 @@ async def test_call_passes_through_tool_specs(
     tools_arg = fake_runner.create_calls[0].tools
     assert tools_arg is not None
     assert tools_arg[0] == {"name": "t", "description": "d", "input_schema": schema}
+
+
+@pytest.mark.asyncio
+async def test_call_rejects_illegal_tool_name_locally(
+    client: AnthropicClient,
+    fake_runner: FakeAnthropicRunner,
+) -> None:
+    """bug-017: an illegal tool name fails locally before any request."""
+    with pytest.raises(ToolNameInvalidError, match="kb_search"):
+        await client.call(
+            system="",
+            messages=[_user("hi")],
+            tools=[ToolSpec(name="kb.search", description="d", schema={"type": "object"})],
+        )
+    assert fake_runner.create_calls == []
 
 
 @pytest.mark.asyncio

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
@@ -32,6 +32,7 @@ from typing import Any, cast
 
 import aioboto3
 from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.tool import validate_tool_name
 from agentforge_core.resolver import register_provider
 from agentforge_core.values.messages import (
     LLMResponse,
@@ -333,6 +334,8 @@ class BedrockClient(LLMClient):
         if system:
             request["system"] = [{"text": system}]
         if tools:
+            for t in tools:
+                validate_tool_name(t.name)
             request["toolConfig"] = {
                 "tools": [
                     {

--- a/packages/agentforge-bedrock/tests/unit/test_client.py
+++ b/packages/agentforge-bedrock/tests/unit/test_client.py
@@ -13,6 +13,7 @@ from agentforge_core.production.exceptions import (
     ProviderError,
     RateLimitError,
     ServiceError,
+    ToolNameInvalidError,
 )
 from agentforge_core.resolver import Resolver
 from agentforge_core.values.messages import Message, ToolCall, ToolSpec
@@ -239,6 +240,19 @@ async def test_call_translates_tools_to_toolconfig(
     tools_sent = sent["toolConfig"]["tools"]
     assert tools_sent[0]["toolSpec"]["name"] == "search"
     assert tools_sent[0]["toolSpec"]["inputSchema"]["json"]["type"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_call_rejects_illegal_tool_name_locally(
+    fake_bedrock: _FakeBedrockClient, fake_session: _FakeSession
+) -> None:
+    """bug-017: a dotted tool name fails locally with a clear error before
+    the request reaches Bedrock (which would otherwise reject it remotely)."""
+    client = BedrockClient(model_id="anthropic.claude-3-haiku-20240307-v1:0", session=fake_session)
+    spec = ToolSpec(name="kb.search", description="d", schema={"type": "object"})
+    with pytest.raises(ToolNameInvalidError, match="kb_search"):
+        await client.call("sys", [Message(role="user", content="hi")], tools=[spec])
+    assert fake_bedrock.calls == []  # nothing left the process
 
 
 # ---- Error mapping ----

--- a/packages/agentforge-core/src/agentforge_core/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/__init__.py
@@ -47,6 +47,7 @@ from agentforge_core.contracts import (
     Reranker,
     Tool,
     VectorStore,
+    validate_tool_name,
 )
 from agentforge_core.migrations import discover_migrations
 from agentforge_core.observability import SCOPE_NAME as OBSERVABILITY_SCOPE_NAME
@@ -67,6 +68,7 @@ from agentforge_core.production import (
     RunIdFilter,
     ServiceError,
     TimeoutError,
+    ToolNameInvalidError,
     bind_run,
     current_run,
     install_json_formatter,
@@ -202,6 +204,7 @@ __all__ = [
     "TokenUsage",
     "Tool",
     "ToolCall",
+    "ToolNameInvalidError",
     "ToolSpec",
     "VectorItem",
     "VectorMatch",
@@ -225,4 +228,5 @@ __all__ = [
     "reset_run",
     "uninstall_json_formatter",
     "uninstall_run_id_filter",
+    "validate_tool_name",
 ]

--- a/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/__init__.py
@@ -25,7 +25,7 @@ from agentforge_core.contracts.renderer import FindingRenderer
 from agentforge_core.contracts.reranker import Reranker
 from agentforge_core.contracts.strategy import ReasoningStrategy
 from agentforge_core.contracts.task import Task
-from agentforge_core.contracts.tool import Tool
+from agentforge_core.contracts.tool import Tool, validate_tool_name
 from agentforge_core.contracts.vector_store import VectorStore
 
 __all__ = [
@@ -49,4 +49,5 @@ __all__ = [
     "Task",
     "Tool",
     "VectorStore",
+    "validate_tool_name",
 ]

--- a/packages/agentforge-core/src/agentforge_core/contracts/tool.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/tool.py
@@ -9,12 +9,47 @@ hood.
 from __future__ import annotations
 
 import inspect
+import re
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
+from agentforge_core.production.exceptions import ToolNameInvalidError
 from agentforge_core.values.messages import ToolSpec
+
+# The tool-name charset every major provider enforces: Bedrock Converse,
+# OpenAI function calling, and Anthropic tool use all validate names
+# against `^[a-zA-Z0-9_-]{1,64}$`. A name legal here is portable across
+# all of them.
+_TOOL_NAME_RE = re.compile(r"[a-zA-Z0-9_-]{1,64}")
+
+
+def validate_tool_name(name: str) -> None:
+    """Raise `ToolNameInvalidError` if `name` isn't portable across providers.
+
+    Providers call this at request-build time so an illegal name (e.g. the
+    dotted `kb.search`) surfaces as a local, actionable error *before* the
+    request leaves the process — instead of a cryptic remote validation
+    failure on the first LLM call.
+
+    Core itself does **not** auto-invoke this: `ToolSpec` stays a neutral
+    representation, and each provider opts into the policy it enforces. The
+    charset happens to be identical across today's providers, but it is a
+    per-provider wire constraint, not a property of the tool definition.
+    """
+    if not _TOOL_NAME_RE.fullmatch(name):
+        raise ToolNameInvalidError(
+            f"tool name {name!r} is not portable: it must match [a-zA-Z0-9_-] "
+            f"and be 1-64 characters (the charset Bedrock, OpenAI, and "
+            f"Anthropic all enforce). Try {_suggest_tool_name(name)!r}."
+        )
+
+
+def _suggest_tool_name(name: str) -> str:
+    """Best-effort legal rewrite for the error message (`kb.search` → `kb_search`)."""
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", name)[:64]
+    return cleaned or "tool"
 
 
 class Tool(ABC):

--- a/packages/agentforge-core/src/agentforge_core/production/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/production/__init__.py
@@ -31,6 +31,7 @@ from agentforge_core.production.exceptions import (
     RateLimitError,
     ServiceError,
     TimeoutError,
+    ToolNameInvalidError,
 )
 from agentforge_core.production.log_filter import (
     RunIdFilter,
@@ -66,6 +67,7 @@ __all__ = [
     "RunIdFilter",
     "ServiceError",
     "TimeoutError",
+    "ToolNameInvalidError",
     "bind_run",
     "current_run",
     "install_json_formatter",

--- a/packages/agentforge-core/src/agentforge_core/production/exceptions.py
+++ b/packages/agentforge-core/src/agentforge_core/production/exceptions.py
@@ -101,6 +101,20 @@ class TimeoutError(ProviderError):
     """
 
 
+class ToolNameInvalidError(ProviderError):
+    """A tool name violates the portable tool-name charset.
+
+    Every major provider (Bedrock Converse, OpenAI, Anthropic) validates
+    tool names against ``^[a-zA-Z0-9_-]{1,64}$``. Provider drivers call
+    `agentforge_core.contracts.tool.validate_tool_name` at request-build
+    time and raise this *before* the request leaves the process, turning a
+    cryptic remote validation failure on the first LLM call into a local,
+    actionable error. Subclasses `ProviderError` so the same handler that
+    catches other provider failures catches this too. Not retryable — the
+    fix is to rename the tool.
+    """
+
+
 class CapabilityNotSupported(AgentForgeError):
     """Raised when an optional capability is invoked on a driver that
     does not declare it.

--- a/packages/agentforge-core/tests/unit/test_contracts_tool.py
+++ b/packages/agentforge-core/tests/unit/test_contracts_tool.py
@@ -6,7 +6,8 @@ from abc import abstractmethod
 from typing import Any
 
 import pytest
-from agentforge_core.contracts.tool import Tool
+from agentforge_core.contracts.tool import Tool, validate_tool_name
+from agentforge_core.production.exceptions import ProviderError, ToolNameInvalidError
 from pydantic import BaseModel
 
 
@@ -92,3 +93,50 @@ def test_inherited_attributes_satisfy_the_check() -> None:
             return "child"
 
     assert _Child.name == "base"
+
+
+# ---- validate_tool_name (bug-017) ----
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "search",
+        "kb_search",
+        "fs__read_file",
+        "tool-1",
+        "A",
+        "a" * 64,
+        "Mixed_Case-123",
+    ],
+)
+def test_validate_tool_name_accepts_portable_names(name: str) -> None:
+    validate_tool_name(name)  # does not raise
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "kb.search",  # dot — the bug-012 / bug-017 case
+        "ns:tool",  # colon
+        "a b",  # space
+        "tool/name",  # slash
+        "café",  # non-ascii
+        "",  # empty
+        "a" * 65,  # too long
+    ],
+)
+def test_validate_tool_name_rejects_illegal_names(name: str) -> None:
+    with pytest.raises(ToolNameInvalidError):
+        validate_tool_name(name)
+
+
+def test_validate_tool_name_error_is_a_provider_error() -> None:
+    """Subclasses ProviderError so existing provider-failure handlers catch it."""
+    with pytest.raises(ProviderError):
+        validate_tool_name("kb.search")
+
+
+def test_validate_tool_name_message_includes_actionable_suggestion() -> None:
+    with pytest.raises(ToolNameInvalidError, match="kb_search"):
+        validate_tool_name("kb.search")

--- a/packages/agentforge-openai/src/agentforge_openai/client.py
+++ b/packages/agentforge-openai/src/agentforge_openai/client.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from agentforge_core.contracts.llm import LLMClient
+from agentforge_core.contracts.tool import validate_tool_name
 from agentforge_core.production.exceptions import ModuleError
 from agentforge_core.resolver import register_provider
 from agentforge_core.values.messages import (
@@ -323,6 +324,8 @@ def _message_to_openai(message: Message) -> dict[str, Any]:
 def _tools_to_openai(tools: list[ToolSpec] | None) -> list[dict[str, Any]] | None:
     if not tools:
         return None
+    for t in tools:
+        validate_tool_name(t.name)
     return [
         {
             "type": "function",

--- a/packages/agentforge-openai/tests/unit/test_openai_client.py
+++ b/packages/agentforge-openai/tests/unit/test_openai_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from agentforge_core.production.exceptions import ToolNameInvalidError
 from agentforge_core.values.messages import Message, ToolCall, ToolSpec
 from agentforge_openai import OpenAIClient
 from agentforge_openai._inmem_runner import FakeOpenAIRunner
@@ -365,6 +366,21 @@ async def test_call_passes_tool_specs(
     assert tools_arg[0]["type"] == "function"
     assert tools_arg[0]["function"]["name"] == "t"
     assert tools_arg[0]["function"]["parameters"] == schema
+
+
+@pytest.mark.asyncio
+async def test_call_rejects_illegal_tool_name_locally(
+    client: OpenAIClient,
+    fake_runner: FakeOpenAIRunner,
+) -> None:
+    """bug-017: an illegal tool name fails locally before any request."""
+    with pytest.raises(ToolNameInvalidError, match="kb_search"):
+        await client.call(
+            system="",
+            messages=[_user("hi")],
+            tools=[ToolSpec(name="kb.search", description="d", schema={"type": "object"})],
+        )
+    assert fake_runner.chat_calls == []
 
 
 # ----------------------------------------------------------------------

--- a/packages/agentforge/src/agentforge/_tools/decorator.py
+++ b/packages/agentforge/src/agentforge/_tools/decorator.py
@@ -20,7 +20,15 @@ Wraps a typed function as a concrete `Tool` subclass:
 The decorator inspects the wrapped function and constructs:
 
   - `name`              from the function's `__name__` (or the
-                        `name=` override argument).
+                        `name=` override argument). Keep it within
+                        `[a-zA-Z0-9_-]` (1-64 chars): that's the
+                        tool-name charset Bedrock, OpenAI, and
+                        Anthropic all enforce, so a name outside it
+                        is rejected at request-build time with
+                        `ToolNameInvalidError` (bug-017). A plain
+                        function name like `lookup_user` is already
+                        legal; avoid dots / colons / spaces in
+                        `name=` overrides.
   - `description`       from the docstring's summary line + Args
                         section, parsed Google-style. The first
                         non-blank non-arg line is the summary;

--- a/packages/agentforge/src/agentforge/templates/_shared/docs/runbooks/02-add-a-tool.md
+++ b/packages/agentforge/src/agentforge/templates/_shared/docs/runbooks/02-add-a-tool.md
@@ -28,6 +28,10 @@ agent = Agent(model="...", tools=[fetch_weather])
 3. **Add a docstring** — the first line is what the LLM reads to
    decide when to call your tool. Keep it short and behaviour-
    focused: "Returns X given Y", not "This tool will...".
+   **Name it with `[a-zA-Z0-9_-]` only** (1-64 chars) — that's the
+   tool-name charset Bedrock, OpenAI, and Anthropic all enforce.
+   A plain function name (`fetch_weather`) is already fine; avoid
+   dots / colons / spaces in `@tool(name="...")` overrides.
 4. **Pass the tool to `Agent(tools=[...])`** or list it under
    `agent.tools:` in `agentforge.yaml` so it's auto-resolved on
    `agentforge run`.
@@ -54,6 +58,7 @@ agent = Agent(model="...", tools=[fetch_weather])
 | `ValidationError` on tool call | type hints don't match LLM args | check the JSON schema with `tool.to_spec()` |
 | Tool runs but observation lost | tool returns `None` | return a string (or a dict; the framework JSON-serialises) |
 | Tool ran twice unexpectedly | LLM retried | check the previous observation surfaced clearly; vague observations cause retries |
+| `ToolNameInvalidError` at first LLM call | tool name has a dot / colon / space, or is >64 chars | rename to `[a-zA-Z0-9_-]` only (the error suggests a legal form, e.g. `kb.search` → `kb_search`) |
 
 ## Related
 


### PR DESCRIPTION
## bug-017 — provider tool-name charset undocumented and unchecked

Every major provider (Bedrock Converse, OpenAI, Anthropic) enforces `^[a-zA-Z0-9_-]{1,64}$` on tool names, but the framework neither documented nor validated it. A name like `kb.search` passed mocked CI and one provider, then failed *remotely* the moment `model:` swapped to Bedrock — the silent vendor-swap regression that vendor-agnostic providers are supposed to prevent.

## Approach — shared helper, invoked at every provider boundary

Decided against validating in core's `ToolSpec` (layering violation — `ToolSpec` is the deliberately neutral representation; the charset is a *per-provider wire constraint* that merely coincides across today's providers) and against Bedrock-only (under-delivers the "valid on one → valid on all" promise the bug is about).

- **core** — `validate_tool_name(name)` + `ToolNameInvalidError(ProviderError)` (`contracts/tool.py`, `production/exceptions.py`); exported from `agentforge_core`, `.contracts`, `.production`. The error suggests a legal rewrite (`kb.search` → `kb_search`).
- **providers** — Bedrock, OpenAI, **and** Anthropic call it at request-build time, so an illegal name fails *locally* with an actionable message before anything leaves the process.
- **core stays neutral** — `ToolSpec` does not auto-validate; each provider opts in via the shared helper. A future lax/local provider simply doesn't call it.

## Docs (layer 1)
feat-003 (custom-provider runbook), feat-004 (§4.6), feat-013 (MCP prefix note), the `@tool` docstring, and the scaffold's `02-add-a-tool` runbook.

## Tests
core: accept/reject parametrised cases + `ProviderError` subclassing + suggestion-in-message; each provider: a dotted name raises `ToolNameInvalidError` locally and nothing is sent.

Part of the v0.2.4 MCP/chat/config cluster; complements bug-012 (which fixed the framework's own `__`-separated MCP names — this adds the defensive net for all, including consumer-authored, names). Full pre-commit gate green; MCP live test re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)