### PR TITLE
fix: create chat session before first turn (bug-018 P0)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,16 +1,16 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-019 (config sugar normaliser)
+feature: v0.2.4 MCP/chat/config cluster — bug-018 (chat session-create contract)
 state: pr-raised
-branch: fix/bug-019-entry-string-normalise
+branch: fix/bug-018-chat-session-create
 started_at: 2026-06-02
 last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
 resume: null
 flags_for_user:
-  - "PR #63 OPEN (fix/bug-019-entry-string-normalise): bug-019 P2 — terse evaluator/guardrail config sugar rejected. model_validator(mode=before) on EvaluatorEntry + GuardrailEntry normalises string + single-key-mapping + canonical forms (mapping sugar was ALSO broken). 1 commit (f12a2d4), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/63 — awaiting merge."
-  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014), #60 (bug-012), #61 (bug-017), #62 (bug-015 meta extra-chain, c166ecd). main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (after #63), suggested order: bug-018 (SqliteChatHistory.update_session_metadata upsert + ChatHistoryStore.create_session() ABC — both in one PR) → bug-013 (from_stdio/from_http auto register_tools) → enh-001 (HTTP server transport, may slip to 0.2.5)."
+  - "PR #64 OPEN (fix/bug-018-chat-session-create): bug-018 P0 — POST /sessions 500'd on fresh SQLite/Postgres/Redis. update_session_metadata now upserts in all 3 SQL/KV drivers; in-memory lists metadata-only sessions; ChatHistoryStore.create_session() added as CONCRETE ABC method (locked-ABC safe); ChatServer calls it. Contract asserted in shared conformance harness (all drivers) + sqlite e2e. 1 commit (58881e0), full gate + Live CI green. https://github.com/Scaffoldic/agentforge-py/pull/64 — awaiting merge."
+  - "MERGED to main: #57 (docs triage), #58 (bug-009/010), #59 (bug-020+bug-014), #60 (bug-012), #61 (bug-017), #62 (bug-015), #63 (bug-019 config sugar, b153199). main at version 0.2.4."
+  - "REMAINING v0.2.4 cluster (after #64): bug-013 (MCPServerClient.from_stdio/from_http/from_sse should auto-call register_tools so discover_tools/bridge work without a manual register step) → enh-001 (HTTP MCP server transport, may slip to 0.2.5). Then bug-008 (~5 lines: version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py) before tagging, then cut v0.2.4."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -40,28 +40,27 @@ rejected as stdio-hijack guard). The cluster unblocker is in main.
 failed (env-gated `test_mcp_live.py` asserted the old `echo.echo`;
 local pre-commit doesn't run live tests) — fixed in commit `0bc8386`.
 
-**Merged — PR #62** (`fix/bug-015-meta-extra-chain`, c166ecd):
-meta-package extras now chain sister vendor-SDK extras (12 fixes + [all]
-+ bedrock phantom + agentforge-chat aiosqlite hard-dep);
-`test_extras_chain.py` locks the invariant.
+**Merged — PR #63** (`fix/bug-019-entry-string-normalise`, b153199):
+terse evaluator/guardrail config sugar normalised (string + single-key
+mapping + canonical) via model_validator(mode=before) on both entries.
 
-**In flight — PR #63** (`fix/bug-019-entry-string-normalise`, off main):
-bug-019 P2 — terse evaluator/guardrail config sugar was rejected
-(`EvaluatorEntry`/`GuardrailEntry` are strict+forbid; nothing normalised
-the string or single-key-mapping forms). Shared `_normalise_named_entry`
-+ `model_validator(mode="before")` on both entries handles all three
-shapes; covers `modules.evaluators` + guardrails `input`/`output`/
-`tool_gates`. The mapping sugar was broken too, not just the string
-form. 1 commit (`f12a2d4`), full gate + Live CI green. Awaiting merge.
+**In flight — PR #64** (`fix/bug-018-chat-session-create`, off main):
+bug-018 P0 — POST /sessions 500'd on fresh SQLite/Postgres/Redis (drivers
+inserted the session row only lazily on first append; ChatServer set
+metadata before that). Fix: update_session_metadata upserts in all 3
+SQL/KV drivers (create-if-missing, leaving existing last_active_at
+untouched); in-memory now lists metadata-only sessions;
+`ChatHistoryStore.create_session()` added as CONCRETE ABC method
+(additive to locked ABC per ADR-0007); ChatServer calls it. Contract
+asserted once in the shared conformance harness (all 4 drivers) + a real
+sqlite `POST /sessions` e2e. 1 commit (`58881e0`), full gate + Live CI
+green. Awaiting merge.
 
 ## Pickup on resume
 
