### PR TITLE
feat(config): application config extension — `app:` namespace + validated sections (feat-026 Phases 1 & 2, #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ release tag bumps every workspace member to the same minor version.
 
 ## [Unreleased]
 
+### Added
+
+- **enh-002 / feat-026 Phase 1 — reserved `app:` namespace.**
+  `agentforge.yaml` now accepts a top-level `app:` block for
+  **application** config. The framework stores the subtree but does not
+  interpret it; a consuming agent validates it with its own Pydantic
+  model via the new `AgentForgeConfig.app_as(model, key=None)` accessor
+  (`key=None` → whole `app:`; otherwise the `app[key]` subtree). Values
+  under `app:` ride the existing loader passes, so they get `${ENV}`
+  interpolation, env-file layering, dotted-path overrides, and
+  `config show --resolved` for free. Every other top-level key stays
+  strict (`extra="forbid"`), so framework-key typos are still caught.
+  Resolves issue #86 (raised by a derived agent that needed its own
+  config in the one file it already ships). Adding a field with a safe
+  default is a minor bump under ADR-0007. See
+  [ADR-0022](docs/adr/0022-app-passthrough-for-application-config.md).
+
 ### Fixed
 
 - **bug-021 (P1):** `agentforge add module` / `remove module` now use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ release tag bumps every workspace member to the same minor version.
   default is a minor bump under ADR-0007. See
   [ADR-0022](docs/adr/0022-app-passthrough-for-application-config.md).
 
+- **feat-026 Phase 2 — registered, validated `app:` sections.** A
+  derived agent or plugin can register a Pydantic schema per
+  `app.<section>` via a new `agentforge.config_sections` entry-point
+  group (mirroring module discovery, ADR-0004):
+
+  ```toml
+  [project.entry-points."agentforge.config_sections"]
+  graph = "agentforge_graph.config:GraphConfig"
+  ```
+
+  `agentforge config validate` now validates each registered section
+  present under `app:` — the same fail-fast parity `modules.*` already
+  has. Registered sections are checked strictly; unregistered sections
+  stay free-form (like an undocumented `[tool.x]` in `pyproject.toml`);
+  a section whose package isn't installed is simply not discovered, so
+  validation degrades gracefully. New public helpers
+  `discover_app_sections()` and `validate_app_config()` in
+  `agentforge_core.config`. See
+  [feat-026](docs/features/feat-026-application-config-extension.md).
+
 ### Fixed
 
 - **bug-021 (P1):** `agentforge add module` / `remove module` now use

--- a/docs/adr/0022-app-passthrough-for-application-config.md
+++ b/docs/adr/0022-app-passthrough-for-application-config.md
@@ -6,7 +6,7 @@
 |---|---|
 | **Number** | 0022 |
 | **Title** | Reserved `app:` block for application config in `agentforge.yaml` |
-| **Status** | Proposed |
+| **Status** | Accepted |
 | **Date** | 2026-06-13 |
 | **Deciders** | kjoshi |
 | **Tags** | architecture, config |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,7 +55,7 @@ Template: [`/.claude/templates/adr.md`](../../.claude/templates/adr.md).
 | [0019](./0019-chatsession-as-wrapper-over-agent.md) | `ChatSession` as wrapper over `Agent` (not a new class) | Accepted | architecture, deployment |
 | [0020](./0020-safety-guardrails-separate-from-legacyluators.md) | Safety guardrails as a separate feature with three ABCs (vs evaluators) | Accepted | architecture, security |
 | [0021](./0021-native-typescript-scaffolding-engine.md) | Native TypeScript scaffolding engine (companion to ADR-0005) | Accepted | scaffolding, upgrade, typescript |
-| [0022](./0022-app-passthrough-for-application-config.md) | Reserved `app:` block for application config in `agentforge.yaml` | Proposed | architecture, config |
+| [0022](./0022-app-passthrough-for-application-config.md) | Reserved `app:` block for application config in `agentforge.yaml` | Accepted | architecture, config |
 
 ## Process
 

--- a/docs/enhancements/enh-002-app-config-passthrough.md
+++ b/docs/enhancements/enh-002-app-config-passthrough.md
@@ -14,7 +14,7 @@
 |---|---|
 | **ID** | enh-002 |
 | **Title** | Reserved `app:` block for application config in `agentforge.yaml` |
-| **Status** | `proposed` |
+| **Status** | `shipped` (0.5.0) |
 | **Owner** | kjoshi |
 | **Created** | 2026-06-13 |
 | **Target version** | 0.5.0 |
@@ -154,7 +154,20 @@ key becomes accepted.
 | Future demand for fully separate app files | Deferred to feat-026 Phase 3 (pluggable config **sources**) — `app:` does not preclude it; it layers on top |
 | Users want framework-level validation of `app:` | Arrives in feat-026 Phase 2 (registered sections + `config validate` coverage). Phase 1 delegates validation to the app's own model via `app_as` |
 
-## 8. References
+## 8. Implementation status
+
+**Shipped in 0.5.0.** `app: dict[str, Any] = Field(default_factory=dict)`
+and `AgentForgeConfig.app_as(model, key=None)` added to
+`agentforge_core/config/schema.py`; `model_config` stays
+`strict=True, extra="forbid"`. No loader changes were needed —
+interpolation (`_walk`), env-file layering (`_deep_merge`), dotted
+overrides, and the `config show --resolved` dump all already operate on
+the raw mapping before `model_validate`, so `app:` rides them for free
+(verified by tests, not assumed). Covered by
+`packages/agentforge-core/tests/unit/test_config_app_passthrough.py`
+(11 tests, all green; mypy `--strict` clean). ADR-0022 accepted.
+
+## 9. References
 
 - Reported in: issue #86 (`agentforge-graph`)
 - Decision: [ADR-0022](../adr/0022-app-passthrough-for-application-config.md)

