### PR TITLE
fix: chain sister-package vendor-SDK extras (bug-015 P2)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,16 +1,16 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-017 (tool-name charset validator)
+feature: v0.2.4 MCP/chat/config cluster — bug-015 (meta extra-chain packaging)
 state: pr-raised
-branch: fix/bug-017-tool-name-validator
+branch: fix/bug-015-meta-extra-chain
 started_at: 2026-06-02
 last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
 resume: null
 flags_for_user:
-  - "PR #61 OPEN (fix/bug-017-tool-name-validator): bug-017 P2 — validate tool-name charset `^[a-zA-Z0-9_-]{1,64}$` at all 3 provider boundaries (validate_tool_name + ToolNameInvalidError in core; NOT auto-enforced on ToolSpec) + docs (feat-003/004/013, @tool docstring, scaffold runbook). 1 commit (3131f92), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/61 — awaiting merge."
-  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014 MCP runtime wiring, c2f1132), #60 (bug-012 MCP `.`→`__` separator, 3cf2bdc). main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (after #61), suggested order: bug-015 (meta extra chain agentforge/pyproject.toml:105 `agentforge-mcp ~=0.2.4`→`agentforge-mcp[mcp] ~=0.2.4` + audit other vendor modules) → bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
+  - "PR #62 OPEN (fix/bug-015-meta-extra-chain): bug-015 P2 — meta-package extras didn't chain sister vendor-SDK extras. Audited all 34 pkgs; fixed 12 missing chains + `[all]`, 1 phantom extra (bedrock), 1 eager-import-as-optional (agentforge-chat aiosqlite → hard dep). mcp ModuleError text updated. New generic test_extras_chain.py locks the invariant. 1 commit (9622d7e), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/62 — awaiting merge."
+  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014 MCP runtime wiring), #60 (bug-012 MCP `.`→`__`), #61 (bug-017 tool-name charset validator, 077795a). main at version 0.2.4."
+  - "REMAINING v0.2.4 cluster (after #62), suggested order: bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates — both EvaluatorEntry AND GuardrailEntry broken) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -40,24 +40,24 @@ rejected as stdio-hijack guard). The cluster unblocker is in main.
 failed (env-gated `test_mcp_live.py` asserted the old `echo.echo`;
 local pre-commit doesn't run live tests) — fixed in commit `0bc8386`.
 
-**In flight — PR #61** (`fix/bug-017-tool-name-validator`, off main):
-bug-017 P2 — `validate_tool_name` + `ToolNameInvalidError(ProviderError)`
-in core, invoked at the request-build boundary of all three providers
-(Bedrock/OpenAI/Anthropic); core `ToolSpec` deliberately NOT
-auto-validated (neutral representation; charset is a per-provider wire
-constraint). Docs in feat-003/004/013 + `@tool` docstring + scaffold
-`02-add-a-tool` runbook. 1 commit (`3131f92`), full gate + Live CI
-green. Awaiting merge.
+**Merged — PR #61** (`fix/bug-017-tool-name-validator`, 077795a):
+tool-name charset validator at all 3 provider boundaries.
+
+**In flight — PR #62** (`fix/bug-015-meta-extra-chain`, off main):
+bug-015 P2 — meta-package extras didn't chain sister vendor-SDK extras
+(`pip install agentforge-py[mcp]` installed the wrapper but not the SDK).
+Audited all 34 pkgs: fixed 12 missing chains + `[all]`, 1 phantom extra
+(`bedrock` → bare), 1 eager-import-as-optional (`agentforge-chat`
+aiosqlite → hard dep, matching memory-sqlite). mcp `ModuleError` text →
+`agentforge-mcp[mcp]`. New `test_extras_chain.py` locks the invariant
+generically. 1 commit (`9622d7e`), full gate + Live CI green. Awaiting
+merge.
 
 ## Pickup on resume
 
-1. **Merge PR #61** (bug-017) once reviewed/CI-green.
+1. **Merge PR #62** (bug-015) once reviewed/CI-green.
 2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
    branch off main, folding into v0.2.4), suggested order:
-   - **bug-015** — meta extra chain: `agentforge/pyproject.toml:105`
-     `mcp = ["agentforge-mcp ~= 0.2.4"]` → `["agentforge-mcp[mcp] ~= 0.2.4"]`;
-     fix the `ModuleError` text; audit other vendor modules for the
-     same broken chain.
    - **bug-019** — `mode="before"` string→{name} normaliser for
      `modules.evaluators` + guardrail `input`/`output`/`tool_gates`
      (both EvaluatorEntry AND GuardrailEntry are broken).

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2948,3 +2948,22 @@ representation, charset is a per-provider wire constraint that merely
 coincides today). Docs: feat-003/004/013, @tool docstring, scaffold
 02-add-a-tool runbook. Full gate + Live CI green (3131f92). PR #61 open.
 Next: bug-015 → bug-019 → bug-018 → bug-013 → enh-001; bug-008 before tag.