-1. **Merge PR #63** (bug-019) once reviewed/CI-green.
+1. **Merge PR #64** (bug-018) once reviewed/CI-green.
 2. **Work the rest of the cluster** (each its own `fix/bug-NNN-*`
-   branch off main, folding into v0.2.4), suggested order:
-   - **bug-018** — `SqliteChatHistory.update_session_metadata` upsert
-     (option 1, minimal) + `ChatHistoryStore.create_session()` ABC
-     (option 2, contract fix) — both in one PR.
+   branch off main, folding into v0.2.4):
    - **bug-013** — `from_stdio`/`from_http` auto-call `register_tools()`.
    - **enh-001** — HTTP MCP server transport (may slip to 0.2.5).
 3. **bug-008** (~5 lines) — fold in somewhere before tagging.

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -2986,3 +2986,23 @@ old feat-012 "string shorthand NYI" test to a positive load_config test;
 updated feat-012 Implementation status. Full gate + Live CI green
 (f12a2d4). PR #63 open. Next: bug-018 → bug-013 → enh-001; bug-008 before
 tag, then cut v0.2.4.
+
+## 2026-06-03T04:30 — v0.2.4 cluster: bug-019 merged (#63), bug-018 opened (#64)
+PR #63 (bug-019 config sugar) merged to main (b153199). Started bug-018 on
+`fix/bug-018-chat-session-create` — P0: POST /sessions 500'd on fresh
+SQLite (ChatServer sets metadata before turn 1; driver inserted the row
+only lazily on append). Audit widened scope: Postgres AND Redis raise
+identically; in-memory never raised but hid metadata-only sessions from
+list_sessions. Fix landed both bug-doc options: (1) update_session_metadata
+upserts in sqlite/postgres/redis (INSERT...ON CONFLICT DO NOTHING /
+hset-if-absent; existing last_active_at untouched), in-memory lists
+metadata-only sessions; (2) ChatHistoryStore.create_session() added as a
+CONCRETE (non-abstract) ABC method — additive to the locked ABC per
+ADR-0007, so third-party drivers inherit it — default delegates to the
+upserting update_session_metadata; ChatServer calls it. Postgres fake
+runner now distinguishes DO NOTHING vs DO UPDATE. Contract asserted once in
+the shared run_chat_history_conformance harness (covers all 4 drivers) +
+real sqlite POST /sessions e2e via httpx ASGITransport. Fixed reference
+_DictHistory + harness to list metadata-only sessions; flipped obsolete
+postgres raise test. Full gate + Live CI green (58881e0). PR #64 open.
+Next: bug-013 → enh-001; bug-008 before tag, then cut v0.2.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,25 @@ activity and the next chat turn's prompt lost prior tool context.
   and Anthropic drivers call it at request-build time so an illegal
   name fails locally with an actionable message instead of as a
   remote provider error (bug-017).
+- **`ChatHistoryStore.create_session(session_id, *, owner=None,
+  metadata=None)`** — a concrete (non-abstract, so additive to the
+  locked ABC) method to register a session before its first turn. The
+  default upserts via `update_session_metadata`; drivers may override
+  (bug-018).
 
 ### Fixed
 
