### PR TITLE
feat: MCP HTTP server transport (enh-001) + fix scaffold version lookup (bug-008)

### DIFF
--- a/.claude/state/current.md
+++ b/.claude/state/current.md
@@ -1,16 +1,17 @@
 ---
-feature: v0.2.4 MCP/chat/config cluster — bug-013 (MCPServer auto-register tools)
+feature: v0.2.4 MCP/chat/config cluster — enh-001 (MCP HTTP server) + bug-008 (version lookup)
 state: pr-raised
-branch: fix/bug-013-auto-register-tools
+branch: enh/001-mcp-http-server-transport
 started_at: 2026-06-02
 last_milestone_at: 2026-06-03
 last_shipped: v0.2.3 — Upgrade-flow fix (bug-007), PR #55 merged 2026-05-21; tag + GitHub Release published. ALL 34 packages now live on PyPI at v0.2.3 (drip completed 2026-05-28). v0.2.4 in progress on main (0.2.4 version bump merged via #58) but NOT yet tagged/released.
 blocker: null
 resume: null
 flags_for_user:
-  - "PR #65 OPEN (fix/bug-013-auto-register-tools): bug-013 P2 — MCPServer.from_stdio/from_http now auto-call register_tools (was empty ListTools from the raw factory). register_tools idempotent (guard); set_tools re-arms it; both factories gained runner= injection for tests. Also reinforced state-tracking discipline (state README + pipeline Rule 4: each PR open/merge is a tracker milestone to push). 1 commit (b13a096) + state sync, full gate green. https://github.com/Scaffoldic/agentforge-py/pull/65 — awaiting merge."
-  - "MERGED to main: #57, #58, #59, #60, #61, #62, #63, #64 (bug-018 chat session-create, 4c735d1). main at version 0.2.4."
-  - "REMAINING v0.2.4 cluster (after #65): enh-001 (HTTP MCP server transport — may slip to 0.2.5). Then bug-008 (~5 lines: version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py) before tagging. Then CUT v0.2.4: set CHANGELOG date from 'unreleased', tag, run release.yml (34 pkgs already at 0.2.4 on main)."
+  - "PR #66 OPEN (enh/001-mcp-http-server-transport): TWO commits in one PR (user-directed). (1) enh-001 — MCP server-side HTTP transport (StreamableHTTPSessionManager under uvicorn; from_http().serve() works; client migrated off deprecated streamablehttp_client; live round-trip test; SSE still deferred). (2) bug-008 — version lookup uses distribution name agentforge-py (scaffolds recorded 0.0.0+unknown). Commits e3497bd + eaa2d3c + state sync, full gate + local live test green. https://github.com/Scaffoldic/agentforge-py/pull/66 — awaiting merge."
+  - "MERGED to main: #57, #58, #59, #60, #61, #62, #63, #64, #65 (bug-013 auto-register, 503ffdb). ALL 8 cluster bugs (012/013/014/015/017/018/019/020) are IN. main at version 0.2.4."
+  - "AFTER #66 merges → CUT v0.2.4: set CHANGELOG `[0.2.4]` date (from 'unreleased'), write docs/releases/v0.2.4.md from the template, run the pre-release checklist, tag v0.2.4 at the merge commit, `gh release create`, run release.yml (34 pkgs already at 0.2.4 on main; skip-existing makes it idempotent)."
+  - "PyPI post-drip chores still pending: revoke ~/.pypirc [pypi] token; convert to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md."
   - "bug-008 still queued for v0.2.4 (NOT done): version(\"agentforge\")→version(\"agentforge-py\") in cli/new_cmd.py + cli/_shared_scaffold.py. ~5 lines."
   - "v0.2.4 CHANGELOG header is `## [0.2.4] — unreleased`; set the date + tag only after the whole cluster lands."
   - "PyPI v0.2.3 drip COMPLETE (34/34). Post-completion chores: revoke ~/.pypirc [pypi] token; convert projects to Trusted Publishing; delete PYPI_PUBLISH_TRACKER.md (see that file + memory)."