+
+## 2026-06-03T02:30 — v0.2.4 cluster: bug-017 merged (#61), bug-015 opened (#62)
+PR #61 (bug-017, tool-name charset validator) merged to main (077795a).
+Started bug-015 on `fix/bug-015-meta-extra-chain`. The reported bug
+(`agentforge-py[mcp]` doesn't pull the mcp SDK) was the tip — a full audit
+of all 34 packages' pyproject deps+extras found EVERY vendor SDK is an
+optional extra (the meta comment claiming ollama/litellm hard-bundle was
+wrong). Fixed 3 defect classes in agentforge/pyproject.toml (extras + [all]):
+12 missing chains (ollama/litellm/voyage/mcp/langfuse/phoenix/statsd/
+evidently/reranker-{cohere,voyage,mixedbread,sentence-transformers}); 1
+phantom extra (bedrock[bedrock] → bare, SDK is hard dep); 1
+eager-import-as-optional (agentforge-chat imports aiosqlite at package
+import but declared it optional → made hard dep like memory-sqlite, dropped
+[sqlite] extra, updated README+manifest). mcp ModuleError text (4 sites) →
+agentforge-mcp[mcp]. New generic test_extras_chain.py parses every sister
+pyproject and asserts each meta extra chains exactly the leaf's extras
+(catches missing + phantom for future packages too). Full gate + Live CI
+green (9622d7e). PR #62 open. Next: bug-019 → bug-018 → bug-013 → enh-001;
+bug-008 before tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,23 @@ activity and the next chat turn's prompt lost prior tool context.
 
 ### Fixed
 
+- **bug-015 — `agentforge-py` extras didn't pull their vendor SDKs.**
+  Sister packages keep their vendor SDK behind an optional `[<sdk>]`
+  extra (lazy-import pattern), but most meta extras requested the bare
+  package, so e.g. `pip install "agentforge-py[mcp]"` installed the
+  wrapper without the `mcp` SDK and the first call raised `ModuleError`.
+  An audit of all 34 packages found the chain broken for **12** extras
+  (`ollama`, `litellm`, `voyage`, `mcp`, `langfuse`, `phoenix`,
+  `statsd`, `evidently`, and the four `reranker-*`) plus `[all]`; they
+  now chain `[<sdk>]`. Two adjacent defects the audit surfaced are also
+  fixed: `bedrock` requested a **phantom** `[bedrock]` extra (its SDK is
+  a hard dep) — now bare; and `agentforge-chat` declared `aiosqlite` as
+  an optional `[sqlite]` extra despite importing it unconditionally
+  (`import agentforge_chat` failed without it) — now a hard dependency,
+  matching sibling `agentforge-memory-sqlite`. The `mcp` `ModuleError`
+  text now points at `agentforge-mcp[mcp]`. A new generic test
+  (`test_extras_chain.py`) locks the invariant for every current and
+  future package.
 - **bug-017 — provider tool-name charset was undocumented and
   unchecked.** Every major provider enforces `^[a-zA-Z0-9_-]{1,64}$`
   on tool names, but nothing in the framework documented or validated

--- a/docs/bugs/bug-015-agentforge-mcp-missing-mcp-sdk-dependency.md
+++ b/docs/bugs/bug-015-agentforge-mcp-missing-mcp-sdk-dependency.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P2
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
@@ -106,3 +106,41 @@ path actually deliver a working MCP runtime.
   that should be `["agentforge-X[vendor] ~= ..."]`. Candidates with
   optional SDK extras: `agentforge-langfuse`, `agentforge-phoenix`,
   `agentforge-a2a`, etc. Worth a one-pass sweep during the fix.
+
+## Resolution (v0.2.4)
+
+Audited all 34 packages (`pyproject.toml` deps + optional-dependencies).
+Every vendor SDK is an optional extra on its leaf package — **none** are
+hard-bundled — so the meta comment claiming "ollama / litellm bundle
+their SDK as a hard dep" was wrong. Three defect classes fixed in
+`packages/agentforge/pyproject.toml` (individual extras **and** `[all]`):
+
+1. **Missing chain (12 extras, the reported bug class)** — `ollama`,
+   `litellm`, `voyage`, `mcp`, `langfuse`, `phoenix`, `statsd`,
+   `evidently`, `reranker-cohere`, `reranker-voyage`,
+   `reranker-mixedbread`, `reranker-sentence-transformers`. Each now
+   chains `agentforge-<pkg>[<sdk>]`. (`anthropic` / `openai` were
+   already correct.) `[all]` previously installed *zero* vendor SDKs;
+   now chains them too.
+2. **Phantom extra** — `bedrock` requested `agentforge-bedrock[bedrock]`,
+   but bedrock has no such extra (its SDK `aioboto3`/`botocore` is a
+   hard dep). Now bare `agentforge-bedrock`.
+3. **Eager-import-as-optional** — `agentforge-chat` imports
+   `SqliteChatHistory` (→ `import aiosqlite`) at package import, yet
+   declared `aiosqlite` as an optional `[sqlite]` extra, so
+   `import agentforge_chat` failed on a bare install. `aiosqlite` is now
+   a hard dependency (matching sibling `agentforge-memory-sqlite`); the
+   `[sqlite]` extra, chat README, and manifest comment were updated.
+
+Also: the `mcp` `ModuleError` text (4 sites in `agentforge-mcp`) now
+recommends `agentforge-mcp[mcp]` instead of bare `pip install mcp`.
+
+A generic regression test (`packages/agentforge/tests/unit/test_extras_chain.py`)
+parses every sister `pyproject.toml` and asserts each meta extra chains
+exactly the leaf package's extras — catching both missing and phantom
+extras for current and future packages.
+
+**Out of scope (noted, not fixed here):** `agentforge-chat`'s
+token-budget truncation lazily imports `tiktoken` / `anthropic` for
+tokenisation; these are genuinely-optional advanced-feature deps with no
+advertised meta extra, so they are not part of this broken-chain fix.

--- a/packages/agentforge-chat/README.md
+++ b/packages/agentforge-chat/README.md
@@ -12,9 +12,10 @@ for the design and runbook.
 
 ```bash
 pip install agentforge-chat
-# or, with the SQLite driver pre-pulled:
-pip install "agentforge-chat[sqlite]"
 ```
+
+The SQLite history driver (`SqliteChatHistory`) works out of the box —
+`aiosqlite` ships as a hard dependency.
 
 ## Three-line chat from a one-shot agent
 

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -32,10 +32,13 @@ classifiers = [
 dependencies = [
     "agentforge-core ~= 0.2.4",
     "agentforge-py ~= 0.2.4",
+    # aiosqlite is a hard dependency, not an optional extra: the package
+    # eagerly imports SqliteChatHistory (agentforge_chat/__init__.py ->
+    # sqlite.py -> `import aiosqlite`), so `import agentforge_chat` fails
+    # without it. Mirrors the sibling agentforge-memory-sqlite, which also
+    # hard-deps aiosqlite. (bug-015 audit.)
+    "aiosqlite>=0.20",
 ]
-
-[project.optional-dependencies]
-sqlite = ["aiosqlite>=0.20"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-chat/src/agentforge_chat/manifest.yaml
+++ b/packages/agentforge-chat/src/agentforge_chat/manifest.yaml
@@ -11,7 +11,7 @@ distribution:
 config_block:
   modules.chat:
     history:
-      driver: memory   # memory | sqlite (sqlite needs `agentforge-chat[sqlite]`)
+      driver: memory   # memory | sqlite (both ship with agentforge-chat)
       config: {}
     truncation:
       strategy: sliding_window

--- a/packages/agentforge-mcp/src/agentforge_mcp/client.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/client.py
@@ -137,7 +137,11 @@ async def _build_stdio_runner(
         from mcp import ClientSession  # noqa: PLC0415
         from mcp.client.stdio import StdioServerParameters, stdio_client  # noqa: PLC0415
     except ImportError as exc:
-        msg = "mcp SDK is not installed. Install via `pip install mcp` to consume MCP servers."
+        msg = (
+            "mcp SDK is not installed. Install via "
+            '`pip install "agentforge-mcp[mcp]"` (or `agentforge-py[mcp]`) '
+            "to consume MCP servers."
+        )
         raise ModuleError(msg) from exc
     parts = command.split()
     if not parts:
@@ -175,8 +179,8 @@ async def _build_http_runner(
             )
     except ImportError as exc:
         msg = (
-            f"mcp SDK is not installed. Install via `pip install mcp` to "
-            f"connect to MCP server {name!r} over {transport}."
+            'mcp SDK is not installed. Install via `pip install "agentforge-mcp[mcp]"` '
+            f"(or `agentforge-py[mcp]`) to connect to MCP server {name!r} over {transport}."
         )
         raise ModuleError(msg) from exc
     return _SDKClientRunner(

--- a/packages/agentforge-mcp/src/agentforge_mcp/server.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/server.py
@@ -129,8 +129,8 @@ def _build_stdio_server_runner(  # pragma: no cover — exercised only with `mcp
         from mcp.server.stdio import stdio_server  # noqa: PLC0415, F401
     except ImportError as exc:
         msg = (
-            "mcp SDK is not installed. Install via `pip install mcp` to "
-            "expose tools as an MCP stdio server."
+            'mcp SDK is not installed. Install via `pip install "agentforge-mcp[mcp]"` '
+            "(or `agentforge-py[mcp]`) to expose tools as an MCP stdio server."
         )
         raise ModuleError(msg) from exc
     return _SDKServerRunner(server=Server(server_name), transport="stdio")
@@ -146,8 +146,8 @@ def _build_http_server_runner(  # pragma: no cover — exercised only with `mcp`
         from mcp.server import Server  # noqa: PLC0415
     except ImportError as exc:
         msg = (
-            "mcp SDK is not installed. Install via `pip install mcp` to "
-            "expose tools as an MCP HTTP server."
+            'mcp SDK is not installed. Install via `pip install "agentforge-mcp[mcp]"` '
+            "(or `agentforge-py[mcp]`) to expose tools as an MCP HTTP server."
         )
         raise ModuleError(msg) from exc
     return _SDKServerRunner(server=Server(server_name), transport="http", host=host, port=port)

--- a/packages/agentforge-mcp/tests/unit/test_client.py
+++ b/packages/agentforge-mcp/tests/unit/test_client.py
@@ -106,7 +106,7 @@ async def test_from_stdio_errors_when_sdk_missing(
     from agentforge_core.production.exceptions import ModuleError  # noqa: PLC0415
 
     monkeypatch.setitem(sys.modules, "mcp", None)
-    with pytest.raises(ModuleError, match="pip install mcp"):
+    with pytest.raises(ModuleError, match="agentforge-mcp"):
         await MCPServerClient.from_stdio(name="x", command="echo")
 
 
@@ -119,7 +119,7 @@ async def test_from_http_errors_when_sdk_missing(
     from agentforge_core.production.exceptions import ModuleError  # noqa: PLC0415
 
     monkeypatch.setitem(sys.modules, "mcp", None)
-    with pytest.raises(ModuleError, match="pip install mcp"):
+    with pytest.raises(ModuleError, match="agentforge-mcp"):
         await MCPServerClient.from_http(name="x", url="http://localhost/mcp")
 
 
@@ -132,5 +132,5 @@ async def test_from_sse_errors_when_sdk_missing(
     from agentforge_core.production.exceptions import ModuleError  # noqa: PLC0415
 
     monkeypatch.setitem(sys.modules, "mcp", None)
-    with pytest.raises(ModuleError, match="pip install mcp"):
+    with pytest.raises(ModuleError, match="agentforge-mcp"):
         await MCPServerClient.from_sse(name="x", url="http://localhost/mcp")

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -55,27 +55,28 @@ dependencies = [
 # resolves to `agentforge-py + agentforge-anthropic`, etc.
 # Add a new entry here every time a new sister package ships.
 
-# LLM providers — for providers with a vendor-SDK extra
-# (anthropic / openai / bedrock), the extra is included so a single
-# `pip install "agentforge-py[<provider>]"` lands both the framework
-# wrapper AND the underlying SDK. ollama / litellm bundle their SDK
-# as a hard dep, so no `[<sdk>]` extra is needed.
+# LLM providers. Where a sister package keeps its vendor SDK behind
+# an optional `[<sdk>]` extra (the lazy-import pattern), the meta extra
+# MUST chain that extra — otherwise `pip install "agentforge-py[x]"`
+# installs the wrapper but not the SDK and the first call raises a
+# ModuleError (bug-015). bedrock hard-deps its SDK (aioboto3/botocore),
+# so it requests no extra — and must NOT request a phantom `[bedrock]`.
 anthropic = ["agentforge-anthropic[anthropic] ~= 0.2.4"]
 openai = ["agentforge-openai[openai] ~= 0.2.4"]
-bedrock = ["agentforge-bedrock[bedrock] ~= 0.2.4"]
-ollama = ["agentforge-ollama ~= 0.2.4"]
-litellm = ["agentforge-litellm ~= 0.2.4"]
+bedrock = ["agentforge-bedrock ~= 0.2.4"]
+ollama = ["agentforge-ollama[ollama] ~= 0.2.4"]
+litellm = ["agentforge-litellm[litellm] ~= 0.2.4"]
 
 # Embeddings
-voyage = ["agentforge-voyage ~= 0.2.4"]
+voyage = ["agentforge-voyage[voyage] ~= 0.2.4"]
 
-# Memory backends
+# Memory backends (each hard-deps its driver SDK — no extra to chain)
 memory-sqlite = ["agentforge-memory-sqlite ~= 0.2.4"]
 memory-postgres = ["agentforge-memory-postgres ~= 0.2.4"]
 memory-neo4j = ["agentforge-memory-neo4j ~= 0.2.4"]
 memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.2.4"]
 
-# Chat surface
+# Chat surface (chat hard-deps aiosqlite; history backends hard-dep their SDK)
 chat = ["agentforge-chat ~= 0.2.4"]
 chat-http = ["agentforge-chat-http ~= 0.2.4"]
 chat-slack = ["agentforge-chat-slack ~= 0.2.4"]
@@ -83,26 +84,26 @@ chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.2.4"]
 chat-history-redis = ["agentforge-chat-history-redis ~= 0.2.4"]
 
 # Rerankers
-reranker-cohere = ["agentforge-reranker-cohere ~= 0.2.4"]
-reranker-voyage = ["agentforge-reranker-voyage ~= 0.2.4"]
-reranker-mixedbread = ["agentforge-reranker-mixedbread ~= 0.2.4"]
-reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers ~= 0.2.4"]
+reranker-cohere = ["agentforge-reranker-cohere[cohere] ~= 0.2.4"]
+reranker-voyage = ["agentforge-reranker-voyage[voyage] ~= 0.2.4"]
+reranker-mixedbread = ["agentforge-reranker-mixedbread[mixedbread] ~= 0.2.4"]
+reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.2.4"]
 
-# Guardrails
+# Guardrails (each hard-deps its SDK — no extra to chain)
 guard-llmguard = ["agentforge-guard-llmguard ~= 0.2.4"]
 guard-presidio = ["agentforge-guard-presidio ~= 0.2.4"]
 guard-nemo = ["agentforge-guard-nemo ~= 0.2.4"]
 guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.2.4"]
 
 # Observability
-langfuse = ["agentforge-langfuse ~= 0.2.4"]
-phoenix = ["agentforge-phoenix ~= 0.2.4"]
+langfuse = ["agentforge-langfuse[langfuse] ~= 0.2.4"]
+phoenix = ["agentforge-phoenix[phoenix] ~= 0.2.4"]
 otel = ["agentforge-otel ~= 0.2.4"]
-statsd = ["agentforge-statsd ~= 0.2.4"]
-evidently = ["agentforge-evidently ~= 0.2.4"]
+statsd = ["agentforge-statsd[statsd] ~= 0.2.4"]
+evidently = ["agentforge-evidently[evidently] ~= 0.2.4"]
 
 # Protocols
-mcp = ["agentforge-mcp ~= 0.2.4"]
+mcp = ["agentforge-mcp[mcp] ~= 0.2.4"]
 a2a = ["agentforge-a2a ~= 0.2.4"]
 
 # Eval
@@ -113,14 +114,15 @@ testing = ["agentforge-testing ~= 0.2.4"]
 
 # Everything (development / docs / smoke-test convenience — not
 # recommended for production deploys; pick the actual integrations
-# you use to keep the dependency tree small).
+# you use to keep the dependency tree small). Vendor-SDK extras are
+# chained here too so `[all]` actually installs every SDK.
 all = [
-    "agentforge-anthropic ~= 0.2.4",
-    "agentforge-openai ~= 0.2.4",
+    "agentforge-anthropic[anthropic] ~= 0.2.4",
+    "agentforge-openai[openai] ~= 0.2.4",
     "agentforge-bedrock ~= 0.2.4",
-    "agentforge-ollama ~= 0.2.4",
-    "agentforge-litellm ~= 0.2.4",
-    "agentforge-voyage ~= 0.2.4",
+    "agentforge-ollama[ollama] ~= 0.2.4",
+    "agentforge-litellm[litellm] ~= 0.2.4",
+    "agentforge-voyage[voyage] ~= 0.2.4",
     "agentforge-memory-sqlite ~= 0.2.4",
     "agentforge-memory-postgres ~= 0.2.4",
     "agentforge-memory-neo4j ~= 0.2.4",
@@ -130,20 +132,20 @@ all = [
     "agentforge-chat-slack ~= 0.2.4",
     "agentforge-chat-history-postgres ~= 0.2.4",
     "agentforge-chat-history-redis ~= 0.2.4",
-    "agentforge-reranker-cohere ~= 0.2.4",
-    "agentforge-reranker-voyage ~= 0.2.4",
-    "agentforge-reranker-mixedbread ~= 0.2.4",
-    "agentforge-reranker-sentence-transformers ~= 0.2.4",
+    "agentforge-reranker-cohere[cohere] ~= 0.2.4",
+    "agentforge-reranker-voyage[voyage] ~= 0.2.4",
+    "agentforge-reranker-mixedbread[mixedbread] ~= 0.2.4",
+    "agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.2.4",
     "agentforge-guard-llmguard ~= 0.2.4",
     "agentforge-guard-presidio ~= 0.2.4",
     "agentforge-guard-nemo ~= 0.2.4",
     "agentforge-guard-llamaguard ~= 0.2.4",
-    "agentforge-langfuse ~= 0.2.4",
-    "agentforge-phoenix ~= 0.2.4",
+    "agentforge-langfuse[langfuse] ~= 0.2.4",
+    "agentforge-phoenix[phoenix] ~= 0.2.4",
     "agentforge-otel ~= 0.2.4",
-    "agentforge-statsd ~= 0.2.4",
-    "agentforge-evidently ~= 0.2.4",
-    "agentforge-mcp ~= 0.2.4",
+    "agentforge-statsd[statsd] ~= 0.2.4",
+    "agentforge-evidently[evidently] ~= 0.2.4",
+    "agentforge-mcp[mcp] ~= 0.2.4",
     "agentforge-a2a ~= 0.2.4",
     "agentforge-eval-geval ~= 0.2.4",
     "agentforge-testing ~= 0.2.4",

--- a/packages/agentforge/tests/unit/test_extras_chain.py
+++ b/packages/agentforge/tests/unit/test_extras_chain.py
@@ -1,0 +1,103 @@
+"""The meta package's extras must chain each sister package's vendor-SDK
+extras (bug-015).
+
+`pip install "agentforge-py[mcp]"` has to deliver a *working* MCP runtime,
+not just the wrapper. When a sister package keeps its vendor SDK behind an
+optional `[<sdk>]` extra (the lazy-import pattern), the meta extra that
+points at it must request that extra — otherwise the SDK never installs and
+the first call raises `ModuleError`. Conversely, a meta extra must NOT
+request an extra the sister package doesn't provide (a phantom extra, e.g.
+the old `agentforge-bedrock[bedrock]` when bedrock hard-deps its SDK).
+
+This test enforces the invariant generically over every meta extra
+(including `all`), so it also covers sister packages added in the future.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+# This test lives at packages/agentforge/tests/unit/ — so resolving the
+# file's parents reaches the meta package dir and the packages root.
+_META_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+_PACKAGES_DIR = Path(__file__).resolve().parents[3]
+
+_REQ_RE = re.compile(r"^\s*(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[(?P<extras>[^\]]*)\])?")
+
+
+def _load(pyproject: Path) -> dict[str, object]:
+    with pyproject.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _provided_extras() -> dict[str, set[str]]:
+    """Map every sister distribution name -> the set of extras it declares."""
+    out: dict[str, set[str]] = {}
+    for pyproject in _PACKAGES_DIR.glob("*/pyproject.toml"):
+        project = _load(pyproject).get("project", {})
+        assert isinstance(project, dict)
+        name = project.get("name")
+        if not isinstance(name, str):
+            continue
+        opt = project.get("optional-dependencies", {})
+        out[name] = set(opt) if isinstance(opt, dict) else set()
+    return out
+
+
+def _parse_requirement(req: str) -> tuple[str, set[str]]:
+    m = _REQ_RE.match(req)
+    assert m is not None, f"unparseable requirement: {req!r}"
+    extras = m.group("extras")
+    requested = {e.strip() for e in extras.split(",") if e.strip()} if extras else set()
+    return m.group("name"), requested
+
+
+def _meta_requirements() -> list[tuple[str, str]]:
+    """Every (extra_name, requirement_string) in the meta package's extras."""
+    project = _load(_META_PYPROJECT).get("project", {})
+    assert isinstance(project, dict)
+    opt = project.get("optional-dependencies", {})
+    assert isinstance(opt, dict)
+    pairs: list[tuple[str, str]] = []
+    for extra_name, reqs in opt.items():
+        assert isinstance(reqs, list)
+        for req in reqs:
+            assert isinstance(req, str)
+            pairs.append((extra_name, req))
+    return pairs
+
+
+_PROVIDED = _provided_extras()
+_REQUIREMENTS = _meta_requirements()
+
+
+@pytest.mark.parametrize(
+    ("extra_name", "requirement"),
+    _REQUIREMENTS,
+    ids=[f"{e}:{r.split()[0]}" for e, r in _REQUIREMENTS],
+)
+def test_meta_extra_chains_sister_extras(extra_name: str, requirement: str) -> None:
+    name, requested = _parse_requirement(requirement)
+    if name not in _PROVIDED:
+        # Not a sister package (e.g. a third-party dep) — nothing to chain.
+        return
+    provided = _PROVIDED[name]
+    assert requested == provided, (
+        f"meta extra [{extra_name}] requires {requirement!r}: it requests extras "
+        f"{sorted(requested)} but {name} provides {sorted(provided)}. "
+        f"A meta extra must chain exactly the sister package's vendor-SDK extras "
+        f"(missing → SDK never installs; phantom → unknown-extra warning). "
+        f"See bug-015."
+    )
+
+
+def test_invariant_actually_covers_vendor_packages() -> None:
+    """Guard against the test silently passing because nothing was checked:
+    at least the known vendor-SDK packages must be present in the meta extras."""
+    checked = {_parse_requirement(req)[0] for _, req in _REQUIREMENTS}
+    for must in ("agentforge-mcp", "agentforge-anthropic", "agentforge-ollama"):
+        assert must in checked, f"{must} not referenced by any meta extra"

--- a/uv.lock
+++ b/uv.lock
@@ -114,10 +114,6 @@ source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge-core" },
     { name = "agentforge-py" },
-]
-
-[package.optional-dependencies]
-sqlite = [
     { name = "aiosqlite" },
 ]
 
@@ -125,9 +121,8 @@ sqlite = [
 requires-dist = [
     { name = "agentforge-core", editable = "packages/agentforge-core" },
     { name = "agentforge-py", editable = "packages/agentforge" },
-    { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.20" },
+    { name = "aiosqlite", specifier = ">=0.20" },
 ]
-provides-extras = ["sqlite"]
 
 [[package]]
 name = "agentforge-chat-history-postgres"
@@ -516,7 +511,7 @@ a2a = [
 ]
 all = [
     { name = "agentforge-a2a" },
-    { name = "agentforge-anthropic" },
+    { name = "agentforge-anthropic", extra = ["anthropic"] },
     { name = "agentforge-bedrock" },
     { name = "agentforge-chat" },
     { name = "agentforge-chat-history-postgres" },
@@ -524,29 +519,29 @@ all = [
     { name = "agentforge-chat-http" },
     { name = "agentforge-chat-slack" },
     { name = "agentforge-eval-geval" },
-    { name = "agentforge-evidently" },
+    { name = "agentforge-evidently", extra = ["evidently"] },
     { name = "agentforge-guard-llamaguard" },
     { name = "agentforge-guard-llmguard" },
     { name = "agentforge-guard-nemo" },
     { name = "agentforge-guard-presidio" },
-    { name = "agentforge-langfuse" },
-    { name = "agentforge-litellm" },
-    { name = "agentforge-mcp" },
+    { name = "agentforge-langfuse", extra = ["langfuse"] },
+    { name = "agentforge-litellm", extra = ["litellm"] },
+    { name = "agentforge-mcp", extra = ["mcp"] },
     { name = "agentforge-memory-neo4j" },
     { name = "agentforge-memory-postgres" },
     { name = "agentforge-memory-sqlite" },
     { name = "agentforge-memory-surrealdb" },
-    { name = "agentforge-ollama" },
-    { name = "agentforge-openai" },
+    { name = "agentforge-ollama", extra = ["ollama"] },
+    { name = "agentforge-openai", extra = ["openai"] },
     { name = "agentforge-otel" },
-    { name = "agentforge-phoenix" },
-    { name = "agentforge-reranker-cohere" },
-    { name = "agentforge-reranker-mixedbread" },
-    { name = "agentforge-reranker-sentence-transformers" },
-    { name = "agentforge-reranker-voyage" },
-    { name = "agentforge-statsd" },
+    { name = "agentforge-phoenix", extra = ["phoenix"] },
+    { name = "agentforge-reranker-cohere", extra = ["cohere"] },
+    { name = "agentforge-reranker-mixedbread", extra = ["mixedbread"] },
+    { name = "agentforge-reranker-sentence-transformers", extra = ["sentence-transformers"] },
+    { name = "agentforge-reranker-voyage", extra = ["voyage"] },
+    { name = "agentforge-statsd", extra = ["statsd"] },
     { name = "agentforge-testing" },
-    { name = "agentforge-voyage" },
+    { name = "agentforge-voyage", extra = ["voyage"] },
 ]
 anthropic = [
     { name = "agentforge-anthropic", extra = ["anthropic"] },
@@ -573,7 +568,7 @@ eval = [
     { name = "agentforge-eval-geval" },
 ]
 evidently = [
-    { name = "agentforge-evidently" },
+    { name = "agentforge-evidently", extra = ["evidently"] },
 ]
 guard-llamaguard = [
     { name = "agentforge-guard-llamaguard" },
@@ -588,13 +583,13 @@ guard-presidio = [
     { name = "agentforge-guard-presidio" },
 ]
 langfuse = [
-    { name = "agentforge-langfuse" },
+    { name = "agentforge-langfuse", extra = ["langfuse"] },
 ]
 litellm = [
-    { name = "agentforge-litellm" },
+    { name = "agentforge-litellm", extra = ["litellm"] },
 ]
 mcp = [
-    { name = "agentforge-mcp" },
+    { name = "agentforge-mcp", extra = ["mcp"] },
 ]
 memory-neo4j = [
     { name = "agentforge-memory-neo4j" },
@@ -609,7 +604,7 @@ memory-surrealdb = [
     { name = "agentforge-memory-surrealdb" },
 ]
 ollama = [
-    { name = "agentforge-ollama" },
+    { name = "agentforge-ollama", extra = ["ollama"] },
 ]
 openai = [
     { name = "agentforge-openai", extra = ["openai"] },
@@ -618,38 +613,38 @@ otel = [
     { name = "agentforge-otel" },
 ]
 phoenix = [
-    { name = "agentforge-phoenix" },
+    { name = "agentforge-phoenix", extra = ["phoenix"] },
 ]
 reranker-cohere = [
-    { name = "agentforge-reranker-cohere" },
+    { name = "agentforge-reranker-cohere", extra = ["cohere"] },
 ]
 reranker-mixedbread = [
-    { name = "agentforge-reranker-mixedbread" },
+    { name = "agentforge-reranker-mixedbread", extra = ["mixedbread"] },
 ]
 reranker-sentence-transformers = [
-    { name = "agentforge-reranker-sentence-transformers" },
+    { name = "agentforge-reranker-sentence-transformers", extra = ["sentence-transformers"] },
 ]
 reranker-voyage = [
-    { name = "agentforge-reranker-voyage" },
+    { name = "agentforge-reranker-voyage", extra = ["voyage"] },
 ]
 statsd = [
-    { name = "agentforge-statsd" },
+    { name = "agentforge-statsd", extra = ["statsd"] },
 ]
 testing = [
     { name = "agentforge-testing" },
 ]
 voyage = [
-    { name = "agentforge-voyage" },
+    { name = "agentforge-voyage", extra = ["voyage"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "agentforge-a2a", marker = "extra == 'a2a'", editable = "packages/agentforge-a2a" },
     { name = "agentforge-a2a", marker = "extra == 'all'", editable = "packages/agentforge-a2a" },
-    { name = "agentforge-anthropic", marker = "extra == 'all'", editable = "packages/agentforge-anthropic" },
+    { name = "agentforge-anthropic", extras = ["anthropic"], marker = "extra == 'all'", editable = "packages/agentforge-anthropic" },
     { name = "agentforge-anthropic", extras = ["anthropic"], marker = "extra == 'anthropic'", editable = "packages/agentforge-anthropic" },
     { name = "agentforge-bedrock", marker = "extra == 'all'", editable = "packages/agentforge-bedrock" },
-    { name = "agentforge-bedrock", extras = ["bedrock"], marker = "extra == 'bedrock'", editable = "packages/agentforge-bedrock" },
+    { name = "agentforge-bedrock", marker = "extra == 'bedrock'", editable = "packages/agentforge-bedrock" },
     { name = "agentforge-chat", marker = "extra == 'all'", editable = "packages/agentforge-chat" },
     { name = "agentforge-chat", marker = "extra == 'chat'", editable = "packages/agentforge-chat" },
     { name = "agentforge-chat-history-postgres", marker = "extra == 'all'", editable = "packages/agentforge-chat-history-postgres" },
@@ -663,8 +658,8 @@ requires-dist = [
     { name = "agentforge-core", editable = "packages/agentforge-core" },
     { name = "agentforge-eval-geval", marker = "extra == 'all'", editable = "packages/agentforge-eval-geval" },
     { name = "agentforge-eval-geval", marker = "extra == 'eval'", editable = "packages/agentforge-eval-geval" },
-    { name = "agentforge-evidently", marker = "extra == 'all'", editable = "packages/agentforge-evidently" },
-    { name = "agentforge-evidently", marker = "extra == 'evidently'", editable = "packages/agentforge-evidently" },
+    { name = "agentforge-evidently", extras = ["evidently"], marker = "extra == 'all'", editable = "packages/agentforge-evidently" },
+    { name = "agentforge-evidently", extras = ["evidently"], marker = "extra == 'evidently'", editable = "packages/agentforge-evidently" },
     { name = "agentforge-guard-llamaguard", marker = "extra == 'all'", editable = "packages/agentforge-guard-llamaguard" },
     { name = "agentforge-guard-llamaguard", marker = "extra == 'guard-llamaguard'", editable = "packages/agentforge-guard-llamaguard" },
     { name = "agentforge-guard-llmguard", marker = "extra == 'all'", editable = "packages/agentforge-guard-llmguard" },
@@ -673,12 +668,12 @@ requires-dist = [
     { name = "agentforge-guard-nemo", marker = "extra == 'guard-nemo'", editable = "packages/agentforge-guard-nemo" },
     { name = "agentforge-guard-presidio", marker = "extra == 'all'", editable = "packages/agentforge-guard-presidio" },
     { name = "agentforge-guard-presidio", marker = "extra == 'guard-presidio'", editable = "packages/agentforge-guard-presidio" },
-    { name = "agentforge-langfuse", marker = "extra == 'all'", editable = "packages/agentforge-langfuse" },
-    { name = "agentforge-langfuse", marker = "extra == 'langfuse'", editable = "packages/agentforge-langfuse" },
-    { name = "agentforge-litellm", marker = "extra == 'all'", editable = "packages/agentforge-litellm" },
-    { name = "agentforge-litellm", marker = "extra == 'litellm'", editable = "packages/agentforge-litellm" },
-    { name = "agentforge-mcp", marker = "extra == 'all'", editable = "packages/agentforge-mcp" },
-    { name = "agentforge-mcp", marker = "extra == 'mcp'", editable = "packages/agentforge-mcp" },
+    { name = "agentforge-langfuse", extras = ["langfuse"], marker = "extra == 'all'", editable = "packages/agentforge-langfuse" },
+    { name = "agentforge-langfuse", extras = ["langfuse"], marker = "extra == 'langfuse'", editable = "packages/agentforge-langfuse" },
+    { name = "agentforge-litellm", extras = ["litellm"], marker = "extra == 'all'", editable = "packages/agentforge-litellm" },
+    { name = "agentforge-litellm", extras = ["litellm"], marker = "extra == 'litellm'", editable = "packages/agentforge-litellm" },
+    { name = "agentforge-mcp", extras = ["mcp"], marker = "extra == 'all'", editable = "packages/agentforge-mcp" },
+    { name = "agentforge-mcp", extras = ["mcp"], marker = "extra == 'mcp'", editable = "packages/agentforge-mcp" },
     { name = "agentforge-memory-neo4j", marker = "extra == 'all'", editable = "packages/agentforge-memory-neo4j" },
     { name = "agentforge-memory-neo4j", marker = "extra == 'memory-neo4j'", editable = "packages/agentforge-memory-neo4j" },
     { name = "agentforge-memory-postgres", marker = "extra == 'all'", editable = "packages/agentforge-memory-postgres" },
@@ -687,28 +682,28 @@ requires-dist = [
     { name = "agentforge-memory-sqlite", marker = "extra == 'memory-sqlite'", editable = "packages/agentforge-memory-sqlite" },
     { name = "agentforge-memory-surrealdb", marker = "extra == 'all'", editable = "packages/agentforge-memory-surrealdb" },
     { name = "agentforge-memory-surrealdb", marker = "extra == 'memory-surrealdb'", editable = "packages/agentforge-memory-surrealdb" },
-    { name = "agentforge-ollama", marker = "extra == 'all'", editable = "packages/agentforge-ollama" },
-    { name = "agentforge-ollama", marker = "extra == 'ollama'", editable = "packages/agentforge-ollama" },
-    { name = "agentforge-openai", marker = "extra == 'all'", editable = "packages/agentforge-openai" },
+    { name = "agentforge-ollama", extras = ["ollama"], marker = "extra == 'all'", editable = "packages/agentforge-ollama" },
+    { name = "agentforge-ollama", extras = ["ollama"], marker = "extra == 'ollama'", editable = "packages/agentforge-ollama" },
+    { name = "agentforge-openai", extras = ["openai"], marker = "extra == 'all'", editable = "packages/agentforge-openai" },
     { name = "agentforge-openai", extras = ["openai"], marker = "extra == 'openai'", editable = "packages/agentforge-openai" },
     { name = "agentforge-otel", marker = "extra == 'all'", editable = "packages/agentforge-otel" },
     { name = "agentforge-otel", marker = "extra == 'otel'", editable = "packages/agentforge-otel" },
-    { name = "agentforge-phoenix", marker = "extra == 'all'", editable = "packages/agentforge-phoenix" },
-    { name = "agentforge-phoenix", marker = "extra == 'phoenix'", editable = "packages/agentforge-phoenix" },
-    { name = "agentforge-reranker-cohere", marker = "extra == 'all'", editable = "packages/agentforge-reranker-cohere" },
-    { name = "agentforge-reranker-cohere", marker = "extra == 'reranker-cohere'", editable = "packages/agentforge-reranker-cohere" },
-    { name = "agentforge-reranker-mixedbread", marker = "extra == 'all'", editable = "packages/agentforge-reranker-mixedbread" },
-    { name = "agentforge-reranker-mixedbread", marker = "extra == 'reranker-mixedbread'", editable = "packages/agentforge-reranker-mixedbread" },
-    { name = "agentforge-reranker-sentence-transformers", marker = "extra == 'all'", editable = "packages/agentforge-reranker-sentence-transformers" },
-    { name = "agentforge-reranker-sentence-transformers", marker = "extra == 'reranker-sentence-transformers'", editable = "packages/agentforge-reranker-sentence-transformers" },
-    { name = "agentforge-reranker-voyage", marker = "extra == 'all'", editable = "packages/agentforge-reranker-voyage" },
-    { name = "agentforge-reranker-voyage", marker = "extra == 'reranker-voyage'", editable = "packages/agentforge-reranker-voyage" },
-    { name = "agentforge-statsd", marker = "extra == 'all'", editable = "packages/agentforge-statsd" },
-    { name = "agentforge-statsd", marker = "extra == 'statsd'", editable = "packages/agentforge-statsd" },
+    { name = "agentforge-phoenix", extras = ["phoenix"], marker = "extra == 'all'", editable = "packages/agentforge-phoenix" },
+    { name = "agentforge-phoenix", extras = ["phoenix"], marker = "extra == 'phoenix'", editable = "packages/agentforge-phoenix" },
+    { name = "agentforge-reranker-cohere", extras = ["cohere"], marker = "extra == 'all'", editable = "packages/agentforge-reranker-cohere" },
+    { name = "agentforge-reranker-cohere", extras = ["cohere"], marker = "extra == 'reranker-cohere'", editable = "packages/agentforge-reranker-cohere" },
+    { name = "agentforge-reranker-mixedbread", extras = ["mixedbread"], marker = "extra == 'all'", editable = "packages/agentforge-reranker-mixedbread" },
+    { name = "agentforge-reranker-mixedbread", extras = ["mixedbread"], marker = "extra == 'reranker-mixedbread'", editable = "packages/agentforge-reranker-mixedbread" },
+    { name = "agentforge-reranker-sentence-transformers", extras = ["sentence-transformers"], marker = "extra == 'all'", editable = "packages/agentforge-reranker-sentence-transformers" },
+    { name = "agentforge-reranker-sentence-transformers", extras = ["sentence-transformers"], marker = "extra == 'reranker-sentence-transformers'", editable = "packages/agentforge-reranker-sentence-transformers" },
+    { name = "agentforge-reranker-voyage", extras = ["voyage"], marker = "extra == 'all'", editable = "packages/agentforge-reranker-voyage" },
+    { name = "agentforge-reranker-voyage", extras = ["voyage"], marker = "extra == 'reranker-voyage'", editable = "packages/agentforge-reranker-voyage" },
+    { name = "agentforge-statsd", extras = ["statsd"], marker = "extra == 'all'", editable = "packages/agentforge-statsd" },
+    { name = "agentforge-statsd", extras = ["statsd"], marker = "extra == 'statsd'", editable = "packages/agentforge-statsd" },
     { name = "agentforge-testing", marker = "extra == 'all'", editable = "packages/agentforge-testing" },
     { name = "agentforge-testing", marker = "extra == 'testing'", editable = "packages/agentforge-testing" },
-    { name = "agentforge-voyage", marker = "extra == 'all'", editable = "packages/agentforge-voyage" },
-    { name = "agentforge-voyage", marker = "extra == 'voyage'", editable = "packages/agentforge-voyage" },
+    { name = "agentforge-voyage", extras = ["voyage"], marker = "extra == 'all'", editable = "packages/agentforge-voyage" },
+    { name = "agentforge-voyage", extras = ["voyage"], marker = "extra == 'voyage'", editable = "packages/agentforge-voyage" },
     { name = "copier", specifier = ">=9.4" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## bug-015 — `agentforge-py` extras didn't pull their vendor SDKs

Sister packages keep their vendor SDK behind an optional `[<sdk>]` extra (the lazy-import pattern). But most meta extras requested the **bare** package, so `pip install "agentforge-py[mcp]"` installed `agentforge-mcp` *without* the `mcp` SDK — and the first call raised `ModuleError`. The user hit this on a live Bedrock+MCP integration.

## Audit (all 34 packages) — three defect classes

Every vendor SDK turned out to be an optional extra (none hard-bundled), so the existing comment claiming "ollama/litellm bundle their SDK as a hard dep" was wrong.

1. **Missing chain — 12 extras** (`ollama`, `litellm`, `voyage`, `mcp`, `langfuse`, `phoenix`, `statsd`, `evidently`, `reranker-{cohere,voyage,mixedbread,sentence-transformers}`): now chain `agentforge-<pkg>[<sdk>]`. `anthropic`/`openai` were already correct. **`[all]` pulled zero SDKs** — now chains them too.
2. **Phantom extra**: `bedrock` requested `agentforge-bedrock[bedrock]`, but bedrock has no such extra (SDK `aioboto3`/`botocore` is a hard dep) → now bare.
3. **Eager-import-as-optional**: `agentforge-chat` imports `SqliteChatHistory` → `import aiosqlite` at package import, yet declared `aiosqlite` an optional `[sqlite]` extra (`import agentforge_chat` failed on a bare install). Now a **hard dependency**, matching sibling `agentforge-memory-sqlite`; README + manifest updated.

Also: the `mcp` `ModuleError` text (4 sites) now recommends `agentforge-mcp[mcp]` instead of bare `pip install mcp`.

## Regression guard
New `test_extras_chain.py` parses every sister `pyproject.toml` and asserts each meta extra chains **exactly** the leaf package's extras — catching both missing and phantom extras for current and future packages.

Part of the v0.2.4 MCP/chat/config cluster. Full pre-commit gate green; no CI step installs `[all]`, so the heavier reranker SDKs don't affect CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)