+- **bug-018 — `POST /sessions` 500'd on a fresh SQLite/Postgres/Redis
+  store.** `ChatServer._create_session` records the session owner before
+  any turn is appended, but the SQL/Redis history drivers only inserted
+  the session row lazily on first `append`, so
+  `update_session_metadata` raised `Cannot update metadata for unknown
+  session`. All three drivers now upsert the row in
+  `update_session_metadata` (create-if-missing, leaving an existing
+  row's `last_active_at` untouched), the in-memory driver lists
+  metadata-only sessions, and `ChatServer` calls the new
+  `create_session`. The fix is verified for every driver through the
+  shared chat-history conformance harness.
 - **bug-019 — documented terse config syntax for evaluators/guardrails
   was rejected.** `EvaluatorEntry` and `GuardrailEntry` are
   `strict=True, extra="forbid"`, and their docstrings + the shipped

--- a/docs/bugs/bug-018-sqlitechathistory-update-metadata-fails-on-lazy-row.md
+++ b/docs/bugs/bug-018-sqlitechathistory-update-metadata-fails-on-lazy-row.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P0
 found-in: v0.2.3
 found-via: live integration of a Bedrock-backed MCP agent (Khemchand Joshi, 2026-05-27)
@@ -116,3 +116,29 @@ lazy (only called from `append()`, `sqlite.py:112`);
 store raises `ModuleError` on first `update_session_metadata`. The
 recommended landing is **option 1 now** (upsert; minimal, unblocks) plus
 **option 2 as the contract fix** in the same PR.
+
+## Resolution (v0.2.4)
+
+Both options shipped together, and the audit found the lazy-row bug was
+**broader than the SQLite driver**: Postgres and Redis raise identically,
+and the in-memory driver — while it never raised — hid metadata-only
+sessions from `list_sessions` (it iterated only sessions with turns). So
+all four shipped drivers needed work.
+
+- **Option 1 (upsert)** — `update_session_metadata` now creates the row
+  if missing in `agentforge-chat` (SQLite), `agentforge-chat-history-postgres`,
+  and `agentforge-chat-history-redis` (`INSERT ... ON CONFLICT DO NOTHING`
+  / `hset`-if-absent, leaving an existing row's `last_active_at`
+  untouched). The in-memory driver now registers metadata-only sessions
+  and includes them in `list_sessions`.
+- **Option 2 (contract)** — `ChatHistoryStore.create_session()` added to
+  the ABC as a **concrete** method (not `@abstractmethod`), so it is
+  additive to the locked contract (ADR-0007) — existing and third-party
+  drivers inherit it unchanged. The default delegates to the now-upserting
+  `update_session_metadata`. `ChatServer._create_session` calls it
+  (`create_session(session_id, owner=...)`) instead of a bare metadata
+  write.
+- **Coverage** — the create-before-first-turn contract is asserted once
+  in the shared `run_chat_history_conformance` harness, so it runs against
+  every driver; plus an end-to-end `POST /sessions` test on a real
+  SQLite-backed `ChatServer` (the exact reported scenario).

--- a/docs/features/feat-020-chat-agents.md
+++ b/docs/features/feat-020-chat-agents.md
@@ -227,6 +227,10 @@ class ChatHistoryStore(ABC):
     ) -> list[SessionInfo]: ...
     @abstractmethod
     async def update_session_metadata(self, session_id: str, metadata: dict) -> None: ...
+    # Concrete default (bug-018): register a session before its first turn.
+    async def create_session(
+        self, session_id: str, *, owner: str | None = None, metadata: dict | None = None
+    ) -> None: ...
     @abstractmethod
     async def expire_before(self, cutoff: datetime) -> int: ...    # TTL sweep
     @abstractmethod
@@ -698,6 +702,24 @@ items from v0.1.
   models (one-line additions in v0.3 when first user lands).
 - Migration framework for the Postgres schema.
 - Multi-cluster Redlock for RedisSessionLock.
+
+### v0.2.4 fix — session-creation contract (bug-018)
+
+`POST /sessions` 500'd on a fresh process with the SQLite (and
+Postgres / Redis) history drivers: `ChatServer._create_session`
+records the session owner before the first turn, but those drivers
+only inserted the session row lazily on first `append`, so
+`update_session_metadata` raised `Cannot update metadata for unknown
+session`. Fixed two ways, both shipped together:
+
+- `update_session_metadata` now **upserts** the session row in every
+  SQL/KV driver (create-if-missing, leaving an existing row's
+  `last_active_at` untouched); the in-memory driver now lists
+  metadata-only sessions.
+- `ChatHistoryStore.create_session()` was added as a **concrete**
+  (non-abstract) ABC method — additive to the locked contract per
+  ADR-0007 — and `ChatServer` now calls it. The contract is asserted
+  for every driver via the shared chat-history conformance harness.
 
 ### v0.3 polish — sentence-window streaming output guardrails
 

