### PR TITLE
docs: align label references with GitHub default label names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,8 +138,8 @@ fully offline.
 - **Features:** describe the use case and the production problem it solves.
   Larger features may need a `feat-NNN` spec under `docs/features/` first —
   maintainers will guide you.
-- Looking for somewhere to start? Check issues labeled `good-first-issue`
-  and `help-wanted`, and the backlog in `docs/roadmap.md`.
+- Looking for somewhere to start? Check issues labeled `good first issue`
+  and `help wanted`, and the backlog in `docs/roadmap.md`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ issue? See [`SECURITY.md`](./SECURITY.md) (please report privately).
 - 90 % coverage floor
 - Every feature PR updates its spec's `Implementation status`
 
-Looking for somewhere to start? Issues labelled `good-first-issue`
-and `help-wanted`, plus the [`docs/roadmap.md`](./docs/roadmap.md)
+Looking for somewhere to start? Issues labelled `good first issue`
+and `help wanted`, plus the [`docs/roadmap.md`](./docs/roadmap.md)
 backlog.
 
 ---


### PR DESCRIPTION
Small follow-up to #69. The contributor labels that power GitHub's
`/contribute` discovery page are `good first issue` and `help wanted`
(with spaces). Update the README and CONTRIBUTING references to match
those exact names so the links/filters resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)