--- a/docs/features/feat-026-application-config-extension.md
+++ b/docs/features/feat-026-application-config-extension.md
@@ -235,6 +235,22 @@ accessor (Zod), and (Phase 2) section registration via npm
 
 ## Implementation status
 
-Not started. Design approved 2026-06-13 (this spec + revised ADR-0022).
-Phase 1 (`app:` field + `app_as`) is specified in enh-002 and targeted
-at 0.5.0; Phase 2 (registered sections) targeted at 0.6.
+**Phase 1 — shipped (0.5.0).** The reserved `app:` namespace
+(`dict[str, Any]`, default `{}`) and the typed accessor
+`AgentForgeConfig.app_as(model, key=None)` landed in
+`agentforge_core/config/schema.py` per enh-002. `app:` rides the
+existing loader passes, so values get `${ENV}` interpolation, env-file
+layering, dotted-path overrides, and `config show --resolved` with no
+extra wiring; framework keys stay strict (`extra="forbid"`). Covered by
+`tests/unit/test_config_app_passthrough.py` (11 tests: field default,
+acceptance, intact typo-protection on non-`app` keys, `app_as` keyed /
+whole / missing-key / delegated-strictness, interpolation + env-file
+layering inside `app:`, and resolved-dump inclusion). ADR-0022 accepted.
+
+**Phase 2 — not started.** Registered typed sections via the
+`agentforge.config_sections` entry-point group, validated in
+`agentforge config validate` by reusing the `module_schemas.py` engine.
+Targeted at 0.6.
+
+**Phase 3 — not started.** Pluggable config *sources* (separate files,
+`spring.config.import`-style). On demand.

--- a/docs/features/feat-026-application-config-extension.md
+++ b/docs/features/feat-026-application-config-extension.md
@@ -6,10 +6,10 @@
 |---|---|
 | **ID** | feat-026 |
 | **Title** | Application config extension — reserved `app:` namespace, registered typed sections, pluggable sources |
-| **Status** | accepted (design approved; Phase 1 ships via enh-002 in 0.5.0, Phase 2 in this feat) |
+| **Status** | accepted — Phases 1 & 2 shipped in 0.5.0; Phase 3 on demand |
 | **Owner** | kjoshi |
 | **Created** | 2026-06-13 |