--- a/packages/agentforge-chat-history-postgres/src/agentforge_chat_history_postgres/_inmem_runner.py
+++ b/packages/agentforge-chat-history-postgres/src/agentforge_chat_history_postgres/_inmem_runner.py
@@ -79,7 +79,22 @@ class PostgresFakeRunner:
             self._insert_turn(params)
             return
         if sql_n.startswith("insert into chat_sessions"):
-            self._upsert_session(params[0], params[1])
+            # DO NOTHING (bug-018 create-if-missing) must not bump
+            # last_active_at on an existing row; DO UPDATE (append path)
+            # does. Mirror the real ON CONFLICT clause.
+            if "do nothing" in sql_n:
+                self._sessions.setdefault(
+                    params[0],
+                    {
+                        "id": params[0],
+                        "owner": None,
+                        "created_at": params[1],
+                        "last_active_at": params[1],
+                        "metadata": {},
+                    },
+                )
+            else:
+                self._upsert_session(params[0], params[1])
             return
         if sql_n.startswith("update chat_sessions set metadata"):
             metadata_json, owner, session_id = params

--- a/packages/agentforge-chat-history-postgres/src/agentforge_chat_history_postgres/history.py
+++ b/packages/agentforge-chat-history-postgres/src/agentforge_chat_history_postgres/history.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from agentforge_core.contracts.chat import ChatHistoryStore
@@ -199,11 +199,22 @@ class PostgresChatHistory(ChatHistoryStore):
         return [await self._row_to_info(row) for row in rows]
 
     async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        # Create the session row if it doesn't exist yet (bug-018):
+        # ChatServer records owner/metadata before the first turn. DO
+        # NOTHING leaves an existing row (and last_active_at) untouched.
+        await self._r.execute(
+            """INSERT INTO chat_sessions
+                 (id, owner, created_at, last_active_at, metadata)
+               VALUES ($1, NULL, $2, $2, '{}'::jsonb)
+               ON CONFLICT (id) DO NOTHING""",
+            session_id,
+            datetime.now(UTC),
+        )
         row = await self._r.fetchrow(
             "SELECT owner, metadata FROM chat_sessions WHERE id = $1",
             session_id,
         )
-        if row is None:
+        if row is None:  # pragma: no cover — the INSERT above guarantees a row
             raise ModuleError(f"Cannot update metadata for unknown session {session_id!r}")
         existing: dict[str, Any] = dict(_coerce_jsonb(row["metadata"]))
         existing.update(dict(metadata))

--- a/packages/agentforge-chat-history-postgres/tests/unit/test_postgres_history_branches.py
+++ b/packages/agentforge-chat-history-postgres/tests/unit/test_postgres_history_branches.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from agentforge_chat_history_postgres import PostgresChatHistory
 from agentforge_chat_history_postgres._inmem_runner import PostgresFakeRunner
-from agentforge_core.production.exceptions import ModuleError
 from agentforge_core.values.chat import ChatTurn
 from agentforge_core.values.messages import ToolCall
 
@@ -63,11 +62,14 @@ async def test_list_sessions_with_before_filter() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_metadata_unknown_session_raises() -> None:
+async def test_update_metadata_creates_unknown_session() -> None:
+    """bug-018: metadata on a not-yet-existing session upserts the row
+    rather than raising, so ChatServer can record owner before turn 1."""
     runner = PostgresFakeRunner()
     store = await PostgresChatHistory.from_dsn("p", runner=runner)
-    with pytest.raises(ModuleError, match="unknown session"):
-        await store.update_session_metadata("nope", {"k": "v"})
+    await store.update_session_metadata("nope", {"k": "v", "owner": "u1"})
+    sessions = await store.list_sessions(owner="u1")
+    assert [s.id for s in sessions] == ["nope"]
 
 
 @pytest.mark.asyncio

