### PR TITLE
fix: normalise terse evaluator/guardrail config sugar (bug-019 P2)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,16 +1,16 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-015 (meta extra-chain packaging)
+feature: v0.2.4 MCP/chat/config cluster — bug-019 (config sugar normaliser)
 state: pr-raised
-branch: fix/bug-015-meta-extra-chain
+branch: fix/bug-019-entry-string-normalise
 started_at: 2026-06-02
 last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
 resume: null
 flags_for_user:
-  - "PR #62 OPEN (fix/bug-015-meta-extra-chain): bug-015 P2 — meta-package extras didn't chain sister vendor-SDK extras. Audited all 34 pkgs; fixed 12 missing chains + `[all]`, 1 phantom extra (bedrock), 1 eager-import-as-optional (agentforge-chat aiosqlite → hard dep). mcp ModuleError text updated. New generic test_extras_chain.py locks the invariant. 1 commit (9622d7e), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/62 — awaiting merge."
-  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014 MCP runtime wiring), #60 (bug-012 MCP `.`→`__`), #61 (bug-017 tool-name charset validator, 077795a). main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (after #62), suggested order: bug-019 (config string→{name} normaliser: evaluators + guardrail input/output/tool_gates — both EvaluatorEntry AND GuardrailEntry broken) → bug-018 (SqliteChatHistory upsert + ChatHistoryStore.create_session ABC) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport)."
+  - "PR #63 OPEN (fix/bug-019-entry-string-normalise): bug-019 P2 — terse evaluator/guardrail config sugar rejected. model_validator(mode=before) on EvaluatorEntry + GuardrailEntry normalises string + single-key-mapping + canonical forms (mapping sugar was ALSO broken). 1 commit (f12a2d4), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/63 — awaiting merge."
+  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014), #60 (bug-012), #61 (bug-017), #62 (bug-015 meta extra-chain, c166ecd). main at version 0.2.4."
+  - "REMAINING v0.2.4 cluster (after #63), suggested order: bug-018 (SqliteChatHistory.update_session_metadata upsert + ChatHistoryStore.create_session() ABC — both in one PR) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport, may slip to 0.2.5)."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -40,27 +40,25 @@ rejected as stdio-hijack guard). The cluster unblocker is in main.
 failed (env-gated `test_mcp_live.py` asserted the old `echo.echo`;
 local pre-commit doesn't run live tests) — fixed in commit `0bc8386`.
 
-**Merged — PR #61** (`fix/bug-017-tool-name-validator`, 077795a):
-tool-name charset validator at all 3 provider boundaries.
+**Merged — PR #62** (`fix/bug-015-meta-extra-chain`, c166ecd):
+meta-package extras now chain sister vendor-SDK extras (12 fixes + [all]
++ bedrock phantom + agentforge-chat aiosqlite hard-dep);
+`test_extras_chain.py` locks the invariant.
 
-**In flight — PR #62** (`fix/bug-015-meta-extra-chain`, off main):
-bug-015 P2 — meta-package extras didn't chain sister vendor-SDK extras
-(`pip install agentforge-py[mcp]` installed the wrapper but not the SDK).
-Audited all 34 pkgs: fixed 12 missing chains + `[all]`, 1 phantom extra
-(`bedrock` → bare), 1 eager-import-as-optional (`agentforge-chat`
-aiosqlite → hard dep, matching memory-sqlite). mcp `ModuleError` text →
-`agentforge-mcp[mcp]`. New `test_extras_chain.py` locks the invariant
-generically. 1 commit (`9622d7e`), full gate + Live CI green. Awaiting
-merge.
+**In flight — PR #63** (`fix/bug-019-entry-string-normalise`, off main):
+bug-019 P2 — terse evaluator/guardrail config sugar was rejected
+(`EvaluatorEntry`/`GuardrailEntry` are strict+forbid; nothing normalised
+the string or single-key-mapping forms). Shared `_normalise_named_entry`
++ `model_validator(mode="before")` on both entries handles all three
+shapes; covers `modules.evaluators` + guardrails `input`/`output`/
+`tool_gates`. The mapping sugar was broken too, not just the string
+form. 1 commit (`f12a2d4`), full gate + Live CI green. Awaiting merge.
 
 ## Pickup on resume
 
-1. **Merge PR #62** (bug-015) once reviewed/CI-green.
+1. **Merge PR #63** (bug-019) once reviewed/CI-green.
 2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
    branch off main, folding into v0.2.4), suggested order:
