### PR TITLE
fix(config): build memory stores from config (bug-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ release tag bumps every workspace member to the same minor version.
 
 ### Fixed
 
+- **bug-022 (P2):** `modules.memory` can now be built from config for
+  every real backend. `build_memory_from_config` previously called the
+  stores' bare constructors (`SqliteMemoryStore(path=…)`), which
+  raised `TypeError` because sqlite/postgres/neo4j/surrealdb all
+  construct asynchronously via `from_path`/`from_dsn`/`from_url` and
+  none implemented the `from_config` factory every other module type
+  has. Each store now exposes an **async** `from_config`, and
+  `build_memory_from_config` is async (its CLI callers — `run`,
+  `health`, `db`, `debug` — already run in async contexts). Without
+  this, any `agentforge run`/`health`/`db migrate`/`debug` (and
+  `run --replay`) with a configured memory backend failed before the
+  agent started.
+
 - **bug-021 (P1):** `agentforge add module` / `remove module` now use
   an **environment-aware installer** instead of `python -m pip`. In a
   uv-managed project (a `uv.lock` is found in the cwd or a parent) it

--- a/docs/bugs/bug-022-memory-from-config.md
+++ b/docs/bugs/bug-022-memory-from-config.md
@@ -1,0 +1,132 @@
+---
+status: open
+severity: P2
+found-in: 0.2.4
+found-via: dogfooding (README demo gif)
+---
+
+# bug-022 — `modules.memory` can't be built from config: every real backend fails through the CLI
+
+## Symptom
+
+Configuring a memory backend in `agentforge.yaml` and running any CLI
+command that builds it (`agentforge run`, `health`, `db migrate`,
+`debug`, or `run --replay`) fails before the agent starts:
+
+```
+$ agentforge run "hi" --config agentforge.yaml   # modules.memory: {driver: sqlite, config: {path: mem.sqlite}}
+SqliteMemoryStore.__init__() got an unexpected keyword argument 'path'
+```
+
+The same `TypeError` shape occurs for postgres / neo4j / surrealdb
+(`unexpected keyword argument 'dsn'` / `'url'`). Configured memory is
+effectively unusable from the CLI for **every** real backend.
+
+## Reproduction
+
+```python
+from agentforge_core.config.schema import AgentForgeConfig
+from agentforge.cli._build import build_memory_from_config
+
+cfg = AgentForgeConfig.model_validate({
+    "agent": {"model": "anthropic:claude-sonnet-4-5", "strategy": "react"},
+    "modules": {"memory": {"driver": "sqlite", "config": {"path": ":memory:"}}},
+})
+build_memory_from_config(cfg)   # TypeError: __init__() got an unexpected keyword argument 'path'
+```
+
+The gap went unnoticed because the shipped example configs and the
+scaffold templates never populate `modules.memory` — the agent falls
+back to the in-process `InMemoryStore`, which sidesteps the builder.
+
+## Root cause
+
+`build_memory_from_config` (in
+`packages/agentforge/src/agentforge/cli/_build.py`) instantiated the
+resolved store via the shared **sync** `_instantiate(cls, cfg)`, whose
+final fallback is `cls(**cfg)`.
+
+But every real memory backend constructs **asynchronously** and via a
+named factory, not its bare constructor:
+
+| backend | factory | `__init__` wants |
+|---------|---------|------------------|
+| sqlite | `async from_path(path)` | `connection` |
+| postgres | `async from_dsn(dsn, …)` | `runner` |
+| neo4j | `async from_url(url, *, auth, …)` | `runner` |
+| surrealdb | `async from_url(url, *, …)` | `runner` |
+
+None implemented the `from_config` factory convention that **every
+other module type already has** — LLM clients (`AnthropicClient`,
+`OpenAIClient`, …), embedders, rerankers, observability hooks, and
+protocol bridges all expose `from_config`. The memory stores were the
+sole module type missing it, so `_instantiate` fell through to
+`cls(**cfg)` and passed the YAML keys straight to a constructor that
+doesn't accept them.
+
+## Fix
+
+Implement the missing convention as an **async** `from_config` on each
+store (memory construction opens a connection, so unlike the sync
+`from_config` on stateless modules it must be a coroutine), and give
+memory a dedicated async build path in `_build.py`:
+
+1. **`from_config` on each store** (delegates to the existing async
+   factory), e.g. sqlite:
+
+   ```python
+   @classmethod
+   async def from_config(cls, *, path: str | Path) -> SqliteMemoryStore:
+       return await cls.from_path(path)
+   ```
+
+   postgres → `from_dsn`, neo4j/surrealdb → `from_url` (coercing the
+   YAML `auth` list to the `tuple[str, str]` they expect).
+
+2. **`_ainstantiate_memory(cls, cfg)`** in `_build.py` — prefers an
+   awaitable `from_config` (`await`s it), falling back to the shared
+   sync `_instantiate` so a sync-constructed store/double still loads.
+
+3. **`build_memory_from_config` becomes `async`**; its five callers
+   (`build_agent_from_config`, `run_cmd`, `health_cmd`, `db_cmd`,
+   `debug_cmd`) are all already in async contexts and now `await` it.
+   `health`'s generic `_probe` awaits the factory result when it's
+   awaitable.
+
+The shared sync `_instantiate` and the other five `build_*_from_config`
+helpers are untouched — only memory routes through the async path, so
+no other module type regresses.
+
+This is implementing an established convention, not a new design
+decision, so no ADR accompanies it.
+
+## Verification
+
+- Regression test (offline, real sqlite) in
+  `packages/agentforge/tests/unit/test_cli_build.py`:
+  `test_build_memory_builds_real_sqlite_store_from_config` configures
+  `modules.memory: {driver: sqlite, config: {path: ":memory:"}}`,
+  `await`s `build_memory_from_config`, and asserts a live
+  `SqliteMemoryStore` with a working `put`/`get` round-trip. This test
+  fails (`TypeError`) on the pre-fix code.
+- The two previously-sync builder tests are converted to async + the
+  `_FakeMemory` (sync, no `from_config`) test exercises the sync
+  fallback branch of `_ainstantiate_memory`.
+- `SqliteMemoryStore.from_config` has its own offline unit test
+  (`packages/agentforge-memory-sqlite/tests/unit/test_memory.py::test_from_config_builds_a_live_store`).
+- postgres / neo4j / surrealdb `from_config` are `# pragma: no cover`
+  (live-only), matching the existing convention for the live factories
+  on those backends.
+- `uv run pre-commit run --all-files` green (ruff, mypy --strict,
+  bandit, coverage ≥ 90%).
+
+## Notes
+
+- This bug is *why* the README demo gif couldn't show `agentforge run
+  --replay` offline: `--replay` rebuilds the recording's store via
+  `build_memory_from_config`, which threw before it could read the
+  recording. With this fix, a sqlite-backed recording can be replayed
+  offline (the gif work is a separate follow-up).
+- Discovered while dogfooding the framework to build the README demo —
+  a class of failure that only a configured-memory CLI path triggers,
+  and no shipped config exercised it.

--- a/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/memory.py
+++ b/packages/agentforge-memory-neo4j/src/agentforge_memory_neo4j/memory.py
@@ -47,6 +47,23 @@ class Neo4jMemoryStore(MemoryStore):
         driver = AsyncGraphDatabase.driver(url, auth=auth)
         return cls(runner=_Neo4jDriverRunner(driver, database))
 
+    @classmethod
+    async def from_config(
+        cls,
+        *,
+        url: str,
+        auth: tuple[str, str] | list[str],
+        database: str = "neo4j",
+    ) -> Neo4jMemoryStore:  # pragma: no cover — exercised only with `-m live`.
+        """Build from a `modules.memory.config` block (bug-022).
+
+        Async config-driven factory matching the framework convention.
+        `auth` arrives from YAML as a 2-item list; coerce to the tuple
+        `from_url` expects.
+        """
+        username, password = auth
+        return await cls.from_url(url, auth=(username, password), database=database)
+
     async def __aenter__(self) -> Neo4jMemoryStore:
         return self
 

--- a/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/memory.py
+++ b/packages/agentforge-memory-postgres/src/agentforge_memory_postgres/memory.py
@@ -76,6 +76,21 @@ class PostgresMemoryStore(MemoryStore):
         pool = await asyncpg.create_pool(dsn=dsn, min_size=min_size, max_size=max_size)
         return cls(runner=_AsyncpgPoolRunner(pool))
 
+    @classmethod
+    async def from_config(
+        cls,
+        *,
+        dsn: str,
+        min_size: int = 1,
+        max_size: int = 10,
+    ) -> Self:  # pragma: no cover — exercised only with `-m live`.
+        """Build from a `modules.memory.config` block (bug-022).
+
+        Async config-driven factory matching the framework convention;
+        delegates to `from_dsn`.
+        """
+        return await cls.from_dsn(dsn, min_size=min_size, max_size=max_size)
+
     async def __aenter__(self) -> Self:
         return self
 

--- a/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/memory.py
+++ b/packages/agentforge-memory-sqlite/src/agentforge_memory_sqlite/memory.py
@@ -56,6 +56,18 @@ class SqliteMemoryStore(MemoryStore):
         await SqliteMigrator(connection).apply_pending()
         return cls(connection=connection)
 
+    @classmethod
+    async def from_config(cls, *, path: str | Path) -> SqliteMemoryStore:
+        """Build from a `modules.memory.config` block (bug-022).
+
+        The framework's config-driven module convention: every module
+        type exposes a `from_config` factory so `build_*_from_config`
+        can instantiate it from YAML. Memory construction is async
+        (it opens a connection), so unlike the sync `from_config` on
+        stateless modules this one is a coroutine.
+        """
+        return await cls.from_path(path)
+
     def migrator(self) -> SqliteMigrator:
         """Return a `SqliteMigrator` configured against the
         package's bundled migrations directory (feat-024)."""

--- a/packages/agentforge-memory-sqlite/tests/unit/test_memory.py
+++ b/packages/agentforge-memory-sqlite/tests/unit/test_memory.py
@@ -33,6 +33,19 @@ async def test_passes_memory_conformance_suite() -> None:
         await store.close()
 
 
+@pytest.mark.asyncio
+async def test_from_config_builds_a_live_store() -> None:
+    """bug-022: `from_config` is the config-driven factory the CLI's
+    `build_memory_from_config` uses. It must return a live store."""
+    store = await SqliteMemoryStore.from_config(path=":memory:")
+    try:
+        claim = Claim(run_id="r1", project="p", agent="a", category="c", payload={"x": 1})
+        claim_id = await store.put(claim)
+        assert (await store.get(claim_id)) is not None
+    finally:
+        await store.close()
+
+
 # ---- Lifecycle ----
 
 

--- a/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/memory.py
+++ b/packages/agentforge-memory-surrealdb/src/agentforge_memory_surrealdb/memory.py
@@ -64,6 +64,24 @@ class SurrealMemoryStore(MemoryStore):
         await client.use(namespace, database)
         return cls(runner=_SurrealClientRunner(client))
 
+    @classmethod
+    async def from_config(
+        cls,
+        *,
+        url: str,
+        namespace: str = "agentforge",
+        database: str = "default",
+        auth: tuple[str, str] | list[str] | None = None,
+    ) -> SurrealMemoryStore:  # pragma: no cover — exercised only with `-m live`.
+        """Build from a `modules.memory.config` block (bug-022).
+
+        Async config-driven factory matching the framework convention.
+        `auth` arrives from YAML as a 2-item list (or omitted); coerce
+        to the tuple `from_url` expects.
+        """
+        auth_tuple = (auth[0], auth[1]) if auth is not None else None
+        return await cls.from_url(url, namespace=namespace, database=database, auth=auth_tuple)
+
     async def __aenter__(self) -> SurrealMemoryStore:
         return self
 

--- a/packages/agentforge/src/agentforge/cli/_build.py
+++ b/packages/agentforge/src/agentforge/cli/_build.py
@@ -21,6 +21,7 @@ deterministic exit codes (per feat-017 §4 — config invalid → 2).
 from __future__ import annotations
 
 import contextlib
+import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -75,7 +76,7 @@ async def build_agent_from_config(
     Splits out from `load_and_build` for tests + reuse — tests build
     a `AgentForgeConfig` directly and skip the YAML parse.
     """
-    memory = build_memory_from_config(config)
+    memory = await build_memory_from_config(config)
     if memory is not None:
         await _maybe_init_schema(memory)
     evaluators = build_evaluators_from_config(config)
@@ -115,12 +116,18 @@ async def build_agent_from_config(
         raise
 
 
-def build_memory_from_config(config: AgentForgeConfig) -> MemoryStore | None:
-    """Resolve + instantiate `modules.memory`. Returns None when absent."""
+async def build_memory_from_config(config: AgentForgeConfig) -> MemoryStore | None:
+    """Resolve + instantiate `modules.memory`. Returns None when absent.
+
+    Async because the real memory backends (sqlite/postgres/neo4j/
+    surrealdb) open a connection at construction and expose an async
+    `from_config` factory (bug-022). Falls back to the sync
+    `_instantiate` path for stores that ship a plain/sync constructor.
+    """
     if config.modules.memory is None:
         return None
     cls = _resolve_class("memory", config.modules.memory.driver)
-    instance = _instantiate(cls, config.modules.memory.config)
+    instance = await _ainstantiate_memory(cls, config.modules.memory.config)
     if not isinstance(instance, MemoryStore):
         msg = (
             f"Resolved memory driver {config.modules.memory.driver!r} "
@@ -399,6 +406,29 @@ def _instantiate(cls: type, cfg: dict[str, Any]) -> Any:
             return from_config(**cfg)
         except TypeError:
             return from_config(cfg)
+    return cls(**cfg)
+
+
+async def _ainstantiate_memory(cls: type, cfg: dict[str, Any]) -> Any:
+    """Async-aware construction for memory stores (bug-022).
+
+    Memory backends construct asynchronously (they open a connection)
+    and expose an awaitable `from_config`. Prefer it; if the resolved
+    class only offers a sync constructor (e.g. a test double), fall
+    back to the shared sync `_instantiate`.
+
+    Mirrors `_instantiate`'s keyword-then-positional `from_config`
+    shape so externally-shipped stores using either signature load.
+    """
+    from_config = getattr(cls, "from_config", None)
+    if callable(from_config):
+        try:
+            result = from_config(**cfg)
+        except TypeError:
+            result = from_config(cfg)
+        if inspect.isawaitable(result):
+            return await result
+        return result
     return cls(**cfg)
 
 

--- a/packages/agentforge/src/agentforge/cli/db_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/db_cmd.py
@@ -83,7 +83,7 @@ async def _dispatch(args: argparse.Namespace) -> int:
     from agentforge_core.config.loader import load_config  # noqa: PLC0415
 
     config = load_config(args.path, env=args.env, overrides=list(args.override) or None)
-    memory = build_memory_from_config(config)
+    memory = await build_memory_from_config(config)
     if memory is None:
         sys.stderr.write("agentforge db: modules.memory must be configured.\n")
         return 1

--- a/packages/agentforge/src/agentforge/cli/debug_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/debug_cmd.py
@@ -49,7 +49,7 @@ async def _dispatch(args: argparse.Namespace) -> int:
     from agentforge_core.config.loader import load_config  # noqa: PLC0415
 
     config = load_config(args.path, env=args.env, overrides=list(args.override) or None)
-    memory = build_memory_from_config(config)
+    memory = await build_memory_from_config(config)
     if memory is None:
         sys.stderr.write("agentforge debug: modules.memory must be configured.\n")
         return 1

--- a/packages/agentforge/src/agentforge/cli/health_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/health_cmd.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import json
 import sys
 from pathlib import Path
@@ -113,6 +114,8 @@ async def _check_backends(config: AgentForgeConfig) -> list[dict[str, Any]]:
 async def _probe(label: str, factory: Any) -> dict[str, Any]:
     try:
         instance = factory()
+        if inspect.isawaitable(instance):
+            instance = await instance
         if instance is None:
             return {"name": label, "kind": "backend", "ok": True, "detail": "none configured"}
         init = getattr(instance, "init_schema", None)

--- a/packages/agentforge/src/agentforge/cli/run_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/run_cmd.py
@@ -170,7 +170,7 @@ async def _build_for_run(args: argparse.Namespace, config: Any) -> tuple[Agent, 
     side-effect-bearing pipeline doesn't re-execute on replay.
     """
     if args.replay is not None:
-        memory = build_memory_from_config(config)
+        memory = await build_memory_from_config(config)
         if memory is None:
             msg = "--replay requires modules.memory to be configured."
             raise ModuleError(msg)

--- a/packages/agentforge/tests/unit/test_cli_build.py
+++ b/packages/agentforge/tests/unit/test_cli_build.py
@@ -111,7 +111,7 @@ async def test_build_memory_resolves_driver_and_calls_init_schema() -> None:
         agent=AgentConfig(),
         modules=ModulesConfig(memory=MemoryModuleConfig(driver="build-fake-mem")),
     )
-    memory = build_memory_from_config(cfg)
+    memory = await build_memory_from_config(cfg)
     assert isinstance(memory, _FakeMemory)
 
 
@@ -126,18 +126,42 @@ async def test_build_evaluators_resolves_entries() -> None:
     assert isinstance(evaluators[0], _FakeEvaluator)
 
 
-def test_build_memory_returns_none_when_no_module_configured() -> None:
+@pytest.mark.asyncio
+async def test_build_memory_returns_none_when_no_module_configured() -> None:
     cfg = AgentForgeConfig(agent=AgentConfig(), modules=ModulesConfig())
-    assert build_memory_from_config(cfg) is None
+    assert await build_memory_from_config(cfg) is None
 
 
-def test_build_memory_errors_on_unregistered_driver() -> None:
+@pytest.mark.asyncio
+async def test_build_memory_errors_on_unregistered_driver() -> None:
     cfg = AgentForgeConfig(
         agent=AgentConfig(),
         modules=ModulesConfig(memory=MemoryModuleConfig(driver="no-such")),
     )
     with pytest.raises(ModuleError, match="No module registered for memory"):
-        build_memory_from_config(cfg)
+        await build_memory_from_config(cfg)
+
+
+@pytest.mark.asyncio
+async def test_build_memory_builds_real_sqlite_store_from_config() -> None:
+    """Regression for bug-022: a real async backend (sqlite) must build
+    from `modules.memory` config via its async `from_config`, and the
+    returned store must be live (a round-trip `put`/`get` works)."""
+    pytest.importorskip("agentforge_memory_sqlite")
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        modules=ModulesConfig(
+            memory=MemoryModuleConfig(driver="sqlite", config={"path": ":memory:"}),
+        ),
+    )
+    memory = await build_memory_from_config(cfg)
+    assert isinstance(memory, MemoryStore)
+    claim = Claim(run_id="r1", project="p", agent="a", category="__step", payload={"k": "v"})
+    claim_id = await memory.put(claim)
+    fetched = await memory.get(claim_id)
+    assert fetched is not None
+    assert fetched.payload == {"k": "v"}
+    await memory.close()
 
 
 @pytest.mark.asyncio
@@ -222,7 +246,7 @@ async def test_in_memory_store_used_when_no_module_section() -> None:
     cfg = AgentForgeConfig(agent=AgentConfig(), modules=ModulesConfig())
     # We can't construct the Agent without a strategy; instead check
     # the helper returns None.
-    assert build_memory_from_config(cfg) is None
+    assert await build_memory_from_config(cfg) is None
     # And InMemoryStore is the runtime default — caller wires it.
     fallback = InMemoryStore()
     assert isinstance(fallback, MemoryStore)


### PR DESCRIPTION
## What

Fixes **bug-022**: `modules.memory` could not be built from config for any real backend. `build_memory_from_config` instantiated the resolved store via the shared sync `_instantiate` → `cls(**cfg)`, but all four backends (sqlite/postgres/neo4j/surrealdb) construct **asynchronously** via `from_path`/`from_dsn`/`from_url` and none implemented the `from_config` factory convention every *other* module type has (LLM clients, embedders, rerankers, observability hooks, protocol bridges).

Result, pre-fix:

```
$ agentforge run "hi" --config agentforge.yaml   # modules.memory configured
SqliteMemoryStore.__init__() got an unexpected keyword argument 'path'
```

This broke `agentforge run` / `health` / `db migrate` / `debug` / `run --replay` whenever memory was configured. The shipped example configs and scaffold templates never populate `modules.memory` (they fall back to `InMemoryStore`), so the gap went unexercised.

## How

- **Add an async `from_config`** to each memory store, delegating to its existing async factory. neo4j/surreal coerce the YAML `auth` list to the `tuple[str, str]` `from_url` expects. postgres/neo4j/surreal are `# pragma: no cover` (live-only), matching the convention for those backends' live factories; **sqlite** gets a real offline test.
- **`_ainstantiate_memory`** in `_build.py`: prefers an awaitable `from_config` (awaits it), falls back to the shared sync `_instantiate` (so sync-constructed doubles still load). `build_memory_from_config` becomes `async`.
- **Callers** (`build_agent_from_config`, `run_cmd`, `health_cmd`, `db_cmd`, `debug_cmd`) already run in async contexts and now `await` it; `health._probe` awaits an awaitable factory result.
- The shared sync `_instantiate` and the other five `build_*_from_config` helpers are untouched — only memory routes through the async path, so no other module type regresses.

Implements an established convention (not a new design) → **no ADR**.

## Tests

- `test_build_memory_builds_real_sqlite_store_from_config` — offline, real sqlite, `put`/`get` round-trip. Fails (`TypeError`) on pre-fix code.
- `SqliteMemoryStore.from_config` unit test (offline).
- Existing sync builder tests converted to async; the `_Holder`/`_FakeMemory` doubles exercise the sync fallback branch.
- `pre-commit run --all-files` green: ruff, mypy --strict, bandit, coverage ≥ 90%.

## Notes

Discovered while dogfooding the framework to build the README demo gif — `--replay` rebuilds the recording's store via `build_memory_from_config`, which threw before reading the recording. This unblocks an offline sqlite-backed replay (the gif itself is a separate follow-up).

See `docs/bugs/bug-022-memory-from-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)