--- a/packages/agentforge-chat-history-redis/src/agentforge_chat_history_redis/history.py
+++ b/packages/agentforge-chat-history-redis/src/agentforge_chat_history_redis/history.py
@@ -173,7 +173,21 @@ class RedisChatHistory(ChatHistoryStore):
     async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
         raw = await self._r.hgetall(_SESSION_KEY.format(session_id))
         if not raw:
-            raise ModuleError(f"Cannot update metadata for unknown session {session_id!r}")
+            # Create the session if it doesn't exist yet (bug-018):
+            # ChatServer records owner/metadata before the first turn.
+            now = datetime.now(UTC).isoformat()
+            await self._r.hset(
+                _SESSION_KEY.format(session_id),
+                {
+                    "id": session_id,
+                    "owner": "",
+                    "created_at": now,
+                    "last_active_at": now,
+                    "metadata": "{}",
+                },
+            )
+            await self._r.sadd(_SESSIONS_INDEX_KEY, session_id)
+            raw = {"metadata": "{}"}
         existing: dict[str, Any] = json.loads(raw.get("metadata", "{}"))
         existing.update(dict(metadata))
         update: dict[str, str] = {"metadata": json.dumps(existing)}

--- a/packages/agentforge-chat-http/src/agentforge_chat_http/server.py
+++ b/packages/agentforge-chat-http/src/agentforge_chat_http/server.py
@@ -281,9 +281,10 @@ class ChatServer:
         async with self._sessions_lock:
             self._sessions[session.session_id] = session
             self._session_owners[session.session_id] = principal.id
-        # Persist an initial owner record on the store so list_sessions
-        # filtering works before the first turn.
-        await self._history.update_session_metadata(session.session_id, {"owner": principal.id})
+        # Create the session row up front so list_sessions filtering works
+        # before the first turn (bug-018). create_session upserts via the
+        # store, so this is safe on a fresh process / SQLite driver.
+        await self._history.create_session(session.session_id, owner=principal.id)
         return session
 
     async def _get_session(self, session_id: str, principal: Principal) -> ChatSession:

--- a/packages/agentforge-chat-http/tests/unit/test_chat_server.py
+++ b/packages/agentforge-chat-http/tests/unit/test_chat_server.py
@@ -89,6 +89,35 @@ def test_create_session_returns_id(client: TestClient) -> None:
     assert "id" in r.json()
 
 
+async def test_create_session_works_with_sqlite_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bug-018: POST /sessions must not 500 on a fresh SQLite-backed server.
+    `_create_session` records the owner before the first turn; the SQLite
+    driver used to raise because the row didn't exist yet."""
+    import httpx  # noqa: PLC0415
+    from agentforge_chat import SqliteChatHistory  # noqa: PLC0415
+
+    monkeypatch.setenv("API_TOKENS", "good-token")
+    store = await SqliteChatHistory.from_path(":memory:")
+    try:
+        server = ChatServer(
+            agent_factory=_agent_factory,
+            history_store=store,
+            auth=EnvBearerAuth("API_TOKENS"),
+            host="127.0.0.1",
+            port=8080,
+        )
+        transport = httpx.ASGITransport(app=server.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.post("/sessions", json={}, headers=_auth())
+        assert r.status_code == 200
+        sid = r.json()["id"]
+        # The session is persisted and listable before any turn.
+        listed = await store.list_sessions()
+        assert sid in {s.id for s in listed}
+    finally:
+        await store.close()
+
+
 def test_missing_bearer_returns_401(client: TestClient) -> None:
     r = client.post("/sessions", json={})
     assert r.status_code == 401

--- a/packages/agentforge-chat/src/agentforge_chat/history.py
+++ b/packages/agentforge-chat/src/agentforge_chat/history.py
@@ -77,7 +77,10 @@ class InMemoryChatHistory(ChatHistoryStore):
         before: datetime | None = None,
     ) -> list[SessionInfo]:
         async with self._lock:
