### PR TITLE
docs: ADR-0022 + enh-002 — reserved `app:` block for app config (#86)

### DIFF
--- a/docs/adr/0022-app-passthrough-for-application-config.md
+++ b/docs/adr/0022-app-passthrough-for-application-config.md
@@ -1,0 +1,163 @@
+# ADR-0022: Reserved `app:` block for application config in `agentforge.yaml`
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Number** | 0022 |
+| **Title** | Reserved `app:` block for application config in `agentforge.yaml` |
+| **Status** | Proposed |
+| **Date** | 2026-06-13 |
+| **Deciders** | kjoshi |
+| **Tags** | architecture, config |
+
+---
+
+## 1. Context and problem statement
+
+The root config model `AgentForgeConfig` is strict
+(`ConfigDict(strict=True, extra="forbid")`). Any top-level key the
+framework doesn't define is rejected:
+
+```yaml
+# agentforge.yaml
+agent: { name: my-agent, model: "anthropic:claude-haiku-4-5" }
+graph:                       # the agent's own engine config
+  store: { path: .ckg }
+```
+
+```
+$ agentforge config validate
+agentforge.yaml validation failed:
+  graph: Extra inputs are not permitted
+```
+
+Strict validation is deliberate and load-bearing: it catches typos in
+framework keys (`agnet:`, `modlues:`) at config-load time rather than
+silently ignoring them. We do **not** want to give that up.
+
+But the strictness has a side effect: an agent built *on* AgentForge
+(reported by `agentforge-graph`, issue #86) has **no sanctioned place
+for its own config** inside `agentforge.yaml`. The workaround — a
+separate `ckg.yaml` loaded by the agent package — works, but that file
+misses the framework's `${ENV}` interpolation, layered env-file support,
+and `config show --resolved`. The framework's (good) config machinery
+is not reusable by the very agents the framework exists to serve.
+
+How do we give application config a sanctioned home **without** weakening
+typo protection for framework keys?
+
+## 2. Decision drivers
+
+- **Typo protection must stay.** `extra="forbid"` on framework keys is a
+  stated value (catches `agnet:`); relaxing it globally is a regression.
+- **The framework exists to serve agents built on it.** A "plug-and-play
+  framework for building production agents" should let those agents reuse
+  its config machinery (interpolation, layering, `--resolved`), not force
+  them to re-implement it.
+- **Config is data, not code (ADR-0013).** Any extension point must stay
+  declarative — no dynamic imports, no executable behavior introduced by
+  the app's subtree.
+- **Contract stability (ADR-0007).** Adding a field with a safe default to
+  `AgentForgeConfig` is a minor bump; removing or renaming is major. We
+  prefer the smallest additive change.
+
+## 3. Considered options
+
+1. **Reserved `app:` passthrough block** — one top-level key the framework
+   accepts but does not interpret; the app validates its own subtree.
+2. **OpenAPI-style `x-*` extension keys** — allow any top-level key
+   prefixed `x-`, ignore them in the framework model.
+3. **Additional config files mechanism** — the framework discovers and
+   loads a separate app config file and surfaces it through the same
+   interpolation/layering/`--resolved` machinery.
+4. **Document-only** — keep strict validation, document that app config
+   belongs in a separate file and that the split is intentional.
+5. **Relax `extra="forbid"` globally** — allow any unknown key.
+
+## 4. Decision outcome
+
+**Chosen: Option 1 — a reserved `app:` block.**
+
+Add a single field to `AgentForgeConfig`:
+
+```python
+app: dict[str, Any] = Field(default_factory=dict)
+"""Sanctioned passthrough for application config. The framework does
+not interpret this subtree — a consuming agent validates `config.app`
+with its own Pydantic model. Everything else stays strict."""
+```
+
+`extra="forbid"` is unchanged, so every *other* unknown top-level key is
+still rejected — `agnet:` still fails fast. Only `app:` is blessed.
+Because `${ENV}` interpolation and env-file layering run over the raw
+mapping (which now includes `app:`), and `app` is a real field, the app's
+config gets interpolation, layering, and `config show --resolved` for
+free. The consuming agent is responsible for validating the *shape* of
+its own `app:` subtree.
+
+```yaml
+# agentforge.yaml — after
+agent: { name: my-agent, model: "anthropic:claude-haiku-4-5" }
+app:
+  graph:
+    store: { path: ${CKG_PATH:.ckg} }   # interpolation now applies
+```
+
+### Positive consequences
+
+- One file. App config reuses **all** the framework config machinery.
+- Typo protection for framework keys is fully preserved.
+- Minimal, additive contract change — a minor version bump per ADR-0007.
+- Stays declarative data — no dynamic behavior (consistent with ADR-0013).
+
+### Negative consequences (trade-offs)
+
+- The framework does **not** validate inside `app:` — that is delegated to
+  the app. (This is correct: the framework cannot know the app's schema.)
+- A single namespace: apps must nest their own structure under `app:`
+  rather than scattering top-level keys.
+- Slight blur of "framework config file" vs "app config" ownership, which
+  the docs must address (the `app:` subtree is owned by the app).
+
+## 5. Pros and cons of the options
+
+### Option 1: Reserved `app:` block (chosen)
+
+- + Smallest additive change; reuses all machinery; typo protection intact
+- + Clear, single, documented ownership boundary
+- − Framework can't validate the subtree (delegated to the app, by design)
+
+### Option 2: `x-*` extension keys
+
+- + Familiar (OpenAPI); multiple top-level extension keys
+- − Multiple escape hatches dilute the "one home for app config" story
+- − Pydantic can't express "allow keys matching a prefix" as cleanly as a
+  single named field; needs a custom validator + still loosens the model
+
+### Option 3: Additional config files
+
+- + Clean file separation; `agentforge.yaml` stays framework-only; scales
+- − Much more machinery (discovery, load order, merge semantics, how it
+  surfaces in `--resolved`); larger surface for a modest need
+- − Defer-able: can be added later *on top of* `app:` if demand appears
+
+### Option 4: Document-only
+
+- + Zero code; strict contract stays pristine
+- − Does not solve the reported need — the separate file still misses
+  interpolation/layering/`--resolved`; blesses the unsatisfying workaround
+
+### Option 5: Relax `extra="forbid"` globally
+
+- + Trivial
+- − **Regression**: loses framework-key typo protection — the exact thing
+  the strictness was introduced to provide. Rejected.
+
+## 6. References
+
+- Reported in: issue #86 (filed by `agentforge-graph`)
+- Implemented by: [`docs/enhancements/enh-002-app-config-passthrough.md`](../enhancements/enh-002-app-config-passthrough.md)
+- Improves: [`docs/features/feat-012-configuration-system.md`](../features/feat-012-configuration-system.md)
+- Related: [ADR-0013](./0013-configuration-is-data-not-code.md) (config is data),
+  [ADR-0007](./0007-abc-protocol-as-stable-surface.md) (contract stability / minor-bump rule)

--- a/docs/adr/0022-app-passthrough-for-application-config.md
+++ b/docs/adr/0022-app-passthrough-for-application-config.md
@@ -61,6 +61,20 @@ typo protection for framework keys?
 - **Contract stability (ADR-0007).** Adding a field with a safe default to
   `AgentForgeConfig` is a minor bump; removing or renaming is major. We
   prefer the smallest additive change.
+- **Consistency with the framework's own pattern.** The framework *already*
+  validates per-component config sections: `module_schemas.py` walks
+  `modules.*`, resolves each driver via the entry-point resolver (ADR-0004),
+  reads its `config_schema`, and validates that section. feat-012's thesis is
+  *"validation must be uniform; per-module schemas compose."* App config
+  validated **differently** from module config would be an inconsistency in
+  our own design — so the end state should let app config register a typed,
+  validated section the same way modules do.
+- **Match the proven industry pattern.** "One shared config file, a reserved
+  namespace, many typed sub-sections each owned and validated by its
+  component" is the mature, widely-adopted answer: Spring Boot
+  `@ConfigurationProperties(prefix)`, Python `pyproject.toml` `[tool.<name>]`
+  (PEP 518), Kubernetes CRDs/annotations, Viper multi-source. We adopt it
+  rather than invent.
 
 ## 3. Considered options
 
@@ -95,6 +109,33 @@ mapping (which now includes `app:`), and `app` is a real field, the app's
 config gets interpolation, layering, and `config show --resolved` for
 free. The consuming agent is responsible for validating the *shape* of
 its own `app:` subtree.
+
+### Phasing — `app:` is the namespace; typed registered sections are the destination
+
+The reserved `app:` block is the **namespace** (the `[tool]` of
+`agentforge.yaml`). The decision is delivered in phases so #86 is unblocked
+immediately without building speculative machinery:
+
+- **Phase 1 (enh-002, 0.5.0):** the `app:` field + a typed accessor
+  `config.app_as(model, key)`. The agent validates its subtree with its own
+  (strict, if it likes) model — so typo protection inside `app:` is
+  *delegated*, not lost.
+- **Phase 2 (feat-026):** registered typed sections. A derived agent/plugin
+  declares `app.<section> → PydanticModel` via an entry-point group
+  (`agentforge.config_sections`), and the framework validates it during
+  `config validate` — reusing the **existing** `module_schemas.py` engine, so
+  app config becomes a first-class, framework-validated section exactly like
+  `modules.*`. Phase 1 is forward-compatible: `app.<section>` simply gains
+  framework validation, with no breaking change.
+- **Phase 3 (feat-026 §4.4, on demand):** pluggable config **sources** — let
+  an app register an additional file (e.g. `graph.yaml`) that still flows
+  through interpolation/layering/`--resolved`/validation. This is the separate
+  "sources" axis (Spring `spring.config.import`, Viper), distinct from the
+  "sections" (typed namespaces) axis above. Built only when a real need
+  appears.
+
+So this ADR blesses both the immediate `app:` block **and** the typed-section
+destination it grows into; feat-026 carries the full design.
 
 ```yaml
 # agentforge.yaml — after
@@ -157,7 +198,12 @@ app:
 ## 6. References
 
 - Reported in: issue #86 (filed by `agentforge-graph`)
-- Implemented by: [`docs/enhancements/enh-002-app-config-passthrough.md`](../enhancements/enh-002-app-config-passthrough.md)
+- Phase 1 (`app:` field + accessor): [`docs/enhancements/enh-002-app-config-passthrough.md`](../enhancements/enh-002-app-config-passthrough.md)
+- Full capability + phasing: [`docs/features/feat-026-application-config-extension.md`](../features/feat-026-application-config-extension.md)
 - Improves: [`docs/features/feat-012-configuration-system.md`](../features/feat-012-configuration-system.md)
-- Related: [ADR-0013](./0013-configuration-is-data-not-code.md) (config is data),
-  [ADR-0007](./0007-abc-protocol-as-stable-surface.md) (contract stability / minor-bump rule)
+  (esp. `agentforge_core/config/module_schemas.py` — the existing per-section validation engine)
+- Related ADRs: [ADR-0013](./0013-configuration-is-data-not-code.md) (config is data),
+  [ADR-0007](./0007-abc-protocol-as-stable-surface.md) (contract stability / minor-bump rule),
+  [ADR-0004](./0004-module-discovery-via-entry-points.md) (entry-point discovery — reused for section registration)
+- Prior art: Spring Boot `@ConfigurationProperties`; Python `pyproject.toml`
+  `[tool.*]` (PEP 518); Viper (Go) multi-source; Kubernetes CRDs + annotations

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,6 +55,7 @@ Template: [`/.claude/templates/adr.md`](../../.claude/templates/adr.md).
 | [0019](./0019-chatsession-as-wrapper-over-agent.md) | `ChatSession` as wrapper over `Agent` (not a new class) | Accepted | architecture, deployment |
 | [0020](./0020-safety-guardrails-separate-from-legacyluators.md) | Safety guardrails as a separate feature with three ABCs (vs evaluators) | Accepted | architecture, security |
 | [0021](./0021-native-typescript-scaffolding-engine.md) | Native TypeScript scaffolding engine (companion to ADR-0005) | Accepted | scaffolding, upgrade, typescript |
+| [0022](./0022-app-passthrough-for-application-config.md) | Reserved `app:` block for application config in `agentforge.yaml` | Proposed | architecture, config |
 
 ## Process
 

--- a/docs/enhancements/enh-002-app-config-passthrough.md
+++ b/docs/enhancements/enh-002-app-config-passthrough.md
@@ -20,6 +20,15 @@
 | **Target version** | 0.5.0 |
 | **Languages** | `python` (TypeScript to follow under contract parity) |
 | **Improves** | feat-012 (configuration system) |
+| **Phase of** | feat-026 (application config extension) — this is **Phase 1** |
+| **Decision** | [ADR-0022](../adr/0022-app-passthrough-for-application-config.md) |
+
+> **Scope note.** This enhancement is Phase 1 of [feat-026](../features/feat-026-application-config-extension.md):
+> the reserved `app:` namespace + a typed accessor. Phase 2 (framework-validated
+> *registered* sections via entry points, reusing the `module_schemas.py` engine)
+> and Phase 3 (pluggable config sources / separate files) live in feat-026. Phase 1
+> is forward-compatible — an `app.<section>` here becomes a registered section later
+> with no breaking change.
 
 ---
 
@@ -85,7 +94,7 @@ class GraphConfig(BaseModel):
     store: StoreConfig
 
 cfg = load_config("agentforge.yaml")        # framework loader
-graph_cfg = GraphConfig.model_validate(cfg.app["graph"])
+graph_cfg = cfg.app_as(GraphConfig, "graph")  # typed + validated subtree
 ```
 
 ## 4. Backward compatibility
@@ -101,13 +110,30 @@ key becomes accepted.
   `AgentForgeConfig` (`agentforge_core/config/schema.py`). Keep
   `model_config = ConfigDict(strict=True, extra="forbid")` — only `app:`
   is added as a recognized field; everything else stays strict.
+- Add the typed accessor method on `AgentForgeConfig`:
+
+  ```python
+  def app_as(self, model: type[T], key: str | None = None) -> T:
+      """Validate + return an app-config subtree. `key=None` → whole
+      `app:`; else the `app[key]` subtree. The caller's model owns its
+      own strictness, so app-key typos are caught at this call."""
+      raw = self.app if key is None else self.app.get(key, {})
+      return model.model_validate(raw)
+  ```
+
+  This delegates (does not lose) strictness inside `app:` — a derived
+  agent's `extra="forbid"` model still fails fast on its own typos.
 - Confirm the interpolation + layering passes already operate on the raw
   mapping (so values inside `app:` get `${ENV}` resolution and env-file
-  layering with no extra wiring). Add coverage if any pass special-cases
-  known keys.
-- Ensure `config show --resolved` emits the resolved `app:` subtree.
-- The framework performs **no** schema validation inside `app:` — that is
-  the consuming agent's responsibility (documented explicitly).
+  layering with no extra wiring — they do, per `loader.py:_walk` /
+  `_deep_merge`, which run before `model_validate`). Add coverage anyway.
+- Ensure `config show --resolved` emits the resolved `app:` subtree (it
+  does for free — `_run_show` calls `cfg.model_dump(mode="json")`).
+- In Phase 1 the framework performs **no** *registered-schema* validation
+  inside `app:` — that arrives in feat-026 Phase 2 (`config validate`
+  coverage via entry-point sections). Document the Phase-1 boundary
+  explicitly: the subtree is app-owned and validated by the app's own
+  model via `app_as`.
 
 ## 6. Test plan
 
@@ -125,11 +151,13 @@ key becomes accepted.
 |---|---|
 | Apps treat `app:` as a dumping ground / scatter unrelated keys | Document the convention: one namespaced subtree, validated by the app's own model |
 | Users expect the framework to validate inside `app:` | Document clearly that the subtree is app-owned; `config validate` only checks framework keys |
-| Future demand for fully separate app files | `app:` does not preclude an "additional config files" mechanism later (ADR-0022 option 3) — it can layer on top |
+| Future demand for fully separate app files | Deferred to feat-026 Phase 3 (pluggable config **sources**) — `app:` does not preclude it; it layers on top |
+| Users want framework-level validation of `app:` | Arrives in feat-026 Phase 2 (registered sections + `config validate` coverage). Phase 1 delegates validation to the app's own model via `app_as` |
 
 ## 8. References
 
 - Reported in: issue #86 (`agentforge-graph`)
 - Decision: [ADR-0022](../adr/0022-app-passthrough-for-application-config.md)
-- Improves: feat-012 (configuration system)
-- Related: ADR-0013 (configuration is data, not code)
+- Full capability + phasing (this is Phase 1): [feat-026](../features/feat-026-application-config-extension.md)
+- Improves: feat-012 (configuration system) — esp. `module_schemas.py` (the engine Phase 2 reuses)
+- Related: ADR-0013 (configuration is data, not code), ADR-0004 (entry-point discovery)

--- a/docs/enhancements/enh-002-app-config-passthrough.md
+++ b/docs/enhancements/enh-002-app-config-passthrough.md
@@ -1,0 +1,135 @@
+# enh-002: Sanctioned `app:` extension point for application config
+
+> Improves a *shipped* feature (feat-012, configuration system). Filed as
+> issue #86 by `agentforge-graph` while building on agentforge-py 0.2.4.
+> Not a defect — strict validation works as designed; this adds a missing
+> extension point so agents can reuse the framework's config machinery.
+> Design decision recorded in [ADR-0022](../adr/0022-app-passthrough-for-application-config.md).
+
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **ID** | enh-002 |
+| **Title** | Reserved `app:` block for application config in `agentforge.yaml` |
+| **Status** | `proposed` |
+| **Owner** | kjoshi |
+| **Created** | 2026-06-13 |
+| **Target version** | 0.5.0 |
+| **Languages** | `python` (TypeScript to follow under contract parity) |
+| **Improves** | feat-012 (configuration system) |
+
+---
+
+## 1. Summary
+
+Add a single reserved top-level key, `app:`, to `agentforge.yaml` that the
+framework accepts but does not interpret. A consuming agent puts its own
+config under `app:` and validates that subtree with its own Pydantic
+model. Strict validation (`extra="forbid"`) stays in force for every other
+top-level key, so framework-key typos are still caught.
+
+## 2. Motivation
+
+`AgentForgeConfig` is strict, so an agent built on AgentForge cannot put
+its own config in `agentforge.yaml`:
+
+```
+$ agentforge config validate
+agentforge.yaml validation failed:
+  graph: Extra inputs are not permitted
+```
+
+The workaround (a separate `ckg.yaml` loaded by the agent) works but
+misses the framework's `${ENV}` interpolation, layered env-file support,
+and `config show --resolved`. Agents end up re-implementing config
+machinery the framework already has. See issue #86.
+
+## 2.5 Framework-level vs derived-agent-level
+
+**Framework.** The config loader, the `${ENV}` interpolation pass, env-file
+layering, and `config show --resolved` are all framework-owned. A consumer
+cannot grant *their own* config those capabilities without re-implementing
+the loader — exactly the workaround #86 describes.
+
+- **Derived-agent test:** the workaround (separate file + hand-rolled
+  interpolation/layering) re-implements framework-owned config machinery →
+  fails the test → framework work.
+- **How it helps derived agents:** an agent declares its config under
+  `app:` in the one file it already ships, and gets interpolation,
+  layering, and `--resolved` for free — while the framework keeps strict
+  typo-checking on its own keys.
+
+## 3. Before / after
+
+| Aspect | Before | After |
+|---|---|---|
+| App config in `agentforge.yaml` | rejected (`extra="forbid"`) | allowed under `app:` |
+| `${ENV}` interpolation for app config | only via hand-rolled loader | free, under `app:` |
+| `config show --resolved` | framework keys only | includes resolved `app:` |
+| Framework-key typo protection | strict | **still strict** (unchanged) |
+
+```yaml
+# after
+agent: { name: my-agent, model: "anthropic:claude-haiku-4-5" }
+app:
+  graph:
+    store: { path: ${CKG_PATH:.ckg} }
+```
+
+```python
+# consuming agent validates its own subtree
+class GraphConfig(BaseModel):
+    store: StoreConfig
+
+cfg = load_config("agentforge.yaml")        # framework loader
+graph_cfg = GraphConfig.model_validate(cfg.app["graph"])
+```
+
+## 4. Backward compatibility
+
+Additive and safe. `app` defaults to `{}`; existing configs that never set
+it are unaffected. Adding a field with a safe default is a minor bump
+under ADR-0007. No framework behavior changes; only a previously-rejected
+key becomes accepted.
+
+## 5. Implementation sketch
+
+- Add `app: dict[str, Any] = Field(default_factory=dict)` to
+  `AgentForgeConfig` (`agentforge_core/config/schema.py`). Keep
+  `model_config = ConfigDict(strict=True, extra="forbid")` — only `app:`
+  is added as a recognized field; everything else stays strict.
+- Confirm the interpolation + layering passes already operate on the raw
+  mapping (so values inside `app:` get `${ENV}` resolution and env-file
+  layering with no extra wiring). Add coverage if any pass special-cases
+  known keys.
+- Ensure `config show --resolved` emits the resolved `app:` subtree.
+- The framework performs **no** schema validation inside `app:` — that is
+  the consuming agent's responsibility (documented explicitly).
+
+## 6. Test plan
+
+- Unit: a config with an `app:` block validates; an unknown *non-`app`*
+  top-level key (`graph:` at the root) still fails — typo protection
+  intact.
+- Unit: `${ENV}` interpolation and env-file layering resolve values nested
+  under `app:`.
+- Unit: `config show --resolved` includes the resolved `app:` subtree.
+- Doc test / example: the `agentforge-graph` repro from #86 now validates.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Apps treat `app:` as a dumping ground / scatter unrelated keys | Document the convention: one namespaced subtree, validated by the app's own model |
+| Users expect the framework to validate inside `app:` | Document clearly that the subtree is app-owned; `config validate` only checks framework keys |
+| Future demand for fully separate app files | `app:` does not preclude an "additional config files" mechanism later (ADR-0022 option 3) — it can layer on top |
+
+## 8. References
+
+- Reported in: issue #86 (`agentforge-graph`)
+- Decision: [ADR-0022](../adr/0022-app-passthrough-for-application-config.md)
+- Improves: feat-012 (configuration system)
+- Related: ADR-0013 (configuration is data, not code)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -41,6 +41,7 @@
 | **feat-007** | Production rails — cost & resilience (budget, fallback chain, run_id propagation, idempotency) | shipped (Python) | 0.1 | both | `agentforge-core`, `agentforge` |
 | **feat-008** | Findings & output shapes (Simple/Patch/Narrative/MultiSpan + renderers) | shipped (Python) | 0.1 | both | `agentforge`, `agentforge-core` |
 | **feat-009** | Observability — structured logging (JSON) + distributed tracing (OTel) + hook fan-out; vendor backends (Langfuse / Phoenix / Evidently / StatsD) slated for v0.2 | shipped (Python, OTel only) | 0.1 (framework + OTel — shipped), 0.2 (vendor backends) | both | `agentforge`, `agentforge-otel`, future `agentforge-langfuse`, `agentforge-phoenix`, `agentforge-evidently`, `agentforge-statsd` |
+| **feat-026** | Application config extension — reserved `app:` namespace + typed `app_as()` accessor (Phase 1), registered typed sections validated via the module-schema engine + entry points (Phase 2), pluggable config sources / separate files (Phase 3). Lets agents built on AgentForge reuse the config machinery (interpolation, layering, `--resolved`, uniform validation). Reported via #86 | accepted (Phase 1 → 0.5 via enh-002; Phase 2 → 0.6) | 0.5 → 0.6 | both | `agentforge-core`, `agentforge` |
 
 ### Safety & security
 

--- a/docs/features/feat-026-application-config-extension.md
+++ b/docs/features/feat-026-application-config-extension.md
@@ -1,0 +1,240 @@
+# feat-026: Application config extension — typed `app:` sections + pluggable sources
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **ID** | feat-026 |
+| **Title** | Application config extension — reserved `app:` namespace, registered typed sections, pluggable sources |
+| **Status** | accepted (design approved; Phase 1 ships via enh-002 in 0.5.0, Phase 2 in this feat) |
+| **Owner** | kjoshi |
+| **Created** | 2026-06-13 |
+| **Target version** | 0.5 (Phase 1) → 0.6 (Phase 2) |
+| **Languages** | both |
+| **Module package(s)** | `agentforge-core`, `agentforge` |
+| **Depends on** | feat-012 (configuration system) |
+| **Decision** | [ADR-0022](../adr/0022-app-passthrough-for-application-config.md) |
+| **Reported via** | issue #86 (`agentforge-graph`) |
+
+---
+
+## 1. Why this feature
+
+An agent built **on** AgentForge has no sanctioned place for its own
+config in `agentforge.yaml`: the root model is strict
+(`extra="forbid"`), so any unknown top-level key is rejected. The
+workaround — a separate hand-loaded file — forfeits the framework's
+`${ENV}` interpolation, env-overlay layering, `--override`, and
+`config show --resolved`. Agents end up re-implementing config
+machinery the framework already owns (issue #86).
+
+This feature gives application config a first-class, **typed,
+validated** home that reuses every part of the feat-012 machinery —
+the same way the framework already treats **module** config.
+
+## 2. Why it must ship as framework
+
+feat-012's own thesis applies verbatim: *"Every module reads config…
+validation must be uniform; per-module schemas compose."* The
+framework already validates `modules.*.config` against each module's
+`config_schema` via the resolver (`agentforge_core/config/
+module_schemas.py`). Application config validated **differently** —
+or not at all — would be an inconsistency in the framework's own
+design. A consumer cannot grant their own config interpolation,
+layering, `--resolved`, and uniform validation without re-implementing
+the loader. Therefore: framework work.
+
+## 3. How derived agents benefit
+
+- One file (`agentforge.yaml`) holds framework **and** app config.
+- App config gets `${ENV}` interpolation, `agentforge.<env>.yaml`
+  overlays, `--override app.x.y=z`, and `config show --resolved` for
+  free (the loader already interpolates/merges the whole tree before
+  validation — see feat-012 §4.3).
+- `agentforge config validate` catches **app-config** typos too, not
+  just framework-key typos — fail-fast parity with modules.
+- Typed access: `config.app_as(MyConfig, "graph")` instead of
+  hand-walking raw dicts.
+
+## 4. Feature specifications
+
+### 4.1 User-facing experience
+
+```yaml
+# agentforge.yaml
+agent: { name: my-agent, model: "anthropic:claude-haiku-4-5" }
+app:                              # the reserved application namespace
+  graph:
+    store: { path: ${CKG_PATH:.ckg} }    # interpolation applies
+    max_hops: 4
+```
+
+```python
+# the derived agent declares its section schema (strict, so its own
+# keys are typo-checked) and reads it typed:
+from agentforge_core.config import load_config
+
+class GraphConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    store: StoreConfig
+    max_hops: int = 3
+
+cfg = load_config()
+graph = cfg.app_as(GraphConfig, "graph")     # validated GraphConfig
+```
+
+```
+$ agentforge config validate
+# with a registered section schema (Phase 2), a typo under app.graph
+# fails here, e.g.:  app.graph.max_hopz: Extra inputs are not permitted
+```
+
+### 4.2 Public API / contract
+
+```python
+# agentforge_core/config/schema.py — AgentForgeConfig (additive field + method)
+class AgentForgeConfig(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")   # unchanged
+    app: dict[str, Any] = Field(default_factory=dict)        # NEW — reserved namespace
+
+    def app_as(self, model: type[T], key: str | None = None) -> T:
+        """Validate and return an app-config subtree.
+
+        `key=None` validates the whole `app:` block; otherwise the
+        `app[key]` subtree. The caller's model owns its own strictness.
+        """
+        raw = self.app if key is None else self.app.get(key, {})
+        return model.model_validate(raw)
+```
+
+```python
+# Phase 2 — registration mirrors module config_schema discovery (ADR-0004).
+# A derived agent / plugin declares an entry point per app-config section:
+#
+#   [project.entry-points."agentforge.config_sections"]
+#   graph = "agentforge_graph.config:GraphConfig"
+#
+# The framework discovers these and validates the matching app.<section>.
+def validate_app_config(cfg: AgentForgeConfig, *, strict: bool = True) -> None:
+    """Validate each registered `app.<section>` against its schema.
+
+    Mirrors `validate_module_configs`: unknown/unregistered sections are
+    allowed (free-form, like an undocumented `[tool.x]`); registered
+    sections are validated strictly. Wired into `agentforge config validate`.
+    """
+    for section, model in _discover_app_sections():
+        if section in cfg.app:
+            _validate_section(section, model, cfg.app[section], strict=strict)
+```
+
+Adding the `app` field and `app_as` method is **additive** →
+minor bump (ADR-0007). The `extra="forbid"` model config is unchanged;
+only `app:` is added as a recognized key, so every other unknown
+top-level key still fails fast.
+
+### 4.3 Internal mechanics
+
+- **Free machinery (no new code):** `loader.py` already runs
+  `_walk` (interpolation) and `_deep_merge` (overlay + `--override`)
+  over the raw mapping *before* `model_validate`, and
+  `config show --resolved` already does `cfg.model_dump()`. So
+  interpolation, layering, overrides, and the resolved view cover
+  `app:` the moment the field exists.
+- **Section validation (Phase 2)** reuses the resolver +
+  `config_schema` pattern from `module_schemas.py`. A new entry-point
+  group `agentforge.config_sections` maps `app.<section>` → Pydantic
+  model. `strict=False` mode (as in `validate_module_configs`) lets
+  `config validate` run against sections whose package isn't installed.
+
+### 4.4 Sections vs sources (the two axes)
+
+This feature deliberately separates two concerns that are often
+conflated:
+
+- **Sections** (this feat, Phases 1–2): *typed, namespaced* config
+  under `app:`. Pattern: Spring Boot `@ConfigurationProperties(prefix)`,
+  Python `pyproject.toml` `[tool.<name>]`. Each owner validates its
+  own subtree.
+- **Sources** (Phase 3, deferred): *where config comes from*. Today the
+  loader has a fixed source list (base file → `agentforge.<env>.yaml`
+  overlay → env interpolation → `--override`). Phase 3 generalizes this
+  into an ordered, pluggable source list so an app can register an
+  **additional file** (e.g. `graph.yaml`) that still flows through
+  interpolation, layering, `--resolved`, and validation. Pattern:
+  Spring `spring.config.import`, Viper multi-source, kustomize layers.
+  Built only on demand — it directly answers the "tomorrow someone
+  wants their own config file" need without forfeiting the machinery.
+
+### 4.5 Phasing
+
+| Phase | Scope | Ships in | Spec |
+|---|---|---|---|
+| **1** | `app:` field + `app_as()` accessor + docs | **0.5.0** | [enh-002](../enhancements/enh-002-app-config-passthrough.md) |
+| **2** | Registered typed sections (entry points) + `config validate` coverage | 0.6 | this feat |
+| **3** | Pluggable config **sources** (extra files) | on demand | this feat §4.4 |
+
+Phase 1 is a forward-compatible slice: `app.<section>` becomes a
+registered section in Phase 2 with **no breaking change** — the raw
+dict simply gains framework validation.
+
+## 5. Plug-and-play & upgrade story
+
+`app:` defaults to `{}`; existing configs are unaffected (additive).
+A scaffolded agent can adopt app config incrementally: drop keys under
+`app:` (free-form) → add an `app_as` model for typed access → register
+the section (Phase 2) for `config validate` coverage. Each step is
+optional and non-breaking.
+
+## 6. Cross-language parity
+
+The TypeScript runtime mirrors the same shape: a reserved `app`
+property on the root config object, a typed `appAs(schema, key)`
+accessor (Zod), and (Phase 2) section registration via npm
+`exports`-based discovery, consistent with ADR-0002 / ADR-0004.
+
+## 7. Test strategy
+
+- **Phase 1 unit:** `app:` block validates; an unknown *non-`app`*
+  top-level key still fails (typo protection intact); `${ENV}`
+  interpolation + env-overlay + `--override` resolve values nested
+  under `app:`; `config show --resolved` includes the resolved `app:`;
+  `app_as` returns the validated model and raises on a bad subtree.
+- **Phase 2 unit:** a registered section schema validates `app.<section>`
+  during `config validate`; a typo under a registered section fails;
+  an unregistered section is left untouched; `strict=False` tolerates a
+  not-yet-installed section package.
+- **Doc test:** the `agentforge-graph` repro from #86 validates.
+
+## 8. Risks & open questions
+
+| Risk / question | Disposition |
+|---|---|
+| Apps scatter unrelated keys under `app:` | Document the convention: namespace by concern (`app.graph`, `app.telemetry`); one model per section |
+| Users expect the framework to validate `app:` even in Phase 1 | Phase 1 docs state the subtree is app-owned until a section schema is registered (Phase 2) |
+| Section registration couples `config validate` to app packages being importable | Mirror `validate_module_configs` `strict=False` to degrade gracefully |
+| Open: should Phase 2 allow registered **top-level** prefixes (not just under `app:`)? | Default **no** — keep the single `app:` boundary (pyproject `[tool.*]` model). Revisit only if a strong case appears |
+
+## 9. Out of scope
+
+- Loosening `extra="forbid"` on framework keys (rejected in ADR-0022).
+- Turing-complete config / templating (ADR-0013 stands).
+- Phase 3 pluggable sources beyond the design sketch in §4.4 (built on
+  demand).
+
+## 10. References
+
+- Decision: [ADR-0022](../adr/0022-app-passthrough-for-application-config.md)
+- Phase 1 spec: [enh-002](../enhancements/enh-002-app-config-passthrough.md)
+- Builds on: [feat-012](./feat-012-configuration-system.md) (config system)
+- Reported via: issue #86 (`agentforge-graph`)
+- Prior art: Spring Boot `@ConfigurationProperties`; Python `pyproject.toml`
+  `[tool.*]` (PEP 518); Viper (Go) multi-source; Kubernetes CRDs + annotations
+- Related ADRs: [ADR-0013](../adr/0013-configuration-is-data-not-code.md),
+  [ADR-0007](../adr/0007-abc-protocol-as-stable-surface.md),
+  [ADR-0004](../adr/0004-module-discovery-via-entry-points.md)
+
+## Implementation status
+
+Not started. Design approved 2026-06-13 (this spec + revised ADR-0022).
+Phase 1 (`app:` field + `app_as`) is specified in enh-002 and targeted
+at 0.5.0; Phase 2 (registered sections) targeted at 0.6.


### PR DESCRIPTION
## What

Design docs for issue #86 — *no sanctioned place for app-level config in `agentforge.yaml`*. **Design only; no implementation in this PR.**

- **ADR-0022** (status: *Proposed*) — records the decision and the five options weighed.
- **enh-002** — the enhancement spec (improves feat-012), with implementation sketch + test plan.
- ADR index (`docs/adr/README.md`) updated.

## Decision

Add a reserved top-level **`app:`** block that the validator accepts but does not interpret. The consuming agent validates its own `app:` subtree with its own Pydantic model.

- `extra="forbid"` stays for **all framework keys** → typo protection (`agnet:`) preserved.
- App config rides in the same file and reuses `${ENV}` interpolation, env-file layering, and `config show --resolved`.
- Additive field with a safe default (`{}`) → minor bump per ADR-0007. Stays declarative data (ADR-0013).

```yaml
agent: { name: my-agent, model: "anthropic:claude-haiku-4-5" }
app:
  graph:
    store: { path: ${CKG_PATH:.ckg} }   # interpolation now applies
```

## Why these docs, not code

#86 is an enhancement that changes the locked `AgentForgeConfig` contract, so it warrants an ADR + spec for review **before** implementation. Implementation lands in a follow-up PR once the ADR is accepted.

## Status / next steps

- [ ] Review + accept ADR-0022 (flip status `Proposed` → `Accepted`)
- [ ] Follow-up PR: implement enh-002 (config field + interpolation/`--resolved` coverage + tests)

Refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)