### PR TITLE
feat(config): `imports:` directive for multi-file config (feat-026 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **feat-026 Phase 3 — `imports:` config directive (multi-file config).**
+  Any `agentforge.yaml` (or env overlay, or imported file) may declare a
+  top-level `imports:` list of additional config files:
+
+  ```yaml
+  imports:
+    - graph.yaml          # the app's own config, in its own file
+  agent: { model: "anthropic:claude-haiku-4-5" }
+  ```
+
+  Imported files flow through the full pipeline — `${ENV}` interpolation,
+  env-overlay layering, `--override`, `config show --resolved`, and
+  schema/section validation — so a derived agent can finally split its
+  config across files without losing any framework machinery. Imports are
+  **lower precedence than the file that imports them** (Spring
+  `spring.config.import` semantics: import shared defaults, override
+  locally); later entries in a list win; imports compose transitively
+  with cycle detection; paths resolve relative to the importer and accept
+  `${ENV}`. The directive is consumed by the loader, so it never reaches
+  the strict root model. Declarative — data, not code (ADR-0013). See
+  [feat-026 §4.4](docs/features/feat-026-application-config-extension.md).
+
 - **enh-002 / feat-026 Phase 1 — reserved `app:` namespace.**
   `agentforge.yaml` now accepts a top-level `app:` block for
   **application** config. The framework stores the subtree but does not

--- a/docs/features/feat-026-application-config-extension.md
+++ b/docs/features/feat-026-application-config-extension.md
@@ -6,10 +6,10 @@
 |---|---|
 | **ID** | feat-026 |
 | **Title** | Application config extension — reserved `app:` namespace, registered typed sections, pluggable sources |
-| **Status** | accepted — Phases 1 & 2 shipped in 0.5.0; Phase 3 on demand |
+| **Status** | accepted — Phases 1, 2 & 3 all shipped in 0.5.0 |
 | **Owner** | kjoshi |
 | **Created** | 2026-06-13 |
-| **Target version** | 0.5.0 (Phases 1 & 2) → on-demand (Phase 3) |
+| **Target version** | 0.5.0 (all three phases) |
 | **Languages** | both |
 | **Module package(s)** | `agentforge-core`, `agentforge` |
 | **Depends on** | feat-012 (configuration system) |
@@ -155,15 +155,31 @@ conflated:
   under `app:`. Pattern: Spring Boot `@ConfigurationProperties(prefix)`,
   Python `pyproject.toml` `[tool.<name>]`. Each owner validates its
   own subtree.
-- **Sources** (Phase 3, deferred): *where config comes from*. Today the
-  loader has a fixed source list (base file → `agentforge.<env>.yaml`
-  overlay → env interpolation → `--override`). Phase 3 generalizes this
-  into an ordered, pluggable source list so an app can register an
-  **additional file** (e.g. `graph.yaml`) that still flows through
-  interpolation, layering, `--resolved`, and validation. Pattern:
+- **Sources** (Phase 3): *where config comes from*. Before Phase 3 the
+  loader had a fixed source list (base file → `agentforge.<env>.yaml`
+  overlay → env interpolation → `--override`). Phase 3 adds an
+  **`imports:` directive** — a reserved top-level list of additional
+  config files that flow through the same machinery (interpolation,
+  layering, `--override`, `--resolved`, validation):
+
+  ```yaml
+  # agentforge.yaml
+  imports:
+    - graph.yaml          # the app's own config, in its own file
+  agent: { model: "anthropic:claude-haiku-4-5" }   # overrides imports
+  ```
+
+  **Precedence** follows Spring Boot `spring.config.import`: an imported
+  file is *lower precedence than the file that imports it* — you import
+  shared defaults and override locally. Within one list, later entries
+  win; imports compose transitively; cycles raise. Paths resolve
+  relative to the importing file and get `${ENV}` interpolation. The
+  directive is **consumed by the loader** (popped before validation), so
+  it never collides with the root model's `extra="forbid"` and
+  `config show --resolved` shows the merged result, not the directive.
+  This is declarative — data, not code (ADR-0013) — and directly answers
+  the "tomorrow someone wants their own config file" need. Prior art:
   Spring `spring.config.import`, Viper multi-source, kustomize layers.
-  Built only on demand — it directly answers the "tomorrow someone
-  wants their own config file" need without forfeiting the machinery.
 
 ### 4.5 Phasing
 
@@ -171,7 +187,7 @@ conflated:
 |---|---|---|---|
 | **1** | `app:` field + `app_as()` accessor + docs | **0.5.0** ✅ | [enh-002](../enhancements/enh-002-app-config-passthrough.md) |
 | **2** | Registered typed sections (entry points) + `config validate` coverage | **0.5.0** ✅ | this feat |
-| **3** | Pluggable config **sources** (extra files) | on demand | this feat §4.4 |
+| **3** | Pluggable config **sources** — `imports:` directive | **0.5.0** ✅ | this feat §4.4 |
 
 Phase 1 is a forward-compatible slice: `app.<section>` becomes a
 registered section in Phase 2 with **no breaking change** — the raw
@@ -203,6 +219,15 @@ accessor (Zod), and (Phase 2) section registration via npm
   during `config validate`; a typo under a registered section fails;
   an unregistered section is left untouched; `strict=False` tolerates a
   not-yet-installed section package.
+- **Phase 3 unit (real files):** an `imports:` file merges into the base;
+  the importing file overrides its imports; later imports beat earlier;
+  transitive imports compose; cycles + missing files + malformed
+  directives raise; relative/absolute/`${ENV}` paths resolve; imported
+  *values* get interpolation; `--override` still wins; the env overlay is
+  import-aware; the directive is consumed (absent from `--resolved`); and
+  the #86 scenario (app config in its own imported file) validates via
+  `app_as`. Plus CLI subprocess e2e over the real `agentforge config
+  {show,validate}` binary.
 - **Doc test:** the `agentforge-graph` repro from #86 validates.
 
 ## 8. Risks & open questions
@@ -218,8 +243,11 @@ accessor (Zod), and (Phase 2) section registration via npm
 
 - Loosening `extra="forbid"` on framework keys (rejected in ADR-0022).
 - Turing-complete config / templating (ADR-0013 stands).
-- Phase 3 pluggable sources beyond the design sketch in §4.4 (built on
-  demand).
+- Non-file config **sources** (remote/HTTP, secrets managers, env-only
+  providers). Phase 3 ships file imports; a future `agentforge.config_sources`
+  provider interface could generalize beyond files if a real need appears.
+- `optional:`-prefixed imports (Spring-style soft imports). Phase 3
+  imports are required — a missing import is a config error. Add on demand.
 
 ## 10. References
 
@@ -269,5 +297,19 @@ discovery resolves the section, and runs the real `agentforge config
 validate` binary in a subprocess against it (valid → exit 0; typo →
 exit 1).
 
-**Phase 3 — not started.** Pluggable config *sources* (separate files,
-`spring.config.import`-style). On demand.
+**Phase 3 — shipped (0.5.0).** Pluggable config *sources* via the
+`imports:` directive — a reserved top-level list of additional config
+files, resolved entirely in the loader
+(`agentforge_core/config/loader.py`, `_load_file_with_imports`). Imports
+sit at lower precedence than the importing file (Spring
+`spring.config.import` semantics); later entries in a list win; imports
+compose transitively with cycle detection; paths resolve relative to the
+importer and get `${ENV}` interpolation; the directive is popped before
+validation so it never reaches the strict root model and `--resolved`
+shows the merged result. No schema or CLI changes were needed — imported
+values ride the existing interpolation / layering / override / validation
+passes. Covered by `tests/unit/test_config_imports.py` (18, real files)
+and `tests/integration/test_config_imports_cli.py` (4, real
+`agentforge config` subprocess). Brought forward from on-demand to ship
+with Phases 1 & 2 in 0.5.0. Stays within ADR-0013 (config is data, not
+code) — no new ADR required.

--- a/packages/agentforge-core/src/agentforge_core/config/loader.py
+++ b/packages/agentforge-core/src/agentforge_core/config/loader.py
@@ -3,11 +3,13 @@
 Resolution order (last wins) per spec §4.3:
 
     1. Defaults from each Pydantic model.
-    2. agentforge.yaml on disk (if present).
-    3. agentforge.<env>.yaml (if AGENTFORGE_ENV set).
-    4. Env-var interpolation inside YAML values.
-    5. CLI / loader-API `--override agent.budget.usd=10` arguments.
-    6. Constructor kwargs to Agent (handled in `agentforge.agent`).
+    2. Files pulled in via an `imports:` directive (feat-026 Phase 3),
+       lower precedence than the file that imports them.
+    3. agentforge.yaml on disk (if present).
+    4. agentforge.<env>.yaml (if AGENTFORGE_ENV set).
+    5. Env-var interpolation inside YAML values.
+    6. CLI / loader-API `--override agent.budget.usd=10` arguments.
+    7. Constructor kwargs to Agent (handled in `agentforge.agent`).
 
 Env-var interpolation syntax (feat-001):
 - `${VAR}` — required; raises at load if missing.
@@ -155,6 +157,65 @@ def _read_yaml(path: Path) -> dict[str, Any]:
     return raw
 
 
+#: Reserved top-level loader directive (feat-026 Phase 3): a list of
+#: paths to other config files to pull in. Consumed by the loader
+#: (popped before validation), so it never reaches `AgentForgeConfig`.
+_IMPORTS_KEY = "imports"
+
+
+def _load_file_with_imports(path: Path, *, _visiting: tuple[Path, ...] = ()) -> dict[str, Any]:
+    """Read a config file and resolve its ``imports:`` directive (feat-026
+    Phase 3 — pluggable config *sources*).
+
+    ``imports:`` is a top-level list of paths to other config files,
+    resolved **relative to this file's directory** (absolute paths are
+    honoured as-is). Import path strings get ``${ENV}`` interpolation so
+    ``imports: ["${EXTRA_CONFIG}"]`` works.
+
+    Precedence follows Spring Boot's ``spring.config.import``: an imported
+    file is **lower precedence than the file that imports it** — you
+    import shared defaults and override them locally. Within one
+    ``imports:`` list, later entries beat earlier ones. Imports compose
+    transitively (an imported file may itself import); cycles raise
+    ``ModuleError``.
+
+    The directive is consumed here — the returned mapping never contains
+    an ``imports`` key, so it doesn't collide with the root model's
+    ``extra="forbid"`` and ``config show --resolved`` shows the merged
+    result, not the directive.
+    """
+    resolved = path.resolve()
+    if resolved in _visiting:
+        chain = " -> ".join(str(p) for p in (*_visiting, resolved))
+        raise ModuleError(f"Circular config import detected: {chain}")
+
+    raw = _read_yaml(path)
+    imports = raw.pop(_IMPORTS_KEY, None)
+    if imports is None:
+        return raw
+    if not isinstance(imports, list):
+        raise ModuleError(
+            f"`imports:` in {path} must be a list of file paths; got {type(imports).__name__}."
+        )
+
+    merged: dict[str, Any] = {}
+    for entry in imports:
+        if not isinstance(entry, str):
+            raise ModuleError(f"`imports:` entries in {path} must be strings; got {entry!r}.")
+        import_path = Path(_interp(entry))
+        if not import_path.is_absolute():
+            import_path = path.parent / import_path
+        if not import_path.exists():
+            raise ModuleError(
+                f"Imported config file not found: {import_path} (imported by {path})."
+            )
+        imported = _load_file_with_imports(import_path, _visiting=(*_visiting, resolved))
+        merged = _deep_merge(merged, imported)
+
+    # The importing file's own keys win over everything it imports.
+    return _deep_merge(merged, raw)
+
+
 def _env_overlay_path(base: Path, env: str) -> Path:
     """Compute the overlay path next to `base`: foo.yaml → foo.<env>.yaml."""
     return base.with_suffix(f".{env}{base.suffix}")
@@ -191,14 +252,15 @@ def load_config(
     if resolved_path is None or not resolved_path.exists():
         merged: dict[str, Any] = {}
     else:
-        merged = _read_yaml(resolved_path)
+        merged = _load_file_with_imports(resolved_path)
         # Layered env file overlays the base. Missing overlay is fine
-        # (env-without-file is just "use base").
+        # (env-without-file is just "use base"). The overlay is itself
+        # import-aware, so an `agentforge.<env>.yaml` may pull in files too.
         resolved_env = env if env is not None else os.environ.get("AGENTFORGE_ENV")
         if resolved_env:
             overlay_path = _env_overlay_path(resolved_path, resolved_env)
             if overlay_path.exists():
-                merged = _deep_merge(merged, _read_yaml(overlay_path))
+                merged = _deep_merge(merged, _load_file_with_imports(overlay_path))
 
     interpolated = _walk(merged)
     if overrides:

--- a/packages/agentforge-core/tests/integration/test_config_imports_cli.py
+++ b/packages/agentforge-core/tests/integration/test_config_imports_cli.py
@@ -1,0 +1,86 @@
+"""Full CLI subprocess e2e for the `imports:` directive (feat-026
+Phase 3).
+
+The unit tests in `tests/unit/test_config_imports.py` load real files
+through the loader API. These go one level further: they run the real
+`agentforge config {show,validate}` binary in a subprocess against a
+multi-file config, proving the directive works end-to-end through the
+CLI exactly as a user invokes it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 — fixed argv, no shell
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _agentforge_bin() -> str | None:
+    candidate = Path(sys.executable).parent / "agentforge"
+    if candidate.exists():
+        return str(candidate)
+    return shutil.which("agentforge")
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603 — fixed argv, no shell
+        [_agentforge_bin() or "agentforge", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+        check=False,
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    _agentforge_bin() is None, reason="agentforge console script not installed"
+)
+
+
+def test_cli_show_resolved_merges_imports(tmp_path: Path) -> None:
+    (tmp_path / "shared.yaml").write_text("agent:\n  model: shared-model\n  max_iterations: 9\n")
+    (tmp_path / "agentforge.yaml").write_text(
+        "imports:\n  - shared.yaml\nagent:\n  name: local-agent\n"
+    )
+
+    result = _run(["config", "show", "--resolved", "--path", "agentforge.yaml"], cwd=tmp_path)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    parsed = yaml.safe_load(result.stdout)
+    # Imported value present, local value present, directive consumed.
+    assert parsed["agent"]["model"] == "shared-model"
+    assert parsed["agent"]["max_iterations"] == 9
+    assert parsed["agent"]["name"] == "local-agent"
+    assert "imports" not in parsed
+
+
+def test_cli_validate_passes_with_imports(tmp_path: Path) -> None:
+    (tmp_path / "shared.yaml").write_text("agent:\n  budget:\n    usd: 3.0\n")
+    (tmp_path / "agentforge.yaml").write_text("imports:\n  - shared.yaml\n")
+
+    result = _run(["config", "validate", "--path", "agentforge.yaml"], cwd=tmp_path)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+def test_cli_validate_fails_on_bad_imported_value(tmp_path: Path) -> None:
+    """A schema violation that lives in an imported file is caught the
+    same as one in the base file — imports are fully validated."""
+    (tmp_path / "shared.yaml").write_text("agent:\n  budget:\n    usd: -5\n")  # negative
+    (tmp_path / "agentforge.yaml").write_text("imports:\n  - shared.yaml\n")
+
+    result = _run(["config", "validate", "--path", "agentforge.yaml"], cwd=tmp_path)
+    assert result.returncode == 1
+    assert "agent.budget.usd" in result.stderr
+
+
+def test_cli_validate_reports_missing_import(tmp_path: Path) -> None:
+    (tmp_path / "agentforge.yaml").write_text("imports:\n  - nope.yaml\n")
+    result = _run(["config", "validate", "--path", "agentforge.yaml"], cwd=tmp_path)
+    assert result.returncode == 1
+    assert "not found" in result.stderr

--- a/packages/agentforge-core/tests/unit/test_config_imports.py
+++ b/packages/agentforge-core/tests/unit/test_config_imports.py
@@ -1,0 +1,216 @@
+"""Unit tests for the `imports:` config-sources directive (feat-026
+Phase 3).
+
+`imports:` is a top-level loader directive: a list of other config files
+to pull in. Imported files flow through the same machinery as the base
+file (interpolation, env-overlay layering, `--override`, `--resolved`,
+validation) and sit at **lower precedence than the importing file**
+(Spring `spring.config.import` semantics). The directive is consumed by
+the loader, so it never reaches the strict root model.
+
+These tests write real files to `tmp_path` and load them for real — no
+mocking of the filesystem or the loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentforge_core.config import load_config
+from agentforge_core.production.exceptions import ModuleError
+from pydantic import BaseModel, ConfigDict
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text)
+    return path
+
+
+# --- basic merge + precedence ------------------------------------
+
+
+def test_import_merges_into_base(tmp_path: Path) -> None:
+    _write(tmp_path / "shared.yaml", "agent:\n  model: shared-model\n  max_iterations: 7\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - shared.yaml\n")
+    cfg = load_config(base)
+    assert cfg.agent.model == "shared-model"
+    assert cfg.agent.max_iterations == 7
+
+
+def test_importing_file_wins_over_import(tmp_path: Path) -> None:
+    """Spring semantics: the file doing the importing overrides what it
+    imports (import defaults, override locally)."""
+    _write(tmp_path / "shared.yaml", "agent:\n  model: shared-model\n  max_iterations: 7\n")
+    base = _write(
+        tmp_path / "agentforge.yaml",
+        "imports:\n  - shared.yaml\nagent:\n  model: local-model\n",
+    )
+    cfg = load_config(base)
+    assert cfg.agent.model == "local-model"  # local wins
+    assert cfg.agent.max_iterations == 7  # inherited from import
+
+
+def test_later_import_beats_earlier(tmp_path: Path) -> None:
+    _write(tmp_path / "a.yaml", "agent:\n  model: from-a\n")
+    _write(tmp_path / "b.yaml", "agent:\n  model: from-b\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - a.yaml\n  - b.yaml\n")
+    cfg = load_config(base)
+    assert cfg.agent.model == "from-b"
+
+
+def test_deep_merge_across_import_boundary(tmp_path: Path) -> None:
+    """Nested mappings merge key-by-key across the import boundary."""
+    _write(
+        tmp_path / "shared.yaml",
+        "agent:\n  model: shared-model\n  budget:\n    usd: 9.0\n",
+    )
+    base = _write(
+        tmp_path / "agentforge.yaml",
+        "imports:\n  - shared.yaml\nagent:\n  name: local\n",
+    )
+    cfg = load_config(base)
+    assert cfg.agent.name == "local"
+    assert cfg.agent.model == "shared-model"
+    assert cfg.agent.budget.usd == pytest.approx(9.0)
+
+
+# --- transitive + cycles -----------------------------------------
+
+
+def test_transitive_imports(tmp_path: Path) -> None:
+    _write(tmp_path / "c.yaml", "agent:\n  model: from-c\n  max_iterations: 3\n")
+    _write(tmp_path / "b.yaml", "imports:\n  - c.yaml\nagent:\n  name: b-named\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - b.yaml\n")
+    cfg = load_config(base)
+    assert cfg.agent.model == "from-c"
+    assert cfg.agent.name == "b-named"
+    assert cfg.agent.max_iterations == 3
+
+
+def test_circular_import_raises(tmp_path: Path) -> None:
+    _write(tmp_path / "a.yaml", "imports:\n  - b.yaml\n")
+    _write(tmp_path / "b.yaml", "imports:\n  - a.yaml\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - a.yaml\n")
+    with pytest.raises(ModuleError, match="Circular config import"):
+        load_config(base)
+
+
+def test_self_import_raises(tmp_path: Path) -> None:
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - agentforge.yaml\n")
+    with pytest.raises(ModuleError, match="Circular config import"):
+        load_config(base)
+
+
+# --- path resolution + errors ------------------------------------
+
+
+def test_relative_path_resolves_against_importer_dir(tmp_path: Path) -> None:
+    sub = tmp_path / "conf"
+    sub.mkdir()
+    _write(sub / "shared.yaml", "agent:\n  model: sub-model\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - conf/shared.yaml\n")
+    cfg = load_config(base)
+    assert cfg.agent.model == "sub-model"
+
+
+def test_absolute_import_path(tmp_path: Path) -> None:
+    shared = _write(tmp_path / "shared.yaml", "agent:\n  model: abs-model\n")
+    base = _write(tmp_path / "agentforge.yaml", f"imports:\n  - {shared}\n")
+    cfg = load_config(base)
+    assert cfg.agent.model == "abs-model"
+
+
+def test_missing_import_raises(tmp_path: Path) -> None:
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - nope.yaml\n")
+    with pytest.raises(ModuleError, match="Imported config file not found"):
+        load_config(base)
+
+
+def test_non_list_imports_raises(tmp_path: Path) -> None:
+    base = _write(tmp_path / "agentforge.yaml", "imports: shared.yaml\n")
+    with pytest.raises(ModuleError, match="must be a list"):
+        load_config(base)
+
+
+def test_non_string_import_entry_raises(tmp_path: Path) -> None:
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - {path: shared.yaml}\n")
+    with pytest.raises(ModuleError, match="must be strings"):
+        load_config(base)
+
+
+# --- composition with the rest of the pipeline -------------------
+
+
+def test_env_interpolation_in_import_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path / "shared.yaml", "agent:\n  model: env-pathed\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - ${SHARED_FILE}\n")
+    monkeypatch.setenv("SHARED_FILE", str(tmp_path / "shared.yaml"))
+    cfg = load_config(base)
+    assert cfg.agent.model == "env-pathed"
+
+
+def test_env_interpolation_in_imported_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Values *inside* an imported file get `${ENV}` interpolation, same
+    as the base file (the whole merged tree is walked once)."""
+    _write(tmp_path / "shared.yaml", "agent:\n  model: ${MODEL:fallback}\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - shared.yaml\n")
+    monkeypatch.setenv("MODEL", "interpolated-model")
+    cfg = load_config(base)
+    assert cfg.agent.model == "interpolated-model"
+
+
+def test_override_still_wins_over_imports(tmp_path: Path) -> None:
+    _write(tmp_path / "shared.yaml", "agent:\n  budget:\n    usd: 5.0\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - shared.yaml\n")
+    cfg = load_config(base, overrides=["agent.budget.usd=42"])
+    assert cfg.agent.budget.usd == pytest.approx(42.0)
+
+
+def test_env_overlay_is_import_aware(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path / "prod-shared.yaml", "agent:\n  model: prod-shared-model\n")
+    _write(tmp_path / "agentforge.yaml", "agent:\n  model: base-model\n")
+    _write(
+        tmp_path / "agentforge.production.yaml",
+        "imports:\n  - prod-shared.yaml\n",
+    )
+    monkeypatch.setenv("AGENTFORGE_ENV", "production")
+    cfg = load_config(tmp_path / "agentforge.yaml")
+    # Overlay imports prod-shared, and the overlay layer (incl. its
+    # imports) beats the base file.
+    assert cfg.agent.model == "prod-shared-model"
+
+
+def test_imports_key_consumed_not_in_resolved(tmp_path: Path) -> None:
+    """`imports:` is a loader directive — it must not survive into the
+    validated model (which is `extra="forbid"`) or the resolved dump."""
+    _write(tmp_path / "shared.yaml", "agent:\n  model: m\n")
+    base = _write(tmp_path / "agentforge.yaml", "imports:\n  - shared.yaml\n")
+    cfg = load_config(base)
+    assert "imports" not in cfg.model_dump()
+
+
+def test_app_config_split_into_separate_file(tmp_path: Path) -> None:
+    """The #86 motivating scenario: a derived agent keeps its app config
+    in its own file and imports it — the framework merges + validates it
+    like any other config, no side-loader needed."""
+
+    class StoreConfig(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        path: str
+
+    class GraphConfig(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        store: StoreConfig
+
+    _write(tmp_path / "graph.yaml", "app:\n  graph:\n    store:\n      path: .ckg\n")
+    base = _write(
+        tmp_path / "agentforge.yaml",
+        "imports:\n  - graph.yaml\nagent:\n  model: my-model\n",
+    )
+    cfg = load_config(base)
+    assert cfg.agent.model == "my-model"
+    graph = cfg.app_as(GraphConfig, "graph")
+    assert graph.store.path == ".ckg"


### PR DESCRIPTION
Implements **feat-026 Phase 3** — pluggable config *sources*. Completes feat-026 (Phases 1 & 2 shipped in #89).

## What

Any config file — the base `agentforge.yaml`, an `agentforge.<env>.yaml` overlay, or an imported file — may declare a top-level **`imports:`** list of additional config files:

```yaml
# agentforge.yaml
imports:
  - graph.yaml          # the app's own config, in its own file
agent: { model: "anthropic:claude-haiku-4-5" }   # overrides imports
```

Imported files flow through the **entire** existing pipeline — `${ENV}` interpolation, env-overlay layering, `--override`, `config show --resolved`, and schema + Phase-2 section validation. A derived agent can finally split its config across files **without re-implementing the loader** — the original #86 pain, now fully closed across all three axes (passthrough → typed sections → multi-file).

## Semantics (Spring `spring.config.import`)

- **Precedence:** an imported file is *lower* than the file that imports it — import shared defaults, override locally.
- Within one `imports:` list, **later entries win**.
- **Transitive:** an imported file may itself import; **cycles raise** `ModuleError`.
- Paths resolve **relative to the importing file**; absolute paths honored; path strings get `${ENV}`.
- The directive is **consumed by the loader** (popped before validation) — never reaches the strict root model, and `--resolved` shows the merged result, not the directive.

## Why this shape

Declarative — **data, not code** (ADR-0013). It's entirely in the loader (`_load_file_with_imports`); **no schema or CLI changes**, and **no new ADR** (stays within existing decisions). Non-file sources (HTTP, secrets managers) and `optional:` imports are explicitly deferred (§9) — add on demand.

## Tests

- `tests/unit/test_config_imports.py` — **18 tests, real files** (no mocking): merge + precedence, later-wins, deep-merge across boundary, transitive, cycle + self-import, relative/absolute/`${ENV}` paths, missing/malformed directives, interpolation of imported values, `--override` still wins, import-aware env overlay, directive consumed, and the **#86 scenario** (app config in its own imported file, validated via `app_as`).
- `tests/integration/test_config_imports_cli.py` — **4 e2e** over the real `agentforge config {show,validate}` subprocess (merged `--resolved`; valid passes; bad imported value fails with the right path; missing import reported).
- Core suite **494 green**, `mypy --strict` clean, coverage ≥90%, all pre-commit hooks pass.

## Docs

feat-026 §4.4 rewritten with the concrete `imports:` design + precedence rationale; phasing table + Status + Implementation status (Phase 3 → shipped 0.5.0); §9 out-of-scope updated; CHANGELOG `### Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)