-            out = [self._build_info(sid) for sid in self._turns]
+            # Include sessions that exist only via metadata (created before
+            # their first turn — bug-018), not just sessions with turns.
+            sids = set(self._turns) | set(self._meta)
+            out = [self._build_info(sid) for sid in sids]
         if owner is not None:
             out = [s for s in out if s.owner == owner]
         if before is not None:
@@ -92,6 +95,11 @@ class InMemoryChatHistory(ChatHistoryStore):
                 bag[k] = v
             if "owner" in metadata:
                 self._owners[session_id] = metadata["owner"]
+            # Register timestamps so a metadata-only session (created before
+            # its first turn — bug-018) carries sane created/last_active.
+            now = datetime.now(UTC)
+            self._created_at.setdefault(session_id, now)
+            self._last_active.setdefault(session_id, now)
 
     async def expire_before(self, cutoff: datetime) -> int:
         async with self._lock:

--- a/packages/agentforge-chat/src/agentforge_chat/sqlite.py
+++ b/packages/agentforge-chat/src/agentforge_chat/sqlite.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -200,12 +200,24 @@ class SqliteChatHistory(ChatHistoryStore):
         return [await self._row_to_info(row) for row in rows]
 
     async def update_session_metadata(self, session_id: str, metadata: Mapping[str, Any]) -> None:
+        # Create the session row if it doesn't exist yet (bug-018):
+        # ChatServer records owner/metadata before the first turn is
+        # appended. DO NOTHING leaves an existing row (and its
+        # last_active_at) untouched.
+        now_iso = datetime.now(UTC).isoformat()
+        await self._db.execute(
+            """INSERT INTO chat_sessions
+               (id, owner, created_at, last_active_at, metadata)
+               VALUES (?, NULL, ?, ?, ?)
+               ON CONFLICT(id) DO NOTHING""",
+            (session_id, now_iso, now_iso, "{}"),
+        )
         async with self._db.execute(
             "SELECT metadata, owner FROM chat_sessions WHERE id = ?",
             (session_id,),
         ) as cur:
             row = await cur.fetchone()
-        if row is None:
+        if row is None:  # pragma: no cover — the INSERT above guarantees a row
             raise ModuleError(f"Cannot update metadata for unknown session {session_id!r}")
         existing = json.loads(row["metadata"])
         existing.update(dict(metadata))

--- a/packages/agentforge-core/src/agentforge_core/contracts/chat.py
+++ b/packages/agentforge-core/src/agentforge_core/contracts/chat.py
@@ -71,8 +71,31 @@ class ChatHistoryStore(ABC):
         """Merge ``metadata`` into the session's metadata dict.
 
         Implementations may overwrite top-level keys; nested merging
-        is the caller's responsibility.
+        is the caller's responsibility. The session need **not** already
+        exist: if it doesn't, the driver creates it (upsert), so callers
+        can record metadata before the first turn is appended (bug-018).
         """