-| **Target version** | 0.5 (Phase 1) → 0.6 (Phase 2) |
+| **Target version** | 0.5.0 (Phases 1 & 2) → on-demand (Phase 3) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-core`, `agentforge` |
 | **Depends on** | feat-012 (configuration system) |
@@ -169,8 +169,8 @@ conflated:
 
 | Phase | Scope | Ships in | Spec |
 |---|---|---|---|
-| **1** | `app:` field + `app_as()` accessor + docs | **0.5.0** | [enh-002](../enhancements/enh-002-app-config-passthrough.md) |
-| **2** | Registered typed sections (entry points) + `config validate` coverage | 0.6 | this feat |
+| **1** | `app:` field + `app_as()` accessor + docs | **0.5.0** ✅ | [enh-002](../enhancements/enh-002-app-config-passthrough.md) |
+| **2** | Registered typed sections (entry points) + `config validate` coverage | **0.5.0** ✅ | this feat |
 | **3** | Pluggable config **sources** (extra files) | on demand | this feat §4.4 |
 
 Phase 1 is a forward-compatible slice: `app.<section>` becomes a
@@ -247,10 +247,21 @@ acceptance, intact typo-protection on non-`app` keys, `app_as` keyed /
 whole / missing-key / delegated-strictness, interpolation + env-file
 layering inside `app:`, and resolved-dump inclusion). ADR-0022 accepted.
 
-**Phase 2 — not started.** Registered typed sections via the
-`agentforge.config_sections` entry-point group, validated in
-`agentforge config validate` by reusing the `module_schemas.py` engine.
-Targeted at 0.6.
+**Phase 2 — shipped (0.5.0).** Registered typed sections via the new
+`agentforge.config_sections` entry-point group. A derived agent maps
+`app.<section>` → a Pydantic schema; `discover_app_sections()` scans the
+group and `validate_app_config(cfg)` validates each registered section
+present in `app:` (`agentforge_core/config/app_sections.py`), mirroring
+`validate_module_configs`: registered sections are strict, unregistered
+ones stay free-form, and a not-installed section's package simply isn't
+discovered (graceful degradation, no special-casing). Wired into
+`agentforge config validate` after module validation. The runtime
+resolver skips the `config_sections` group so schemas don't pollute the
+module registry (`resolver/discover.py`). Covered by
+`tests/unit/test_config_app_sections.py` (11), the resolver-exclusion
+test, and three CLI tests in `agentforge/tests/unit/test_cli_config.py`.
+Brought forward from 0.6 — ships alongside Phase 1 in the same 0.5.0
+release train.
 
 **Phase 3 — not started.** Pluggable config *sources* (separate files,
 `spring.config.import`-style). On demand.

--- a/docs/features/feat-026-application-config-extension.md
+++ b/docs/features/feat-026-application-config-extension.md
@@ -261,7 +261,13 @@ module registry (`resolver/discover.py`). Covered by
 `tests/unit/test_config_app_sections.py` (11), the resolver-exclusion
 test, and three CLI tests in `agentforge/tests/unit/test_cli_config.py`.
 Brought forward from 0.6 — ships alongside Phase 1 in the same 0.5.0
-release train.
+release train. Beyond the monkeypatched unit tests, a real end-to-end
+suite (`tests/integration/test_app_sections_real_discovery.py`, 6 tests)
+proves the path with **no mocking**: it lays down a real `.dist-info` +
+`entry_points.txt` on `sys.path` so actual `importlib.metadata`
+discovery resolves the section, and runs the real `agentforge config
+validate` binary in a subprocess against it (valid → exit 0; typo →
+exit 1).
 
 **Phase 3 — not started.** Pluggable config *sources* (separate files,
 `spring.config.import`-style). On demand.

--- a/packages/agentforge-core/src/agentforge_core/config/__init__.py
+++ b/packages/agentforge-core/src/agentforge_core/config/__init__.py
@@ -20,6 +20,10 @@ bump; removing or renaming requires a major bump.
 
 from __future__ import annotations
 
+from agentforge_core.config.app_sections import (
+    discover_app_sections,
+    validate_app_config,
+)
 from agentforge_core.config.loader import load_config, parse_overrides
 from agentforge_core.config.module_schemas import validate_module_configs
 from agentforge_core.config.schema import (
@@ -56,7 +60,9 @@ __all__ = [
     "RerankerEntry",
     "RetrievalConfig",
     "RetrieverModuleConfig",
+    "discover_app_sections",
     "load_config",
     "parse_overrides",
+    "validate_app_config",
     "validate_module_configs",
 ]

--- a/packages/agentforge-core/src/agentforge_core/config/app_sections.py
+++ b/packages/agentforge-core/src/agentforge_core/config/app_sections.py
@@ -1,0 +1,124 @@
+"""Registered app-config section validation (feat-026 Phase 2).
+
+Phase 1 (enh-002) added the reserved ``app:`` namespace and the
+``app_as`` accessor: the framework stored the subtree but validated
+nothing inside it — a derived agent owned validation entirely. Phase 2
+closes the parity gap with *module* config. A derived agent or plugin
+registers a Pydantic schema per ``app.<section>`` through a new
+entry-point group, exactly mirroring how modules register their classes
+(ADR-0004)::
+
+    [project.entry-points."agentforge.config_sections"]
+    graph = "agentforge_graph.config:GraphConfig"
+
+``agentforge config validate`` then validates each registered section
+the same way :func:`validate_module_configs` validates ``modules.*``:
+
+- A section present in ``app:`` **and** registered → validated strictly
+  against its schema; a typo or bad value fails the command.
+- A section present in ``app:`` but **not** registered → left untouched
+  (free-form, like an undocumented ``[tool.x]`` in ``pyproject.toml``).
+- A registered section **absent** from ``app:`` → nothing to validate.
+- A section whose package isn't installed → simply never discovered, so
+  validation degrades gracefully with no special-casing (the lenient
+  behaviour ``validate_module_configs`` gets from ``strict=False``).
+
+This keeps the single ``app:`` boundary (feat-026 §8): registration maps
+names *under* ``app:`` to schemas; it never opens new top-level keys.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+
+from agentforge_core.production.exceptions import ModuleError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from agentforge_core.config.schema import AgentForgeConfig
+
+_log = logging.getLogger("agentforge.config")
+
+#: Entry-point group mapping an ``app.<section>`` name to a Pydantic
+#: schema. Parallel to the ``agentforge.<category>`` groups the resolver
+#: scans, but consumed here rather than by the runtime resolver (the
+#: resolver skips this group — see ``resolver.discover``).
+SECTIONS_GROUP = "agentforge.config_sections"
+
+
+def discover_app_sections() -> dict[str, type[BaseModel]]:
+    """Scan the ``agentforge.config_sections`` entry-point group.
+
+    Returns a mapping of section name → Pydantic model class. Entries
+    that fail to import, or whose target is not a ``BaseModel`` subclass,
+    are skipped with a warning. On a duplicate name across distributions
+    the first registration wins (matches the resolver's §8 conflict
+    rule).
+    """
+    sections: dict[str, type[BaseModel]] = {}
+    for ep in entry_points(group=SECTIONS_GROUP):
+        if ep.name in sections:
+            _log.warning(
+                "duplicate app-config section %r ignored (first registration wins)",
+                ep.name,
+            )
+            continue
+        try:
+            model = ep.load()
+        except Exception as exc:
+            _log.warning(
+                "skipping app-config section %r: load failed (%s: %s)",
+                ep.name,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+        if not (isinstance(model, type) and issubclass(model, BaseModel)):
+            _log.warning(
+                "skipping app-config section %r: %r is not a pydantic BaseModel subclass",
+                ep.name,
+                model,
+            )
+            continue
+        sections[ep.name] = model
+    return sections
+
+
+def validate_app_config(
+    cfg: AgentForgeConfig,
+    *,
+    sections: Mapping[str, type[BaseModel]] | None = None,
+) -> None:
+    """Validate each registered ``app.<section>`` against its schema.
+
+    Mirrors :func:`validate_module_configs`. Only sections that are both
+    present in ``cfg.app`` and registered via an entry point are checked;
+    unregistered sections are left untouched (free-form). A registered
+    section that fails its schema always raises :class:`ModuleError` —
+    validation failures are fatal, the same as for module config.
+
+    Args:
+        cfg: a loaded :class:`AgentForgeConfig` (post-``load_config``).
+        sections: pre-discovered section map. Defaults to
+            :func:`discover_app_sections`; injectable so tests (and
+            future callers with a cached registry) can supply their own.
+
+    Raises:
+        ModuleError: a registered ``app.<section>`` subtree fails its
+            schema.
+    """
+    registry = sections if sections is not None else discover_app_sections()
+    for name, model in registry.items():
+        if name not in cfg.app:
+            continue
+        try:
+            model.model_validate(cfg.app[name])
+        except ValidationError as exc:
+            raise ModuleError(
+                f"app.{name} failed validation: {exc.errors(include_url=False)}"
+            ) from exc

--- a/packages/agentforge-core/src/agentforge_core/config/schema.py
+++ b/packages/agentforge-core/src/agentforge_core/config/schema.py
@@ -15,9 +15,11 @@ is the data-side representation.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_AppModelT = TypeVar("_AppModelT", bound=BaseModel)
 
 
 def _normalise_named_entry(value: Any) -> Any:
@@ -470,3 +472,34 @@ class AgentForgeConfig(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
     guardrail_policy: GuardrailPolicy = Field(default_factory=GuardrailPolicy)
+    app: dict[str, Any] = Field(default_factory=dict)
+    """Reserved namespace for **application** config (enh-002, feat-026
+    Phase 1). The framework accepts this subtree but does not interpret
+    it: a consuming agent puts its own config here and validates it with
+    its own Pydantic model via :meth:`app_as`. Every other top-level key
+    stays strict (`extra="forbid"`), so framework-key typos are still
+    caught. Values inside `app:` get `${ENV}` interpolation, env-file
+    layering, dotted-path overrides, and `config show --resolved` for
+    free — they ride the same loader passes as framework keys. The
+    framework performs no *registered-schema* validation inside `app:`
+    in Phase 1; that arrives in feat-026 Phase 2."""
+
+    def app_as(self, model: type[_AppModelT], key: str | None = None) -> _AppModelT:
+        """Validate and return an application-config subtree.
+
+        `key=None` validates the whole `app:` mapping; otherwise the
+        `app[key]` subtree (missing key → empty mapping, so the caller's
+        model supplies its own defaults). The caller's model owns its own
+        strictness, so app-key typos surface here — strictness is
+        delegated into `app:`, not lost.
+
+        Example::
+
+            class GraphConfig(BaseModel):
+                store: StoreConfig
+
+
+            graph_cfg = cfg.app_as(GraphConfig, "graph")
+        """
+        raw = self.app if key is None else self.app.get(key, {})
+        return model.model_validate(raw)

--- a/packages/agentforge-core/src/agentforge_core/resolver/discover.py
+++ b/packages/agentforge-core/src/agentforge_core/resolver/discover.py
@@ -34,6 +34,12 @@ _log = logging.getLogger("agentforge.resolver")
 
 _GROUP_PREFIX = "agentforge."
 
+# Groups under `agentforge.*` that are NOT runtime-resolver categories.
+# `config_sections` maps app-config section names to pydantic schemas
+# (feat-026 Phase 2); it is consumed by `config.app_sections`, not the
+# resolver, so skip it here to keep schemas out of the module registry.
+_NON_RESOLVER_GROUPS = frozenset({"config_sections"})
+
 # Module-level state held on a mutable list to avoid `global` (PLW0603).
 _discovered: list[bool] = [False]
 # Cache of resolved ModuleInfo per registered entry — keyed by
@@ -75,6 +81,8 @@ def discover_entry_points(resolver: Resolver, *, force: bool = False) -> int:
         if not ep.group.startswith(_GROUP_PREFIX):
             continue
         category = ep.group[len(_GROUP_PREFIX) :]
+        if category in _NON_RESOLVER_GROUPS:
+            continue
         try:
             cls = ep.load()
         except Exception as exc:

--- a/packages/agentforge-core/tests/integration/test_app_sections_real_discovery.py
+++ b/packages/agentforge-core/tests/integration/test_app_sections_real_discovery.py
@@ -1,0 +1,170 @@
+"""Real end-to-end discovery test for feat-026 Phase 2 — *no* mocking.
+
+`test_config_app_sections.py` (unit) injects a section map or
+monkeypatches `entry_points`. This test goes the whole way: it drops a
+**real installed distribution** on `sys.path` — a real `.dist-info` with
+a real `entry_points.txt` declaring the `agentforge.config_sections`
+group, plus a real importable module exposing the schema class — and
+exercises the actual `importlib.metadata` discovery path:
+
+- `discover_app_sections()` finds the section via real entry-point
+  resolution and `ep.load()` imports the real schema class.
+- `validate_app_config()` validates a real `app.<section>` subtree
+  against that freshly-imported schema, and rejects a typo.
+
+This is the proof the monkeypatched tests can't give: that a derived
+agent declaring `[project.entry-points."agentforge.config_sections"]` in
+its own `pyproject.toml` is actually discovered and validated.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+import subprocess  # nosec B404 — fixed argv, no shell
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from agentforge_core.config import (
+    AgentForgeConfig,
+    discover_app_sections,
+    validate_app_config,
+)
+from agentforge_core.production.exceptions import ModuleError
+
+_MODULE = "af_fake_section_pkg"
+_DIST = "af-fake-section"
+_SECTION = "graph"
+_ATTR = "GraphConfig"
+
+
+def _install_fake_dist(site: Path) -> None:
+    """Lay down a real importable module + a real `.dist-info` whose
+    `entry_points.txt` registers our section — the on-disk shape pip / uv
+    produce when a package declares the entry point."""
+    (site / f"{_MODULE}.py").write_text(
+        textwrap.dedent(
+            f"""
+            from pydantic import BaseModel, ConfigDict
+
+            class _Store(BaseModel):
+                model_config = ConfigDict(strict=True, extra="forbid")
+                path: str
+
+            class {_ATTR}(BaseModel):
+                model_config = ConfigDict(strict=True, extra="forbid")
+                store: _Store
+                max_hops: int = 3
+            """
+        )
+    )
+    dist_info = site / f"{_DIST.replace('-', '_')}-1.0.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {_DIST}\nVersion: 1.0.0\n")
+    (dist_info / "entry_points.txt").write_text(
+        f"[agentforge.config_sections]\n{_SECTION} = {_MODULE}:{_ATTR}\n"
+    )
+
+
+@pytest.fixture
+def fake_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Install the fake distribution on a throwaway site dir, put it on
+    `sys.path`, and tear it all down afterwards."""
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _install_fake_dist(site)
+    monkeypatch.syspath_prepend(str(site))
+    importlib.invalidate_caches()
+    try:
+        yield
+    finally:
+        sys.modules.pop(_MODULE, None)
+
+
+def test_real_entry_point_is_discovered(fake_section: None) -> None:
+    found = discover_app_sections()
+    assert _SECTION in found, "real entry point was not discovered via importlib.metadata"
+    assert found[_SECTION].__name__ == _ATTR
+
+
+def test_real_section_validates_ok(fake_section: None) -> None:
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {_SECTION: {"store": {"path": ".ckg"}, "max_hops": 4}}}
+    )
+    # Real discovery + real schema, no injected registry → must not raise.
+    validate_app_config(cfg)
+
+
+def test_real_section_typo_is_rejected(fake_section: None) -> None:
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {_SECTION: {"store": {"path": ".ckg"}, "max_hopz": 4}}}
+    )
+    with pytest.raises(ModuleError) as exc:
+        validate_app_config(cfg)
+    assert f"app.{_SECTION}" in str(exc.value)
+
+
+def test_unregistered_section_untouched_with_real_discovery(fake_section: None) -> None:
+    """Even with a real registered `graph` section discovered, an
+    *unregistered* sibling section stays free-form."""
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {"telemetry": {"whatever": "is fine", "deeply": {"nested": 1}}}}
+    )
+    validate_app_config(cfg)  # graph not present; telemetry unregistered → no raise
+
+
+# --- full CLI subprocess e2e: the real `agentforge` binary --------
+
+
+def _agentforge_bin() -> str | None:
+    """The installed `agentforge` console script next to this interpreter."""
+    candidate = Path(sys.executable).parent / "agentforge"
+    if candidate.exists():
+        return str(candidate)
+    return shutil.which("agentforge")
+
+
+def _run_validate(site: Path, yaml_path: Path) -> subprocess.CompletedProcess[str]:
+    """Run `agentforge config validate` in a real subprocess with the
+    fake distribution discoverable via PYTHONPATH (so the child's own
+    `importlib.metadata` finds the entry point — no in-process state)."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(site), *([p] if (p := env.get("PYTHONPATH")) else [])])
+    return subprocess.run(  # nosec B603 — fixed argv, no shell
+        [_agentforge_bin() or "agentforge", "config", "validate", "--path", str(yaml_path)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(_agentforge_bin() is None, reason="agentforge console script not installed")
+def test_cli_subprocess_validates_registered_section(tmp_path: Path) -> None:
+    """End-to-end: the real `agentforge` binary discovers a real installed
+    `agentforge.config_sections` entry point and validates `app.graph`."""
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _install_fake_dist(site)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: .ckg\n    max_hops: 4\n")
+
+    result = _run_validate(site, yaml_path)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+@pytest.mark.skipif(_agentforge_bin() is None, reason="agentforge console script not installed")
+def test_cli_subprocess_rejects_section_typo(tmp_path: Path) -> None:
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _install_fake_dist(site)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: .ckg\n    max_hopz: 4\n")
+
+    result = _run_validate(site, yaml_path)
+    assert result.returncode == 1
+    assert "app.graph" in result.stderr

--- a/packages/agentforge-core/tests/unit/test_config_app_passthrough.py
+++ b/packages/agentforge-core/tests/unit/test_config_app_passthrough.py
@@ -1,0 +1,154 @@
+"""Unit tests for the reserved ``app:`` passthrough namespace
+(enh-002, feat-026 Phase 1).
+
+The framework accepts an ``app:`` subtree in ``agentforge.yaml`` but
+does not interpret it: a consuming agent validates that subtree with
+its own Pydantic model via :meth:`AgentForgeConfig.app_as`. Every other
+top-level key stays strict (``extra="forbid"``). Values under ``app:``
+ride the same loader passes as framework keys, so they get ``${ENV}``
+interpolation, env-file layering, and ``config show --resolved`` for
+free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentforge_core.config import AgentForgeConfig, load_config
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+# --- the field exists and defaults to {} -------------------------
+
+
+def test_app_defaults_to_empty_mapping() -> None:
+    cfg = AgentForgeConfig()
+    assert cfg.app == {}
+
+
+def test_app_block_is_accepted(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text(
+        """
+agent:
+  model: anthropic:claude-haiku-4-5
+app:
+  graph:
+    store:
+      path: .ckg
+"""
+    )
+    cfg = load_config(yaml_path)
+    assert cfg.app["graph"]["store"]["path"] == ".ckg"
+
+
+# --- typo protection on framework keys is unchanged --------------
+
+
+def test_unknown_root_key_outside_app_still_rejected(tmp_path: Path) -> None:
+    """A stray top-level key (not ``app``) still fails strict validation —
+    typo protection is intact."""
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("graph:\n  store:\n    path: .ckg\n")
+    with pytest.raises(ValidationError) as exc:
+        load_config(yaml_path)
+    assert "graph" in str(exc.value)
+
+
+# --- app_as: typed + validated subtree ---------------------------
+
+
+class _StoreConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+
+
+class _GraphConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    store: _StoreConfig
+
+
+def test_app_as_validates_keyed_subtree(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: .ckg\n")
+    cfg = load_config(yaml_path)
+    graph_cfg = cfg.app_as(_GraphConfig, "graph")
+    assert isinstance(graph_cfg, _GraphConfig)
+    assert graph_cfg.store.path == ".ckg"
+
+
+def test_app_as_whole_block_when_key_none(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  store:\n    path: .ckg\n")
+    cfg = load_config(yaml_path)
+    whole = cfg.app_as(_GraphConfig)
+    assert whole.store.path == ".ckg"
+
+
+def test_app_as_missing_key_yields_empty_mapping() -> None:
+    """An absent app key validates against an empty mapping, so the
+    caller's model supplies its own defaults (or raises if required)."""
+
+    class _Defaulted(BaseModel):
+        flag: bool = True
+
+    cfg = AgentForgeConfig()
+    assert cfg.app_as(_Defaulted, "missing").flag is True
+
+
+def test_app_as_delegates_strictness_to_caller_model(tmp_path: Path) -> None:
+    """A typo *inside* ``app:`` is caught by the caller's own
+    ``extra="forbid"`` model — strictness is delegated, not lost."""
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    stop:\n      path: .ckg\n")
+    cfg = load_config(yaml_path)
+    with pytest.raises(ValidationError):
+        cfg.app_as(_GraphConfig, "graph")
+
+
+# --- app: rides the loader passes (interpolation + layering) -----
+
+
+def test_env_interpolation_resolves_inside_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: ${CKG_PATH:.ckg}\n")
+    monkeypatch.setenv("CKG_PATH", "/data/ckg")
+    cfg = load_config(yaml_path)
+    assert cfg.app["graph"]["store"]["path"] == "/data/ckg"
+
+
+def test_env_interpolation_default_inside_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: ${CKG_PATH:.ckg}\n")
+    monkeypatch.delenv("CKG_PATH", raising=False)
+    cfg = load_config(yaml_path)
+    assert cfg.app["graph"]["store"]["path"] == ".ckg"
+
+
+def test_env_file_layering_overrides_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base = tmp_path / "agentforge.yaml"
+    base.write_text("app:\n  graph:\n    store:\n      path: .ckg\n")
+    overlay = tmp_path / "agentforge.production.yaml"
+    overlay.write_text("app:\n  graph:\n    store:\n      path: /srv/ckg\n")
+    monkeypatch.setenv("AGENTFORGE_ENV", "production")
+    cfg = load_config(base)
+    assert cfg.app["graph"]["store"]["path"] == "/srv/ckg"
+
+
+# --- config show --resolved includes app -------------------------
+
+
+def test_model_dump_includes_resolved_app(tmp_path: Path) -> None:
+    """``config show --resolved`` dumps ``cfg.model_dump(mode="json")``,
+    so the resolved ``app:`` subtree is emitted for free."""
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: .ckg\n")
+    cfg = load_config(yaml_path)
+    dumped = cfg.model_dump(mode="json")
+    assert dumped["app"]["graph"]["store"]["path"] == ".ckg"

--- a/packages/agentforge-core/tests/unit/test_config_app_sections.py
+++ b/packages/agentforge-core/tests/unit/test_config_app_sections.py
@@ -1,0 +1,169 @@
+"""Unit tests for registered app-config section validation
+(feat-026 Phase 2).
+
+A derived agent registers a Pydantic schema per ``app.<section>`` via
+the ``agentforge.config_sections`` entry-point group. The framework
+validates each registered section that is present in ``app:`` — strictly
+— and leaves unregistered sections free-form, mirroring
+``validate_module_configs``.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import EntryPoint
+
+import pytest
+from agentforge_core.config import (
+    AgentForgeConfig,
+    discover_app_sections,
+    validate_app_config,
+)
+from agentforge_core.config import app_sections as app_sections_mod
+from agentforge_core.production.exceptions import ModuleError
+from pydantic import BaseModel, ConfigDict
+
+
+class _StoreConfig(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    path: str
+
+
+class _GraphConfig(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    store: _StoreConfig
+    max_hops: int = 3
+
+
+_SECTIONS = {"graph": _GraphConfig}
+
+
+# --- validate_app_config with an injected registry ----------------
+
+
+def test_registered_section_validates_ok() -> None:
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {"graph": {"store": {"path": ".ckg"}, "max_hops": 4}}}
+    )
+    # Does not raise.
+    validate_app_config(cfg, sections=_SECTIONS)
+
+
+def test_typo_under_registered_section_raises() -> None:
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {"graph": {"store": {"path": ".ckg"}, "max_hopz": 4}}}
+    )
+    with pytest.raises(ModuleError) as exc:
+        validate_app_config(cfg, sections=_SECTIONS)
+    assert "app.graph" in str(exc.value)
+
+
+def test_bad_value_under_registered_section_raises() -> None:
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {"graph": {"store": {"path": ".ckg"}, "max_hops": "lots"}}}
+    )
+    with pytest.raises(ModuleError):
+        validate_app_config(cfg, sections=_SECTIONS)
+
+
+def test_unregistered_section_left_untouched() -> None:
+    """A section nobody registered is free-form — never validated."""
+    cfg = AgentForgeConfig.model_validate(
+        {"app": {"telemetry": {"anything": "goes", "nested": {"x": 1}}}}
+    )
+    validate_app_config(cfg, sections=_SECTIONS)  # no graph key → nothing to do
+
+
+def test_registered_section_absent_from_app_is_skipped() -> None:
+    cfg = AgentForgeConfig.model_validate({"app": {}})
+    validate_app_config(cfg, sections=_SECTIONS)  # graph registered but absent
+
+
+def test_empty_registry_is_a_noop() -> None:
+    cfg = AgentForgeConfig.model_validate({"app": {"graph": {"whatever": 1}}})
+    validate_app_config(cfg, sections={})
+
+
+# --- discover_app_sections via monkeypatched entry points ---------
+
+
+def _make_loader(mapping: dict[str, object]):
+    def _fake_load(self: EntryPoint) -> object:
+        return mapping[self.name]
+
+    return _fake_load
+
+
+def test_discover_picks_up_basemodel(monkeypatch: pytest.MonkeyPatch) -> None:
+    ep = EntryPoint(name="graph", value="x:GraphConfig", group=app_sections_mod.SECTIONS_GROUP)
+    monkeypatch.setattr(EntryPoint, "load", _make_loader({"graph": _GraphConfig}))
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [ep])
+    found = discover_app_sections()
+    assert found == {"graph": _GraphConfig}
+
+
+def test_discover_skips_non_basemodel(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _not_a_model() -> None: ...
+
+    ep = EntryPoint(name="bad", value="x:func", group=app_sections_mod.SECTIONS_GROUP)
+    monkeypatch.setattr(EntryPoint, "load", _make_loader({"bad": _not_a_model}))
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [ep])
+    with caplog.at_level(logging.WARNING):
+        found = discover_app_sections()
+    assert found == {}
+    assert "not a pydantic BaseModel" in caplog.text
+
+
+def test_discover_skips_load_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _boom(self: EntryPoint) -> object:
+        raise ImportError("no such package")
+
+    good = EntryPoint(name="graph", value="x:GraphConfig", group=app_sections_mod.SECTIONS_GROUP)
+    bad = EntryPoint(name="broken", value="x:Nope", group=app_sections_mod.SECTIONS_GROUP)
+
+    def _load(self: EntryPoint) -> object:
+        if self.name == "broken":
+            _boom(self)
+        return _GraphConfig
+
+    monkeypatch.setattr(EntryPoint, "load", _load)
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [good, bad])
+    with caplog.at_level(logging.WARNING):
+        found = discover_app_sections()
+    assert found == {"graph": _GraphConfig}
+    assert "load failed" in caplog.text
+
+
+def test_discover_first_registration_wins(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    class _Other(BaseModel):
+        pass
+
+    first = EntryPoint(name="graph", value="x:GraphConfig", group=app_sections_mod.SECTIONS_GROUP)
+    second = EntryPoint(name="graph", value="y:Other", group=app_sections_mod.SECTIONS_GROUP)
+    monkeypatch.setattr(
+        EntryPoint, "load", _make_loader({"graph": _GraphConfig})
+    )  # only first matters
+    # second.load() would return _Other, but it must never be consulted.
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [first, second])
+    with caplog.at_level(logging.WARNING):
+        found = discover_app_sections()
+    assert found == {"graph": _GraphConfig}
+    assert "duplicate app-config section" in caplog.text
+
+
+def test_validate_app_config_default_discovery_no_sections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no registered sections, default discovery yields {} and
+    validation is a no-op (covers the discovery-path default arg)."""
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [])
+    cfg = AgentForgeConfig.model_validate({"app": {"graph": {"store": {"path": ".ckg"}}}})
+    validate_app_config(cfg)

--- a/packages/agentforge-core/tests/unit/test_resolver_discovery.py
+++ b/packages/agentforge-core/tests/unit/test_resolver_discovery.py
@@ -23,6 +23,7 @@ from agentforge_core.resolver.discover import (
     module_info_for,
     reset_discovery,
 )
+from pydantic import BaseModel
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +223,42 @@ def test_non_class_entry_point_skipped(monkeypatch, caplog):
     discover_entry_points(Resolver.global_(), force=True)
 
     assert any("not a class" in r.message for r in caplog.records)
+
+
+def test_config_sections_group_excluded_from_resolver(monkeypatch):
+    """`agentforge.config_sections` maps app-config sections to pydantic
+    schemas (feat-026 Phase 2); the runtime resolver must skip the group
+    so schemas never land in the module registry."""
+
+    class _GraphSchema(BaseModel):
+        pass
+
+    section_ep = EntryPoint(
+        name="graph",
+        value="x:GraphSchema",
+        group="agentforge.config_sections",
+    )
+    tool_ep = EntryPoint(name="real", value="x:Real", group="agentforge.tools")
+
+    class _Real:
+        pass
+
+    monkeypatch.setattr(
+        EntryPoint,
+        "load",
+        lambda self: _GraphSchema if self.group.endswith("config_sections") else _Real,
+    )
+    monkeypatch.setattr(EntryPoint, "dist", property(lambda _self: None))
+    monkeypatch.setattr(discover_mod, "entry_points", lambda: [section_ep, tool_ep])
+
+    reset_discovery()
+    Resolver.global_().clear()
+    discover_entry_points(Resolver.global_(), force=True)
+
+    # The tool registered; the config section did NOT leak into the resolver.
+    assert Resolver.global_().resolve("tools", "real") is _Real
+    with pytest.raises(ModuleError):
+        Resolver.global_().resolve("config_sections", "graph")
 
 
 # --- helper coverage --------------------------------------------

--- a/packages/agentforge/src/agentforge/cli/config_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/config_cmd.py
@@ -26,6 +26,7 @@ import yaml
 from agentforge_core.config import (
     AgentForgeConfig,
     load_config,
+    validate_app_config,
     validate_module_configs,
 )
 from agentforge_core.production.exceptions import ModuleError
@@ -127,6 +128,14 @@ def _run_validate(args: argparse.Namespace) -> int:
         validate_module_configs(cfg, strict=args.strict_modules)
     except ModuleError as exc:
         sys.stderr.write(f"module config validation failed: {exc}\n")
+        return 1
+    # Registered `app.<section>` schemas are always validated strictly
+    # (feat-026 Phase 2). Unregistered / not-installed sections are
+    # free-form, so `--strict-modules` governs only module resolution.
+    try:
+        validate_app_config(cfg)
+    except ModuleError as exc:
+        sys.stderr.write(f"app config validation failed: {exc}\n")
         return 1
     sys.stdout.write("OK\n")
     return 0

--- a/packages/agentforge/tests/unit/test_cli_config.py
+++ b/packages/agentforge/tests/unit/test_cli_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from importlib.metadata import EntryPoint
 from pathlib import Path
 from typing import ClassVar
 
@@ -10,6 +11,7 @@ import pytest
 import yaml
 from agentforge.cli.main import main
 from agentforge_core import Resolver, register
+from agentforge_core.config import app_sections as app_sections_mod
 from agentforge_core.resolver import discover as discover_mod
 from pydantic import BaseModel, ConfigDict
 
@@ -115,6 +117,60 @@ def test_validate_module_config_against_schema(tmp_path: Path, capsys) -> None:
     code = main(["config", "validate", "--path", str(yaml_path)])
     assert code == 1
     assert "modules.memory.config" in capsys.readouterr().err
+
+
+# --- registered app-config sections (feat-026 Phase 2) ------------
+
+
+class _AppStoreConfig(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+    path: str
+
+
+class _AppGraphConfig(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+    store: _AppStoreConfig
+
+
+def _register_app_section(monkeypatch: pytest.MonkeyPatch, name: str, model: type) -> None:
+    """Point app-section discovery at a single in-test schema."""
+    ep = EntryPoint(name=name, value="x:Schema", group=app_sections_mod.SECTIONS_GROUP)
+    monkeypatch.setattr(EntryPoint, "load", lambda _self: model)
+    monkeypatch.setattr(app_sections_mod, "entry_points", lambda group: [ep])
+
+
+def test_validate_registered_app_section_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    _register_app_section(monkeypatch, "graph", _AppGraphConfig)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    store:\n      path: .ckg\n")
+    code = main(["config", "validate", "--path", str(yaml_path)])
+    assert code == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_validate_registered_app_section_typo_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    _register_app_section(monkeypatch, "graph", _AppGraphConfig)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  graph:\n    stor:\n      path: .ckg\n")  # typo: stor
+    code = main(["config", "validate", "--path", str(yaml_path)])
+    assert code == 1
+    assert "app.graph" in capsys.readouterr().err
+
+
+def test_validate_unregistered_app_section_is_freeform(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A section nobody registered passes validation untouched."""
+    _register_app_section(monkeypatch, "graph", _AppGraphConfig)
+    yaml_path = tmp_path / "agentforge.yaml"
+    yaml_path.write_text("app:\n  telemetry:\n    anything: goes\n")
+    code = main(["config", "validate", "--path", str(yaml_path)])
+    assert code == 0
+    assert "OK" in capsys.readouterr().out
 
 
 # --- show ---------------------------------------------------------


### PR DESCRIPTION
Closes #86. Implements **feat-026 Phases 1 & 2** in one branch, two commits.

| Commit | Phase | Scope |
|---|---|---|
| `b07db69` | **P1** (enh-002) | Reserved `app:` namespace + typed `app_as()` accessor |
| `23f598e` | **P2** | Registered, validated `app.<section>` schemas via entry points |

Design (ADR-0022 + specs) was approved and merged in #88; this PR is the implementation.

## Phase 1 — `app:` passthrough

- `AgentForgeConfig` gains `app: dict[str, Any]` (default `{}`) — a reserved top-level block the framework **accepts but does not interpret**.
- New accessor `app_as(model, key=None)` validates a subtree with the caller's own Pydantic model.
- `model_config` stays `strict=True, extra="forbid"` — every other top-level key keeps typo protection. Strictness *inside* `app:` is delegated to the app's own model.
- **No loader changes**: interpolation (`_walk`) + layering (`_deep_merge`) already run on the raw mapping before `model_validate`, and `config show --resolved` dumps `model_dump()`. So `app:` gets `${ENV}`, env-file layering, `--override`, and `--resolved` for free (verified by tests).

## Phase 2 — registered, validated sections

A derived agent registers a Pydantic schema per `app.<section>` via a new entry-point group, mirroring module discovery (ADR-0004):

```toml
[project.entry-points."agentforge.config_sections"]
graph = "agentforge_graph.config:GraphConfig"
```

- `discover_app_sections()` scans the `agentforge.config_sections` group; `validate_app_config(cfg)` validates each registered section present under `app:`.
- Wired into `agentforge config validate` after module validation — same fail-fast parity `modules.*` already has.
- **Graceful by construction**: registered sections are strict; unregistered sections stay free-form (the `[tool.x]` model); a section whose package isn't installed simply isn't discovered.
- The runtime resolver now **skips** the `config_sections` group, so app-config schemas never pollute the module registry.

## Why it helps derived agents

`agentforge-graph` (which filed #86) can now keep its own config in the one `agentforge.yaml` it already ships — with interpolation, layering, `--resolved`, **and** `config validate` typo-checking — instead of re-implementing the loader in a side file.

## Tests

- `test_config_app_passthrough.py` — 11 (Phase 1).
- `test_config_app_sections.py` — 11 (Phase 2 engine: validation + discovery edge cases).
- `test_resolver_discovery.py` — +1 (resolver excludes `config_sections`).
- `test_cli_config.py` — +3 (registered section ok / typo fails / unregistered free-form).
- `test_app_sections_real_discovery.py` — 6 **real, no-mock** e2e: a real `.dist-info` + `entry_points.txt` on `sys.path` drives actual `importlib.metadata` discovery, and the real `agentforge config validate` binary runs in a subprocess (valid → 0, typo → 1).
- Full `agentforge-core` unit suite **472 green**, CLI config **16 green**, `mypy --strict` clean, coverage ≥90%, all pre-commit hooks pass.

## Docs

- ADR-0022 **Accepted**; enh-002 `shipped (0.5.0)`; feat-026 Implementation status + phasing table (Phases 1 & 2 → 0.5.0); CHANGELOG `### Added` (both phases).

Additive fields/helpers → minor bump under ADR-0007. Phase 3 (pluggable config **sources** / extra files) remains deferred to on-demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