@@ -40,32 +41,43 @@ rejected as stdio-hijack guard). The cluster unblocker is in main.
 failed (env-gated `test_mcp_live.py` asserted the old `echo.echo`;
 local pre-commit doesn't run live tests) — fixed in commit `0bc8386`.
 
-**Merged — PR #64** (`fix/bug-018-chat-session-create`, 4c735d1):
-chat session-create contract — drivers upsert in update_session_metadata,
-in-memory lists metadata-only sessions, concrete create_session() ABC
-method, ChatServer calls it; asserted in shared conformance harness.
+**Merged — PR #65** (`fix/bug-013-auto-register-tools`, 503ffdb):
+MCPServer factories auto-register tools (idempotent guard + set_tools
+re-arm + runner= injection). Cluster bugs all landed.
 
-**In flight — PR #65** (`fix/bug-013-auto-register-tools`, off main):
-bug-013 P2 — `MCPServer.from_stdio`/`from_http` now call `register_tools()`
-before returning (raw factory previously served an empty ListTools).
-`register_tools()` idempotent via a `_registered` guard; `set_tools()`
-re-arms it (bridge expose path stays correct); both factories gained an
-optional `runner=` injection so the fix is unit-tested, not live-only.
-Also reinforced the state-tracking cadence (project state README +
-workspace pipeline Rule 4: each PR open/merge is a tracker milestone to
-commit+push). 1 commit (`b13a096`) + state sync, full gate green.
-Awaiting merge.
+**In flight — PR #66** (`enh/001-mcp-http-server-transport`, off main) —
+TWO commits, user-directed bundle:
+- **enh-001** (`e3497bd`) — MCP server-side HTTP transport.
+  `_SDKServerRunner.serve()` branches on transport; `http` runs the SDK's
+  `StreamableHTTPSessionManager` mounted at `/mcp` under uvicorn,
+  `stop()` graceful. Unsupported transport rejected at construction.
+  Client HTTP transport migrated off deprecated `streamablehttp_client` →
+  `streamable_http_client` + `create_mcp_http_client`. Live HTTP
+  round-trip test (verified locally). starlette/uvicorn are transitive
+  via `agentforge-mcp[mcp]`. SSE server transport deferred.
+- **bug-008** (`eaa2d3c`) — `_template_version`/`_framework_version` look
+  up `agentforge-py` (distribution name) not `agentforge` (import name),
+  so scaffolds record the real version instead of `0.0.0+unknown`.
+  Regression test added.
+
+Full gate green; local `RUN_LIVE_MCP=1` live run green. (Note: these were
+briefly committed on local main by mistake, then moved to this branch and
+main was reset to origin/main before any push — no remote impact.)
 
 ## Pickup on resume
 
-1. **Merge PR #65** (bug-013) once reviewed/CI-green. **The bug cluster
-   is then DONE** (all of bug-012/013/014/015/017/018/019/020 landed).
-2. **enh-001** — HTTP MCP server transport. Decide: include in v0.2.4 or
-   slip to 0.2.5. If slipping, it's the only remaining cluster item.
-3. **bug-008** (~5 lines) — `version("agentforge")` → `version("agentforge-py")`
-   in `cli/new_cmd.py` + `cli/_shared_scaffold.py`. Fold in before tagging.
-4. **Cut v0.2.4** — set the CHANGELOG `[0.2.4]` date (from "unreleased"),
-   tag, push, run `release.yml` (34 pkgs already at 0.2.4 on main).
+1. **Merge PR #66** (enh-001 + bug-008). **The entire v0.2.4 cluster is
+   then DONE.**
+2. **Cut v0.2.4** (locked release procedure, memory feedback_workflow #9):
+   - Pull main. Set CHANGELOG `## [0.2.4]` date (replace "unreleased").
+   - Write `docs/releases/v0.2.4.md` from `.claude/templates/release-notes.md`.
+   - Run `.claude/checklists/pre-release.md` end-to-end.
+   - Tag `v0.2.4` at the merge commit; `gh release create v0.2.4 --notes-file docs/releases/v0.2.4.md`.
+   - `release.yml` fires on the tag (34 pkgs already at 0.2.4 on main;
+     `skip-existing` keeps it idempotent). Re-run via
+     `gh workflow run release.yml --ref v0.2.4` if the quota wall is hit.
+3. **PyPI post-drip chores**: revoke `~/.pypirc [pypi]` token, convert to
+   Trusted Publishing, delete `PYPI_PUBLISH_TRACKER.md`.
 3. **bug-008** (~5 lines) — fold in somewhere before tagging.
 4. **Tag v0.2.4** only after the cluster lands: set CHANGELOG date,
    push tag, run `release.yml` (34 packages already at 0.2.4 on main).

--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -3025,3 +3025,26 @@ tracker milestone to commit+push (not batched to session end), esp. in a
 multi-PR cluster. Full gate green (b13a096). PR #65 open. After merge the
 bug cluster is DONE; remaining: enh-001 (may slip to 0.2.5), bug-008 (~5
 lines) before tagging, then cut v0.2.4.
+
+## 2026-06-03T06:30 — v0.2.4 cluster: bug-013 merged (#65); enh-001 + bug-008 opened (#66)
+PR #65 (bug-013) merged to main (503ffdb) — all 8 cluster bugs now in.
+Per user, bundled enh-001 + bug-008 into ONE PR with TWO commits on
+`enh/001-mcp-http-server-transport`:
+- enh-001 (e3497bd): MCP server-side HTTP transport. _SDKServerRunner.serve()
+  branches stdio/http; http = StreamableHTTPSessionManager mounted at /mcp
+  under uvicorn (stop() graceful); unsupported transport rejected at
+  construction. Migrated the CLIENT http transport off the SDK's deprecated
+  streamablehttp_client → streamable_http_client + create_mcp_http_client
+  (the deprecation errored under filterwarnings=error and blocked the
+  round-trip). starlette/uvicorn transitive via agentforge-mcp[mcp] — no new
+  dep. Live HTTP round-trip test added + verified locally (RUN_LIVE_MCP=1).
+  SSE server transport still deferred (phase 2).
+- bug-008 (eaa2d3c): _template_version/_framework_version look up
+  distribution name agentforge-py (not import name agentforge), so scaffolds
+  record the real version not 0.0.0+unknown; regression test added.
+PROCESS NOTE: both commits were briefly made on local main by mistake (forgot
+to branch after #65 merge), then moved to the feature branch and main was
+reset to origin/main BEFORE any push — zero remote impact. Reinforces the
+"branch first" discipline. Full gate green. PR #66 open. AFTER it merges the
+v0.2.4 cluster is DONE → cut v0.2.4 (CHANGELOG date, release notes,
+pre-release checklist, tag, release.yml).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ activity and the next chat turn's prompt lost prior tool context.
   locked ABC) method to register a session before its first turn. The
   default upserts via `update_session_metadata`; drivers may override
   (bug-018).
+- **MCP server-side HTTP transport (enh-001).** `MCPServer.from_http(...)`
+  + `serve()` now actually serve the MCP protocol over streamable-HTTP
+  (the SDK's `StreamableHTTPSessionManager` under uvicorn) instead of
+  raising `not yet implemented`, enabling multi-instance hosted MCP
+  servers. `starlette` / `uvicorn` arrive transitively via
+  `agentforge-mcp[mcp]`. Unsupported transports now fail at construction;
+  the client HTTP transport was migrated off the SDK's deprecated
+  `streamablehttp_client`. SSE server transport remains deferred.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ activity and the next chat turn's prompt lost prior tool context.
 
 ### Fixed
 
+- **bug-008 — scaffolds recorded `_template_version: 0.0.0+unknown`.**
+  `_template_version` / `_framework_version` looked the version up by the
+  import name `agentforge`, but the PyPI distribution is `agentforge-py`
+  (renamed in v0.2.1 around a squatted name), so `importlib.metadata.version`
+  raised on every install and fell back to the sentinel — every scaffolded
+  agent's `answers.yml` and `AGENTFORGE-MANAGED:` markers lied about which
+  framework version produced them. Both call sites now look up
+  `agentforge-py` (with a comment so it isn't "fixed" back). Regression
+  test asserts a scaffold records the real installed version.
 - **bug-013 — `MCPServer.from_stdio` / `from_http` served an empty tool
   list.** The factories constructed the server holding the tool list but
   never registered the tools with the runner, so a server built straight

--- a/docs/bugs/bug-008-template-version-stale-distribution-name.md
+++ b/docs/bugs/bug-008-template-version-stale-distribution-name.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.2.4
 severity: P3
 found-in: v0.2.3
 found-via: post-bug-007 validation via published CLI, 2026-05-21

--- a/docs/enhancements/enh-001-mcp-http-server-transport.md
+++ b/docs/enhancements/enh-001-mcp-http-server-transport.md
@@ -14,7 +14,7 @@
 |---|---|
 | **ID** | enh-001 |
 | **Title** | Implement server-side HTTP transport for `MCPServer` |
-| **Status** | `proposed` |
+| **Status** | `implemented in 0.2.4` |
 | **Owner** | kjoshi |
 | **Created** | 2026-06-02 |
 | **Target version** | 0.2.4 (or 0.2.5 if scope slips) |
@@ -116,3 +116,27 @@ Fail-fast improvement to fold in: `MCPServer.from_http` / the bridge's
 - Improved feature: feat-013 (MCP)
 - Reclassified from: bug-016 (removed)
 - Related: bug-013 (auto-register tools), bug-020 (runtime wiring)
+
+## 9. Resolution (v0.2.4)
+
+`_SDKServerRunner.serve()` now branches on transport: `stdio` via
+`stdio_server()` (unchanged) and `http` via the SDK's
+`StreamableHTTPSessionManager` mounted at `/mcp` in a minimal Starlette
+app under uvicorn. `stop()` signals uvicorn to exit gracefully. The
+shared `@list_tools` / `@call_tool` handlers register once before the
+transport split. `MCPServer.from_http(...).serve()` now serves instead of
+raising. The fail-fast improvement landed too: `_SDKServerRunner.__init__`
+rejects an unsupported transport at construction (not deferred to
+`serve()`).
+
+`starlette` + `uvicorn` are already transitive deps of `mcp`, so
+`agentforge-mcp[mcp]` covers the HTTP stack — no new dependency.
+
+While wiring the round-trip, the **client** HTTP transport was migrated
+off the SDK's deprecated `streamablehttp_client` to `streamable_http_client`
+(+ `create_mcp_http_client` for headers), which the SDK now requires.
+
+A `@pytest.mark.live` integration test (`test_mcp_live.py`) starts an HTTP
+`MCPServer`, connects `MCPServerClient.from_http`, and asserts a
+list + call round-trip. **SSE server transport remains deferred** (phase 2,
+pending the SDK's SSE server adapter) — only HTTP shipped.

--- a/docs/features/feat-013-mcp-integration.md
+++ b/docs/features/feat-013-mcp-integration.md
@@ -310,6 +310,7 @@ nothing.
 | 2 | `agentforge_core.contracts.protocol_bridge.ProtocolBridge` — a `@runtime_checkable` Protocol (`tools` / `start` / `close`) so the runtime wires protocol handlers without `agentforge` importing `agentforge-mcp`. `Agent` gains a `protocol_bridges` kwarg and closes each on `close()`. |
 | 3 | **bug-020** — `build_protocols_from_config` resolves each `modules.protocols` entry under the `protocols` category, builds it via `from_config`, awaits `start()`, and collects its tools. `build_agent_from_config` merges native `agent.tools` (previously never wired through this path) + protocol tools into `Agent(tools=...)` and passes the started bridges. Server-side `expose` is rejected with a clear error (would hijack the agent process's stdio); expose runtime-wiring is a follow-up. |
 | 4 | **bug-013** — `MCPServer.from_stdio` / `from_http` now call `register_tools()` before returning, so a server built straight from the factory advertises its tools instead of serving an empty `ListTools`. `register_tools()` is idempotent (guarded), and `set_tools()` re-arms it, so the bridge expose path (build empty → `attach_local_tools` → `start()` registers) and an explicit caller both stay correct. Both factories gained an optional `runner=` injection for testing. |
+| 5 | **enh-001** — `MCPServer` HTTP server transport. `_SDKServerRunner.serve()` branches on transport: `http` runs the SDK's `StreamableHTTPSessionManager` mounted at `/mcp` in a Starlette app under uvicorn (`stop()` signals graceful exit); unsupported transports are rejected at construction. The client HTTP transport was migrated off the deprecated `streamablehttp_client` to `streamable_http_client` + `create_mcp_http_client`. Live test covers an HTTP list+call round-trip. SSE server transport stays deferred. |
 
 ### Out-of-scope (deferred to a later v0.x follow-up)
 
@@ -417,7 +418,7 @@ tools = await client.discover_tools()
 | Symptom | Cause | Fix |
 |---|---|---|
 | `ModuleError: mcp SDK is not installed` | upstream missing | `pip install agentforge-mcp[mcp]` (or `agentforge add module mcp` to install both) |
-| `MCP server transport 'http' is not yet implemented` | v0.2.1 polish gap | use `transport: stdio` in `modules.protocols.mcp.expose` for now; HTTP server transport lands as a v0.2.1 chore |
+| `MCP server transport 'sse' is not supported` | only `stdio` + `http` server transports ship | use `transport: stdio` or `transport: http`; SSE server transport is still deferred (enh-001 phase 2). HTTP server transport landed in v0.2.4 (enh-001). |
 | Tool name collision | two servers expose the same name | both arrive prefixed with their server name (`fs__read_file` vs `s3__read_file`) — collision avoided |
 | Subprocess won't terminate on agent close | `bridge.close` not called | use `async with Agent(...)` so the framework's `__aexit__` invokes the bridge close path |
 | Non-text content blocks dropped from `call_tool` result | `_SDKClientRunner` concatenates `TextContent` blocks and ignores `ImageContent` / `EmbeddedResource` for v0.2 | follow-up when a real use case justifies the wire-format change; meanwhile route binary tools through a different adapter shape |

--- a/packages/agentforge-mcp/src/agentforge_mcp/client.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/client.py
@@ -170,21 +170,34 @@ async def _build_http_runner(
     """Production HTTP / SSE runner — lazy-imports `mcp`."""
     try:
         from mcp import ClientSession  # noqa: PLC0415
-
-        if transport == "sse":
-            from mcp.client.sse import sse_client as connect  # noqa: PLC0415
-        else:
-            from mcp.client.streamable_http import (  # noqa: PLC0415
-                streamablehttp_client as connect,
-            )
     except ImportError as exc:
         msg = (
             'mcp SDK is not installed. Install via `pip install "agentforge-mcp[mcp]"` '
             f"(or `agentforge-py[mcp]`) to connect to MCP server {name!r} over {transport}."
         )
         raise ModuleError(msg) from exc
+
+    if transport == "sse":  # pragma: no cover — live wiring (real SDK only)
+        from mcp.client.sse import sse_client  # noqa: PLC0415
+
+        def _connect() -> Any:
+            return sse_client(url, headers=dict(headers or {}))
+    else:  # pragma: no cover — live wiring (real SDK only)
+        # `streamable_http_client` (the non-deprecated entry point) takes an
+        # `http_client`, not `headers`; `create_mcp_http_client` builds one
+        # carrying the requested headers.
+        from mcp.client.streamable_http import (  # noqa: PLC0415
+            create_mcp_http_client,
+            streamable_http_client,
+        )
+
+        def _connect() -> Any:
+            return streamable_http_client(
+                url, http_client=create_mcp_http_client(headers=dict(headers or {}))
+            )
+
     return _SDKClientRunner(
-        session_factory=lambda: connect(url, headers=dict(headers or {})),
+        session_factory=_connect,
         session_cls=ClientSession,
         timeout_s=timeout_s,
     )

--- a/packages/agentforge-mcp/src/agentforge_mcp/server.py
+++ b/packages/agentforge-mcp/src/agentforge_mcp/server.py
@@ -201,10 +201,10 @@ class _SDKServerRunner:  # pragma: no cover — only with `mcp` SDK + `-m live`
     decorator-based registration pattern over the accumulated
     registry: one `@server.list_tools()` handler returns every
     registered descriptor; one `@server.call_tool()` handler
-    dispatches by name into the per-tool handler. Then we open
-    the configured transport (stdio for v0.2; HTTP / SSE is a
-    follow-up — see spec §10) and await `server.run(...)`.
-    `stop()` cancels the serve task.
+    dispatches by name into the per-tool handler. Then we open the
+    configured transport — `stdio` via `stdio_server()`, or `http`
+    via the SDK's streamable-HTTP manager under uvicorn (enh-001).
+    `stop()` cancels the serve task / signals uvicorn to exit.
     """
 
     def __init__(
@@ -215,12 +215,17 @@ class _SDKServerRunner:  # pragma: no cover — only with `mcp` SDK + `-m live`
         host: str | None = None,
         port: int | None = None,
     ) -> None:
+        if transport not in ("stdio", "http"):
+            # Fail fast at construction, not at serve() (enh-001 §5).
+            msg = f"MCP server transport {transport!r} is not supported; use 'stdio' or 'http'."
+            raise ModuleError(msg)
         self._server = server
         self._transport = transport
         self._host = host
         self._port = port
         self._tools: dict[str, _RegisteredTool] = {}
         self._serve_task: asyncio.Task[None] | None = None
+        self._uv_server: Any = None
 
     def register_tool(
         self,
@@ -237,16 +242,6 @@ class _SDKServerRunner:  # pragma: no cover — only with `mcp` SDK + `-m live`
         )
 
     async def serve(self) -> None:
-        if self._transport != "stdio":
-            # HTTP / SSE server transport ships in a v0.2.1 follow-up
-            # — needs the streamable-http manager + uvicorn wiring.
-            # Stdio is the v0.2 deliverable.
-            msg = (
-                f"MCP server transport {self._transport!r} is not yet "
-                "implemented. Use transport='stdio' for v0.2."
-            )
-            raise ModuleError(msg)
-        from mcp.server.stdio import stdio_server  # noqa: PLC0415
         from mcp.types import TextContent  # noqa: PLC0415
         from mcp.types import Tool as MCPTool  # noqa: PLC0415
 
@@ -274,11 +269,57 @@ class _SDKServerRunner:  # pragma: no cover — only with `mcp` SDK + `-m live`
             result_text = await tool.handler(arguments)
             return [TextContent(type="text", text=result_text)]
 
+        if self._transport == "http":
+            await self._serve_http()
+        else:
+            await self._serve_stdio()
+
+    async def _serve_stdio(self) -> None:
+        from mcp.server.stdio import stdio_server  # noqa: PLC0415
+
         options = self._server.create_initialization_options()
         async with stdio_server() as (read_stream, write_stream):
             await self._server.run(read_stream, write_stream, options)
 
+    async def _serve_http(self) -> None:
+        """Serve the MCP protocol over streamable-HTTP (enh-001).
+
+        Wires the SDK's `StreamableHTTPSessionManager` into a minimal
+        Starlette app mounted at `/mcp` and runs it under uvicorn. The
+        manager's session lifespan is driven by the app lifespan; tools
+        were registered on `self._server` in `serve()` above.
+        """
+        import uvicorn  # noqa: PLC0415
+        from mcp.server.streamable_http_manager import (  # noqa: PLC0415
+            StreamableHTTPSessionManager,
+        )
+        from starlette.applications import Starlette  # noqa: PLC0415
+        from starlette.routing import Mount  # noqa: PLC0415
+
+        manager = StreamableHTTPSessionManager(app=self._server, json_response=True, stateless=True)
+
+        async def _asgi(scope: Any, receive: Any, send: Any) -> None:
+            await manager.handle_request(scope, receive, send)
+
+        @contextlib.asynccontextmanager
+        async def _lifespan(_app: Any) -> Any:
+            async with manager.run():
+                yield
+
+        app = Starlette(routes=[Mount("/mcp", app=_asgi)], lifespan=_lifespan)
+        config = uvicorn.Config(
+            app,
+            host=self._host or "127.0.0.1",
+            port=self._port or 8765,
+            log_level="warning",
+        )
+        self._uv_server = uvicorn.Server(config)
+        await self._uv_server.serve()
+
     async def stop(self) -> None:
+        if self._uv_server is not None:
+            # Graceful uvicorn shutdown (HTTP transport).
+            self._uv_server.should_exit = True
         if self._serve_task is not None and not self._serve_task.done():
             self._serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/packages/agentforge-mcp/tests/integration/test_mcp_live.py
+++ b/packages/agentforge-mcp/tests/integration/test_mcp_live.py
@@ -14,11 +14,17 @@ skips this with `-m "not live"`. Run explicitly with:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import socket
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
-from agentforge_mcp import MCPServerClient
+from agentforge_core.contracts.tool import Tool
+from agentforge_mcp import MCPServer, MCPServerClient
+from pydantic import BaseModel
 
 
 @pytest.mark.live
@@ -41,3 +47,68 @@ async def test_stdio_roundtrip_against_real_mcp_server() -> None:
         assert "hello mcp" in result
     finally:
         await client.close()
+
+
+class _HttpEchoInput(BaseModel):
+    text: str
+
+
+class _HttpEcho(Tool):
+    name = "http_echo"
+    description = "Echo the input text."
+    input_schema = _HttpEchoInput
+
+    async def run(self, **kwargs: Any) -> str:
+        return f"echoed:{kwargs.get('text', '')}"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+async def _wait_until_listening(host: str, port: int, *, timeout_s: float = 10.0) -> None:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        try:
+            _, writer = await asyncio.open_connection(host, port)
+        except OSError:
+            await asyncio.sleep(0.1)
+        else:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+            return
+    raise TimeoutError(f"MCP HTTP server on {host}:{port} did not start in {timeout_s}s")
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_http_roundtrip_against_real_mcp_server() -> None:
+    """enh-001: an HTTP MCPServer serves tools and a client round-trips
+    list + call over streamable-HTTP."""
+    host, port = "127.0.0.1", _free_port()
+    server = MCPServer.from_http(tools=[_HttpEcho()], host=host, port=port)
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        await _wait_until_listening(host, port)
+        client = await MCPServerClient.from_http(name="echo", url=f"http://{host}:{port}/mcp")
+        try:
+            tools = await client.discover_tools()
+            assert [type(t).name for t in tools] == ["echo__http_echo"]
+            result = await tools[0].run(text="hello http")
+            assert "hello http" in result
+        finally:
+            await client.close()
+    finally:
+        # stop() signals uvicorn to exit; let it drain so its sockets
+        # close cleanly before falling back to cancellation.
+        await server.stop()
+        with contextlib.suppress(TimeoutError, asyncio.CancelledError, Exception):
+            await asyncio.wait_for(serve_task, timeout=5.0)
+        if not serve_task.done():
+            serve_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await serve_task

--- a/packages/agentforge/src/agentforge/cli/_shared_scaffold.py
+++ b/packages/agentforge/src/agentforge/cli/_shared_scaffold.py
@@ -150,7 +150,9 @@ def _framework_version() -> str:
     from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
 
     try:
-        return version("agentforge")
+        # Distribution name is `agentforge-py`, not the import name
+        # `agentforge` (bug-008). Do NOT change this back to "agentforge".
+        return version("agentforge-py")
     except PackageNotFoundError:  # pragma: no cover
         return "0.0.0+unknown"
 

--- a/packages/agentforge/src/agentforge/cli/new_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/new_cmd.py
@@ -166,12 +166,17 @@ def _write_answers_file(
 
 
 def _template_version() -> str:
-    """Resolve the installed `agentforge` version — used as the
+    """Resolve the installed framework version — used as the
     template's `source_version` in the lock file."""
     from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
 
     try:
-        return version("agentforge")
+        # The PyPI *distribution* name is `agentforge-py` (the import name
+        # `agentforge` is a squatted PyPI project). `version()` keys off the
+        # distribution name, so `version("agentforge")` raised on every
+        # install and fell through to the sentinel (bug-008). Do NOT change
+        # this back to "agentforge".
+        return version("agentforge-py")
     except PackageNotFoundError:  # pragma: no cover
         return "0.0.0+unknown"
 

--- a/packages/agentforge/tests/unit/test_new_cmd.py
+++ b/packages/agentforge/tests/unit/test_new_cmd.py
@@ -52,6 +52,27 @@ def test_minimal_template_renders_with_no_prompts(tmp_path: Path, capsys):
     # (`.agentforge-state/` plumbing).
 
 
+def test_scaffold_records_real_framework_version(tmp_path: Path):
+    """bug-008: the lock/answers `_template_version` must be the real
+    installed framework version, not the `0.0.0+unknown` sentinel — the
+    version lookup keys off the distribution name `agentforge-py`."""
+    from importlib.metadata import version  # noqa: PLC0415
+
+    dst = tmp_path / "agent"
+    _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="minimal",
+            provider="bedrock",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+    answers = yaml.safe_load((dst / ".agentforge-state" / "answers.yml").read_text())
+    assert answers["_template_version"] != "0.0.0+unknown"
+    assert answers["_template_version"] == version("agentforge-py")
+
+
 def test_anthropic_provider_routes_to_correct_model(tmp_path: Path):
     dst = tmp_path / "agent"
     _run_new(


### PR DESCRIPTION
Two commits in one PR (as requested) — the last two items in the v0.2.4 cluster.

## Commit 1 — enh-001: MCP server-side HTTP transport

`MCPServer.from_http(...).serve()` previously raised `transport 'http' is not yet implemented`. Now `_SDKServerRunner.serve()` branches on transport:
- **stdio**: unchanged (`stdio_server()`).
- **http**: the SDK's `StreamableHTTPSessionManager` mounted at `/mcp` in a minimal Starlette app under uvicorn; `stop()` signals graceful exit.

The shared `@list_tools`/`@call_tool` handlers register once before the split. **Unsupported transports now fail at construction** (the enh-001 §5 fail-fast). `starlette` + `uvicorn` are already transitive deps of `mcp`, so `agentforge-mcp[mcp]` covers the HTTP stack — no new dependency.

**Client side**: migrated the HTTP transport off the SDK's deprecated `streamablehttp_client` to `streamable_http_client` (+ `create_mcp_http_client` for headers), which the SDK now requires — needed for the round-trip and to avoid a `DeprecationWarning` erroring under `filterwarnings=error`.

**Live test**: starts an HTTP `MCPServer`, connects `MCPServerClient.from_http`, asserts a list + call round-trip (verified locally with `RUN_LIVE_MCP=1`). **SSE server transport stays deferred** (phase 2).

## Commit 2 — bug-008: scaffold version lookup

`_template_version` / `_framework_version` looked up `version("agentforge")`, but the PyPI distribution is `agentforge-py` (the import name is a squatted project), so the lookup raised and fell back to `0.0.0+unknown` — every scaffolded agent's `answers.yml` + `AGENTFORGE-MANAGED:` markers recorded a fake version. Both call sites now look up `agentforge-py` (with a comment so it isn't reverted). Regression test asserts a scaffold records the real installed version.

---

With this PR the **entire v0.2.4 bug cluster (012/013/014/015/017/018/019/020 + enh-001 + bug-008) is complete** — next step is cutting v0.2.4. Full pre-commit gate green; live MCP suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)