+
+    async def create_session(
+        self,
+        session_id: str,
+        *,
+        owner: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Ensure a session row exists before any turn is appended.
+
+        Concrete (non-abstract) so it is additive to this locked ABC
+        (ADR-0007): existing and third-party drivers inherit it without
+        change. The default records the initial ``owner`` / ``metadata``
+        via :meth:`update_session_metadata`, which every shipped driver
+        upserts. Idempotent — calling it for an existing session merges
+        the given metadata. Drivers may override with a direct insert.
+        """
+        merged: dict[str, Any] = dict(metadata or {})
+        if owner is not None:
+            merged["owner"] = owner
+        await self.update_session_metadata(session_id, merged)
 
     @abstractmethod
     async def expire_before(self, cutoff: datetime) -> int:

--- a/packages/agentforge-core/src/agentforge_core/testing/conformance.py
+++ b/packages/agentforge-core/src/agentforge_core/testing/conformance.py
@@ -815,6 +815,29 @@ async def run_task_conformance(
 # ----------------------------------------------------------------------
 
 
+async def _assert_create_before_first_turn(store: ChatHistoryStore) -> None:
+    """A session must be creatable / metadata-settable before its first
+    turn is appended (bug-018), and listable as soon as it is."""
+    from uuid import uuid4  # noqa: PLC0415
+
+    fresh = f"conf-{uuid4().hex[:8]}"
+    await store.create_session(fresh, owner="carol")
+    listed = await store.list_sessions()
+    assert fresh in {s.id for s in listed}, (
+        "create_session() must make a session listable before any turn"
+    )
+    assert any(s.id == fresh and s.owner == "carol" for s in listed), (
+        "create_session(owner=...) must persist the owner"
+    )
+    fresh2 = f"conf-{uuid4().hex[:8]}"
+    await store.update_session_metadata(fresh2, {"owner": "dave"})
+    assert fresh2 in {s.id for s in await store.list_sessions()}, (
+        "update_session_metadata() on an unknown session must upsert it, not raise"
+    )
+    await store.delete_session(fresh)
+    await store.delete_session(fresh2)
+
+
 async def run_chat_history_conformance(store: ChatHistoryStore) -> None:
     """Validate that a `ChatHistoryStore` honours the locked contract.
 
@@ -905,6 +928,9 @@ async def run_chat_history_conformance(store: ChatHistoryStore) -> None:
     far_future = datetime(2099, 1, 1, tzinfo=UTC)
     removed_b = await store.expire_before(far_future)
     assert isinstance(removed_b, int), "expire_before must return an int"
+
+    # 11. create_session / metadata before any turn (bug-018).
+    await _assert_create_before_first_turn(store)
 
     # 11. capabilities is a set.
     caps = store.capabilities()

--- a/packages/agentforge-core/tests/unit/test_chat_conformance.py
+++ b/packages/agentforge-core/tests/unit/test_chat_conformance.py
@@ -70,7 +70,9 @@ class _DictHistory(ChatHistoryStore):
         limit: int = 100,
         before: datetime | None = None,
     ) -> list[SessionInfo]:
-        ids = {t.session_id for t in self._turns}
+        # Include metadata-only sessions (created before their first
+        # turn — bug-018), not just sessions that have turns.
+        ids = {t.session_id for t in self._turns} | set(self._meta)
         out: list[SessionInfo] = []
         for sid in ids:
             o = self._owners.get(sid)


### PR DESCRIPTION
## bug-018 — `POST /sessions` 500'd on a fresh SQLite/Postgres/Redis store

`ChatServer._create_session` records the session owner before any turn is appended, but the SQL/KV history drivers only inserted the session row lazily on first `append` — so `update_session_metadata` raised `Cannot update metadata for unknown session` and every session-creation request failed on a fresh process.

The audit widened scope: **SQLite, Postgres, and Redis all raised**; the **in-memory** driver never raised but hid metadata-only sessions from `list_sessions` (it iterated only turn-bearing sessions). So all four shipped drivers needed work.

## Fix — option 1 (upsert) + option 2 (contract), together

- **Upsert**: `update_session_metadata` now creates the row if missing in sqlite/postgres/redis (`INSERT ... ON CONFLICT DO NOTHING` / `hset`-if-absent, leaving an existing row's `last_active_at` untouched). In-memory lists metadata-only sessions and stamps their timestamps.
- **Contract**: `ChatHistoryStore.create_session(session_id, *, owner=None, metadata=None)` added as a **concrete** (non-abstract) ABC method — additive to the locked contract per ADR-0007, so existing and third-party drivers inherit it unchanged. Default delegates to the now-upserting `update_session_metadata`. `ChatServer` now calls `create_session(owner=...)`.
- The postgres fake runner distinguishes `DO NOTHING` (create-only) from `DO UPDATE` (create-or-bump) to stay faithful to the real driver.

## Tests
The create-before-first-turn contract is asserted **once** in the shared `run_chat_history_conformance` harness, so it runs against **all four drivers**; plus a real SQLite-backed `POST /sessions` end-to-end test (the exact reported scenario). Flipped the obsolete postgres "raises on unknown session" test; updated the reference `_DictHistory` + harness to list metadata-only sessions.

Docs: CHANGELOG, bug-018 resolution, feat-020 Implementation status. Part of the v0.2.4 cluster. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)