-   - **bug-019** — `mode="before"` string→{name} normaliser for
-     `modules.evaluators` + guardrail `input`/`output`/`tool_gates`
-     (both EvaluatorEntry AND GuardrailEntry are broken).
    - **bug-018** — `SqliteChatHistory.update_session_metadata` upsert
      (option 1, minimal) + `ChatHistoryStore.create_session()` ABC
      (option 2, contract fix) — both in one PR.

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2967,3 +2967,22 @@ pyproject and asserts each meta extra chains exactly the leaf's extras
 (catches missing + phantom for future packages too). Full gate + Live CI
 green (9622d7e). PR #62 open. Next: bug-019 → bug-018 → bug-013 → enh-001;
 bug-008 before tag.
+
+## 2026-06-03T03:30 — v0.2.4 cluster: bug-015 merged (#62), bug-019 opened (#63)
+PR #62 (bug-015 meta extra-chain) merged to main (c166ecd). Note: its
+first Live CI run failed on a transient `docker pull postgres:16` Docker
+Hub timeout (infra, not code) — `gh run rerun --failed` cleared it. The CI
+Live job depends on pulling postgres:16 at runtime; flaky on registry
+hiccups (harden later via digest pin / retry if it recurs).
+Started bug-019 on `fix/bug-019-entry-string-normalise`. Scope wider than
+the reported string-form symptom: the single-key-mapping sugar
+(`- geval: {rubric}`, in the schema's own example YAML) was equally broken
+under strict+forbid. Fix: shared `_normalise_named_entry` + a
+`model_validator(mode="before")` on BOTH EvaluatorEntry and GuardrailEntry
+(one validator per type covers evaluators + guardrails input/output/
+tool_gates; composes through Pydantic list validation under strict). All
+three shapes (string / single-key mapping / canonical) load. Flipped the
+old feat-012 "string shorthand NYI" test to a positive load_config test;
+updated feat-012 Implementation status. Full gate + Live CI green
+(f12a2d4). PR #63 open. Next: bug-018 → bug-013 → enh-001; bug-008 before
+tag, then cut v0.2.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,18 @@ activity and the next chat turn's prompt lost prior tool context.
 
 ### Fixed
 
+- **bug-019 — documented terse config syntax for evaluators/guardrails
+  was rejected.** `EvaluatorEntry` and `GuardrailEntry` are
+  `strict=True, extra="forbid"`, and their docstrings + the shipped
+  example YAML promised a string form (`- faithfulness`) and a
+  single-key-mapping form (`- geval: {rubric: ...}`) — but nothing
+  normalised either, so both raised `ValidationError`. A
+  `model_validator(mode="before")` on each entry now normalises all
+  three shapes (string, single-key mapping, canonical
+  `{name, config}`) before strict validation, so the terse syntax in
+  `modules.evaluators` and guardrails' `input` / `output` /
+  `tool_gates` works as documented. (The mapping-sugar form was broken
+  too, not just the string form the report first showed.)
 - **bug-015 — `agentforge-py` extras didn't pull their vendor SDKs.**
   Sister packages keep their vendor SDK behind an optional `[<sdk>]`
   extra (lazy-import pattern), but most meta extras requested the bare

--- a/docs/bugs/bug-019-guardrail-entry-string-form-not-normalised.md
+++ b/docs/bugs/bug-019-guardrail-entry-string-form-not-normalised.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P2
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
@@ -126,3 +126,27 @@ models reject.
   the terse form appears in shipped example YAML across three configs.
   Implement the `mode="before"` normaliser once and mirror it to
   `evaluators`, `input`, `output`, `tool_gates`.
+
+## Resolution (v0.2.4)
+
+Implemented as a single shared helper `_normalise_named_entry` plus a
+`@model_validator(mode="before")` on **both** `EvaluatorEntry` and
+`GuardrailEntry` (`agentforge_core/config/schema.py`). Putting the
+normaliser on the entry models rather than on each parent list means one
+validator per type covers every usage — `modules.evaluators` and
+guardrails' `input` / `output` / `tool_gates` — with no per-field
+duplication, and it composes through Pydantic's list validation even
+under `strict=True`.
+
+Scope was wider than the reported string-form symptom: the **single-key
+mapping sugar** (`- geval: {rubric: ...}`, shipped in the schema's own
+example YAML) was equally broken under `extra="forbid"`. The fix
+normalises all three documented shapes — string, single-key mapping, and
+canonical `{name, config}` — so copy-pasting any of them validates.
+Docstrings for both entries were corrected (they claimed "the loader
+normalises"; the loader does not — it is now the entry's before-validator).
+`ObservabilityEntry` shares the shape but its docs/example only show the
+canonical form, so it is intentionally left unchanged (no doc-vs-code
+contradiction to fix). Tests cover all three forms across evaluators +
+all three guardrail gates, plus empty-name rejection and that canonical
+dicts still forbid extra keys.

--- a/docs/features/feat-012-configuration-system.md
+++ b/docs/features/feat-012-configuration-system.md
@@ -253,11 +253,12 @@ The two implementations are tested against the same fixture set.
   `Agent(budget_usd=, max_iterations=)` kwargs (locked under
   feat-001) are unchanged.
 - **Evaluator string-shorthand** `- faithfulness` mentioned in
-  spec §4.1 is not implemented. The YAML must spell out
-  `- name: faithfulness`. Normalising the bare-string form to
-  `EvaluatorEntry(name=..., config={})` is a small loader follow-
-  up; the runtime cost is zero (constructed graders work
-  identically).
+  spec §4.1 was not implemented at feat-012 ship; the YAML had to
+  spell out `- name: faithfulness`. **Resolved in v0.2.4 (bug-019):**
+  a `model_validator(mode="before")` on `EvaluatorEntry` and
+  `GuardrailEntry` normalises the bare-string form (and the
+  single-key-mapping sugar) to `{name, config}` before strict
+  validation, so all three documented shapes load.
 - **`Resolver` lateness**: `agentforge_core.config.module_schemas`
   imports `Resolver` lazily inside `validate_module_configs` to
   avoid a load-order cycle with the values / contracts modules
@@ -270,7 +271,6 @@ The two implementations are tested against the same fixture set.
 
 ### What's *not* yet implemented
 
-- **Evaluator string-shorthand** normalisation (see above).
 - **Auto-wiring** of `modules.memory`, `modules.evaluators`,
   `modules.observability` etc. into `Agent.__init__`. The schema +
   resolver are ready; `Agent.__init__` still expects constructed

--- a/packages/agentforge-core/src/agentforge_core/config/schema.py
+++ b/packages/agentforge-core/src/agentforge_core/config/schema.py
@@ -17,7 +17,35 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _normalise_named_entry(value: Any) -> Any:
+    """Normalise the terse YAML sugar for `name + config` entries into the
+    canonical mapping before strict validation (bug-019).
+
+    Three shapes are accepted; the first two are sugar:
+
+    - String form ``faithfulness`` → ``{"name": "faithfulness"}``
+    - Single-key mapping ``{geval: {rubric: "..."}}`` →
+      ``{"name": "geval", "config": {"rubric": "..."}}``
+    - Canonical mapping ``{name: x, config: {...}}`` → returned unchanged.
+
+    Anything else is returned untouched so the model's own validation
+    raises a clear error. Used by `EvaluatorEntry` and `GuardrailEntry`,
+    so every list that holds them (`modules.evaluators` and guardrails'
+    `input` / `output` / `tool_gates`) accepts all three forms.
+    """
+    if isinstance(value, str):
+        return {"name": value}
+    if isinstance(value, dict) and "name" not in value and len(value) == 1:
+        ((key, cfg),) = value.items()
+        if isinstance(key, str):
+            entry: dict[str, Any] = {"name": key}
+            if cfg is not None:
+                entry["config"] = cfg
+            return entry
+    return value
 
 
 class BudgetConfig(BaseModel):
@@ -178,19 +206,25 @@ class RetrievalConfig(BaseModel):
 
 
 class EvaluatorEntry(BaseModel):
-    """An entry in `modules.evaluators:`. Two YAML shapes are valid:
+    """An entry in `modules.evaluators:`. Three YAML shapes are valid:
 
     - String form: `- faithfulness` (just the name).
-    - Mapping form: `- faithfulness: {cost_cap_usd: 0.05, ...}`.
+    - Single-key mapping: `- faithfulness: {cost_cap_usd: 0.05, ...}`.
+    - Canonical mapping: `- {name: faithfulness, config: {...}}`.
 
-    We model the mapping form here; the loader normalises strings to
-    `EvaluatorEntry(name=..., config={})` before validation.
+    The first two are sugar; a `mode="before"` validator normalises them
+    to `EvaluatorEntry(name=..., config={...})` before strict validation.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
     name: str = Field(min_length=1)
     config: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_sugar(cls, value: Any) -> Any:
+        return _normalise_named_entry(value)
 
 
 class ObservabilityEntry(BaseModel):
@@ -226,19 +260,25 @@ class GuardrailPolicy(BaseModel):
 class GuardrailEntry(BaseModel):
     """One entry inside `modules.guardrails.{input,output,tool_gates}`.
 
-    Two YAML shapes are valid (mirrors `EvaluatorEntry`):
+    Three YAML shapes are valid (mirrors `EvaluatorEntry`):
 
     - String form: `- prompt_injection_basic` (just the name).
-    - Mapping form: `- presidio: {entities: ["EMAIL_ADDRESS"]}`.
+    - Single-key mapping: `- presidio: {entities: ["EMAIL_ADDRESS"]}`.
+    - Canonical mapping: `- {name: presidio, config: {...}}`.
 
-    Both normalise to `GuardrailEntry(name=..., config={})` before
-    validation.
+    The first two are sugar; a `mode="before"` validator normalises them
+    to `GuardrailEntry(name=..., config={...})` before strict validation.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
     name: str = Field(min_length=1)
     config: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_sugar(cls, value: Any) -> Any:
+        return _normalise_named_entry(value)
 
 
 class ChatHistoryDriverConfig(BaseModel):

--- a/packages/agentforge-core/tests/unit/test_config_feat012.py
+++ b/packages/agentforge-core/tests/unit/test_config_feat012.py
@@ -14,7 +14,6 @@ from agentforge_core.config import (
     parse_overrides,
 )
 from agentforge_core.production.exceptions import ModuleError
-from pydantic import ValidationError
 
 # --- widened schema ----------------------------------------------
 
@@ -269,16 +268,14 @@ def test_explicit_env_arg_beats_env_var(tmp_path: Path, monkeypatch: pytest.Monk
     assert cfg.agent.budget.usd == pytest.approx(50.0)
 
 
-# --- evaluator string-shorthand (NYI in this chunk) ------------
+# --- evaluator string-shorthand (normalised since bug-019) -----
 
 
-def test_evaluator_string_shorthand_not_yet_supported(tmp_path: Path) -> None:
-    """The spec §4.1 mentions `evaluators: - faithfulness` (bare
-    string). This loader doesn't yet normalise that — the YAML must
-    spell out `- name: faithfulness`. Tracked under feat-012's
-    Implementation status.
-    """
+def test_evaluator_string_shorthand_loads(tmp_path: Path) -> None:
+    """Spec §4.1's `evaluators: - faithfulness` (bare string) now loads
+    end-to-end: the entry's `mode="before"` validator normalises the
+    string to `{name: faithfulness, config: {}}` (bug-019)."""
     yaml_path = tmp_path / "agentforge.yaml"
     yaml_path.write_text("modules:\n  evaluators:\n    - faithfulness\n")
-    with pytest.raises(ValidationError):
-        load_config(yaml_path)
+    cfg = load_config(yaml_path)
+    assert [(e.name, e.config) for e in cfg.modules.evaluators] == [("faithfulness", {})]

--- a/packages/agentforge-core/tests/unit/test_config_module_schemas.py
+++ b/packages/agentforge-core/tests/unit/test_config_module_schemas.py
@@ -172,6 +172,61 @@ def test_evaluator_entry_invalid_config_raises():
         validate_module_configs(cfg)
 
 
+# --- bug-019: terse string / single-key-mapping sugar normalises ----
+
+
+def test_evaluators_accept_all_three_sugar_forms() -> None:
+    """String, single-key-mapping, and canonical forms all parse from raw
+    YAML-shaped dicts (bug-019)."""
+    modules = ModulesConfig.model_validate(
+        {
+            "evaluators": [
+                "faithfulness",  # string sugar
+                {"geval": {"rubric": "be nice"}},  # single-key mapping sugar
+                {"name": "correctness", "config": {"ground_truth_field": "ref"}},  # canonical
+            ]
+        }
+    )
+    assert [(e.name, e.config) for e in modules.evaluators] == [
+        ("faithfulness", {}),
+        ("geval", {"rubric": "be nice"}),
+        ("correctness", {"ground_truth_field": "ref"}),
+    ]
+
+
+@pytest.mark.parametrize("gate", ["input", "output", "tool_gates"])
+def test_guardrail_gates_accept_all_three_sugar_forms(gate: str) -> None:
+    modules = ModulesConfig.model_validate(
+        {
+            "guardrails": {
+                gate: [
+                    "prompt_injection_basic",  # string sugar
+                    {"presidio": {"entities": ["EMAIL_ADDRESS"]}},  # single-key mapping sugar
+                    {"name": "capability_check", "config": {}},  # canonical
+                ]
+            }
+        }
+    )
+    entries = getattr(modules.guardrails, gate)
+    assert [(e.name, e.config) for e in entries] == [
+        ("prompt_injection_basic", {}),
+        ("presidio", {"entities": ["EMAIL_ADDRESS"]}),
+        ("capability_check", {}),
+    ]
+
+
+def test_string_sugar_rejects_empty_name() -> None:
+    """An empty string still fails (name has min_length=1)."""
+    with pytest.raises(ValueError, match="evaluators"):
+        ModulesConfig.model_validate({"evaluators": [""]})
+
+
+def test_canonical_form_still_forbids_extra_keys() -> None:
+    """Normalisation must not loosen strict/extra=forbid for canonical dicts."""
+    with pytest.raises(ValueError, match="evaluators"):
+        ModulesConfig.model_validate({"evaluators": [{"name": "x", "config": {}, "bogus": 1}]})
+
+
 # --- non-class schema attribute (defensive) --------------------
 
 


### PR DESCRIPTION
## bug-019 — documented terse config syntax was rejected

`EvaluatorEntry` and `GuardrailEntry` are `strict=True, extra="forbid"`, and their docstrings + the shipped example YAML promised two terse shapes — a string (`- faithfulness`) and a single-key mapping (`- geval: {rubric: ...}`) — but nothing normalised either, so both raised `ValidationError`. A doc-vs-code contradiction a consumer can't fix.

The reported symptom showed only the string form; the audit found the **single-key-mapping sugar is equally broken** (it appears in the schema's own example YAML, `schema.py`).

## Fix

A shared `_normalise_named_entry` helper + a `model_validator(mode="before")` on **both** entry models. Putting the normaliser on the entry (not on each parent list) means one validator per type covers every usage — `modules.evaluators` and guardrails' `input`/`output`/`tool_gates` — and it composes through Pydantic's list validation even under `strict=True`. All three shapes now load:

```yaml
modules:
  evaluators:
    - faithfulness                       # string
    - geval: {rubric: "be concise"}      # single-key mapping
    - {name: correctness, config: {...}} # canonical
  guardrails:
    input:  [prompt_injection_basic]
    output: [pii_redact_basic]
    tool_gates: [capability_check]
```

## Tests
All three forms across evaluators + each guardrail gate; empty-name still rejected; canonical dicts still forbid extra keys. Flipped the old feat-012 "string shorthand NYI" test into a positive `load_config` end-to-end test.

Docs: corrected both entry docstrings (they claimed "the loader normalises" — it doesn't), CHANGELOG, bug-019 resolution, feat-012 Implementation status. Part of the v0.2.4 cluster. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)