### PR TITLE
feat(providers): config passthrough + Bedrock STS assume-role (enh-004, closes #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ release tag bumps every workspace member to the same minor version.
 
 ### Added
 
+- **enh-004 — provider `config:` passthrough + Bedrock STS assume-role.**
+  `providers.<name>.config` is now passed to the provider constructor, so
+  `region` / `aws_profile` / `role_arn` / `timeout_seconds` reach the
+  client from YAML (it was documented but silently dropped — a plain
+  `type:model` string could only carry the model id; an unknown key now
+  raises a clear `ModuleError`). The Bedrock chat + embedding clients gain
+  a `role_arn` (+ `role_session_name`) option that assumes an IAM role via
+  STS before driving `bedrock-runtime` (cross-account / least-privilege),
+  alongside the existing ambient credential chain. Runbook 13 gains an AWS
+  Bedrock section (inference-profile ids, IAM, assume-role). Closes #92.
+  See [enh-004](docs/enhancements/enh-004-bedrock-provider-config-and-assume-role.md).
+
 - **enh-003 — MCP HTTP transport middleware seam.** `MCPServer.from_http`
   now accepts `middleware=[Middleware(...)]`, applied to the
   streamable-HTTP Starlette app the default runner builds — the seam for

--- a/docs/enhancements/enh-004-bedrock-provider-config-and-assume-role.md
+++ b/docs/enhancements/enh-004-bedrock-provider-config-and-assume-role.md
@@ -1,0 +1,126 @@
+# enh-004: provider `config:` passthrough + Bedrock STS assume-role
+
+> Improves a *shipped* feature (feat-003, LLM provider abstraction). Filed
+> as issue #92 by a consumer agent running Claude + Cohere on AWS Bedrock.
+> The Bedrock provider already exists and is published; the real gaps are
+> (1) `providers.*.config` was documented but silently dropped, so AWS
+> settings could not reach the client via YAML, and (2) no first-class STS
+> assume-role for cross-account / least-privilege Bedrock access.
+
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **ID** | enh-004 |
+| **Title** | Pass `providers.config` to the provider constructor + Bedrock `role_arn` assume-role |
+| **Status** | `shipped` (0.5.0) |
+| **Owner** | kjoshi |
+| **Created** | 2026-06-16 |
+| **Target version** | 0.5.0 |
+| **Languages** | `python` |
+| **Improves** | feat-003 (LLM provider abstraction) |
+
+---
+
+## 1. Summary
+
+Honor the `providers.<name>.config` block (already in the schema, already
+documented in runbook 13) by passing it to the provider constructor, so
+`region` / `aws_profile` / `role_arn` / `timeout_seconds` reach the client
+from YAML. Add a `role_arn` (+ `role_session_name`) option to the Bedrock
+chat and embedding clients that performs an STS assume-role before driving
+`bedrock-runtime`.
+
+## 2. Motivation
+
+Issue #92 reported "there is no AWS Bedrock provider." In fact
+`agentforge-bedrock` is published (PyPI 0.2.x) and registered — `BedrockClient`
+(Converse, tools, streaming, retry, pricing, inference-profile ids) and
+`BedrockEmbeddingClient` (Titan/Cohere) both work. The consumer re-rolled
+boto3 because two things blocked configuring it:
+
+1. **`providers.config` was dropped.** `ProviderConfig.config` is documented
+   ("passed through to the provider's constructor") and runbook 13 shows a
+   `config:` block — but `_resolve_llm` collapsed the named provider to a
+   bare `"type:model"` string, discarding `config`. So **no** provider
+   (Bedrock, Anthropic, OpenAI) could receive `region` / credentials / retry
+   settings from YAML; the only path was constructing the client in Python
+   and passing the instance.
+2. **No first-class assume-role.** Bedrock in production is commonly reached
+   via an assumed IAM role (cross-account, least-privilege). The ambient
+   chain (`AWS_PROFILE` with `role_arn`, IRSA, instance profile) works, but
+   there was no explicit per-client `role_arn`.
+
+The inference-profile gotcha the issue calls out (`us.anthropic.claude-…`,
+the `…-v1:0` suffix) is **already handled** — documented here and in runbook
+13 so it stops surprising people.
+
+## 2.5 Framework-level vs derived-agent-level
+
+**Framework.** Provider construction from config and the AWS session/STS
+wiring are framework code. A consumer cannot make `providers.config` work
+(the build path owns it) and shouldn't re-implement STS credential plumbing
+per agent.
+
+- **Derived-agent test:** the workaround (call `bedrock-runtime` via boto3
+  directly, reuse only the `BudgetPolicy` value) re-implements the runtime
+  the framework owns — fails the test → framework work.
+- **How it helps derived agents:** an AWS agent configures Bedrock entirely
+  in YAML (`type: bedrock`, inference-profile `model`, `region`, `role_arn`)
+  and gets the `Agent` runtime + budget + provenance + retry/pricing — one
+  IAM credential set, swap-by-config between the Anthropic API and Bedrock.
+
+## 3. Before / after
+
+| Aspect | Before | After |
+|---|---|---|
+| `providers.default.config` | silently dropped | passed to the provider constructor |
+| Region / creds from YAML | impossible (Python construction only) | `providers.<name>.config: { region, aws_profile, … }` |
+| Bedrock assume-role | ambient chain only | explicit `role_arn` (+ `role_session_name`) via STS |
+| Inference-profile id | worked, undocumented | documented (runbook 13) |
+
+## 4. Backward compatibility
+
+Additive. A provider with no `config:` block still resolves to the same
+`"type:model"` string. A config key the provider can't accept raises a clear
+`ModuleError` (was: silently ignored). `role_arn=None` (default) keeps the
+ambient credential chain — no behaviour change for existing Bedrock users.
+
+## 5. Implementation
+
+- `_resolve_llm` (`agentforge/cli/_build.py`): when `providers.default.config`
+  is non-empty, build the client via the resolver with
+  `cls(model_id=…, **config)` (the same `cls(model_id=…)` contract `Agent`
+  uses for a model string, extended with the settings); a `TypeError` from
+  unknown keys surfaces as a `ModuleError`.
+- `BedrockClient` / `BedrockEmbeddingClient`: new `role_arn` /
+  `role_session_name` params. `_ensure_client` calls a new
+  `_assume_role_credentials()` (STS `assume_role` → temp credential kwargs)
+  when `role_arn` is set, else uses the ambient session.
+
+## 6. Test plan
+
+- `test_provider_config_block_passed_to_constructor` — a recording fake
+  provider receives `model_id` + the `config` kwargs.
+- `test_provider_config_rejects_unknown_keys` — unknown key → `ModuleError`.
+- `test_assume_role_drives_bedrock_with_temp_credentials` /
+  `test_embedding_assume_role_drives_runtime_with_temp_credentials` — an
+  injected session asserts STS `assume_role` is called and the temp
+  credentials are threaded into the `bedrock-runtime` client; the no-role
+  path skips STS.
+
+## 7. Out of scope (backlog)
+
+- **`config:` on a plain `agent.model` string.** Settings still require the
+  `providers.<name>` form; attaching config to a bare `agent.model: "…"`
+  string is deferred.
+- **Generic "model-role" registry** (judge / summarizer / classifier as
+  `provider:model`) from the issue's "related" list — its own feat.
+
+## 8. References
+
+- Improved feature: feat-003 (LLM provider abstraction)
+- Issue: #92
+- Runbook: 13 — Configure multi-provider (AWS Bedrock section)

--- a/docs/features/feat-003-llm-provider-abstraction.md
+++ b/docs/features/feat-003-llm-provider-abstraction.md
@@ -456,6 +456,14 @@ Shipped:
   `global.…`) supported transparently.
 - Resolver pattern for `Agent(model="bedrock:…")` lookup.
 - Pricing entry-point with strip-cross-region-prefix logic.
+- **enh-004** — `providers.<name>.config` is passed through to the
+  provider constructor (`region` / `aws_profile` / `role_arn` /
+  `timeout_seconds` reach the client from YAML; previously dropped —
+  a plain `type:model` string carries only the model id, and an
+  unknown config key now raises `ModuleError`). The Bedrock chat +
+  embedding clients gained `role_arn` (+ `role_session_name`) STS
+  assume-role. Runbook 13 documents the AWS Bedrock path
+  (inference-profile ids, IAM, assume-role). Closes #92.
 
 Not yet shipped (backlog):
 

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/client.py
@@ -85,6 +85,16 @@ class BedrockClient(LLMClient):
         timeout_seconds: Per-request timeout. Default 60s.
         aws_profile: Optional named profile from `~/.aws/credentials`.
             `None` uses the default boto3 credential chain.
+        role_arn: Optional IAM role ARN to assume via STS before
+            calling Bedrock (enh-004). When set, the client assumes the
+            role on first use and drives `bedrock-runtime` with the
+            returned temporary credentials — for cross-account access
+            or least-privilege Bedrock roles. `None` (default) uses the
+            ambient credentials (profile / env / instance / IRSA),
+            which is itself enough for assume-role via an `AWS_PROFILE`
+            configured with `role_arn` + `source_profile`.
+        role_session_name: STS session name for the assume-role call.
+            Defaults to `"agentforge"`.
         session: Optional injected `aioboto3.Session` — primarily for
             tests; production code passes nothing.
     """
@@ -97,6 +107,8 @@ class BedrockClient(LLMClient):
         max_retries: int = _DEFAULT_MAX_RETRIES,
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
         aws_profile: str | None = None,
+        role_arn: str | None = None,
+        role_session_name: str = "agentforge",
         session: Any | None = None,
     ) -> None:
         if not model_id:
@@ -110,6 +122,8 @@ class BedrockClient(LLMClient):
         self._max_retries = max_retries
         self._timeout_seconds = timeout_seconds
         self._aws_profile = aws_profile
+        self._role_arn = role_arn
+        self._role_session_name = role_session_name
         self._session: Any | None = session
         self._client_cm: Any | None = None
         self._client: Any | None = None
@@ -311,14 +325,36 @@ class BedrockClient(LLMClient):
         )
 
     async def _ensure_client(self) -> Any:
-        """Lazily instantiate the aioboto3 Bedrock Runtime client."""
+        """Lazily instantiate the aioboto3 Bedrock Runtime client.
+
+        When `role_arn` is set, assume the role via STS first and drive
+        `bedrock-runtime` with the returned temporary credentials
+        (enh-004); otherwise use the session's ambient credentials.
+        """
         if self._client is not None:
             return self._client
         if self._session is None:
             self._session = aioboto3.Session(profile_name=self._aws_profile)
-        self._client_cm = self._session.client("bedrock-runtime", region_name=self._region)
+        creds = await self._assume_role_credentials() if self._role_arn else {}
+        self._client_cm = self._session.client("bedrock-runtime", region_name=self._region, **creds)
         self._client = await self._client_cm.__aenter__()
         return self._client
+
+    async def _assume_role_credentials(self) -> dict[str, str]:
+        """Assume `role_arn` via STS and return temporary credential
+        kwargs for the `bedrock-runtime` client (enh-004)."""
+        assert self._session is not None
+        async with self._session.client("sts", region_name=self._region) as sts:
+            resp = await sts.assume_role(
+                RoleArn=self._role_arn,
+                RoleSessionName=self._role_session_name,
+            )
+        creds = resp["Credentials"]
+        return {
+            "aws_access_key_id": creds["AccessKeyId"],
+            "aws_secret_access_key": creds["SecretAccessKey"],
+            "aws_session_token": creds["SessionToken"],
+        }
 
     def _build_converse_request(
         self,

--- a/packages/agentforge-bedrock/src/agentforge_bedrock/embedding.py
+++ b/packages/agentforge-bedrock/src/agentforge_bedrock/embedding.py
@@ -76,6 +76,8 @@ class BedrockEmbeddingClient(EmbeddingClient):
         max_retries: int = _DEFAULT_MAX_RETRIES,
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
         aws_profile: str | None = None,
+        role_arn: str | None = None,
+        role_session_name: str = "agentforge",
         cohere_input_type: str = "search_document",
         session: Any | None = None,
     ) -> None:
@@ -90,6 +92,8 @@ class BedrockEmbeddingClient(EmbeddingClient):
         self._max_retries = max_retries
         self._timeout_seconds = timeout_seconds
         self._aws_profile = aws_profile
+        self._role_arn = role_arn
+        self._role_session_name = role_session_name
         self._cohere_input_type = cohere_input_type
         self._session: Any | None = session
         self._client_cm: Any | None = None
@@ -197,9 +201,26 @@ class BedrockEmbeddingClient(EmbeddingClient):
             return self._client
         if self._session is None:
             self._session = aioboto3.Session(profile_name=self._aws_profile)
-        self._client_cm = self._session.client("bedrock-runtime", region_name=self._region)
+        creds = await self._assume_role_credentials() if self._role_arn else {}
+        self._client_cm = self._session.client("bedrock-runtime", region_name=self._region, **creds)
         self._client = await self._client_cm.__aenter__()
         return self._client
+
+    async def _assume_role_credentials(self) -> dict[str, str]:
+        """Assume `role_arn` via STS and return temporary credential
+        kwargs for the `bedrock-runtime` client (enh-004)."""
+        assert self._session is not None
+        async with self._session.client("sts", region_name=self._region) as sts:
+            resp = await sts.assume_role(
+                RoleArn=self._role_arn,
+                RoleSessionName=self._role_session_name,
+            )
+        creds = resp["Credentials"]
+        return {
+            "aws_access_key_id": creds["AccessKeyId"],
+            "aws_secret_access_key": creds["SecretAccessKey"],
+            "aws_session_token": creds["SessionToken"],
+        }
 
 
 # ----------------------------------------------------------------------

--- a/packages/agentforge-bedrock/tests/unit/test_client.py
+++ b/packages/agentforge-bedrock/tests/unit/test_client.py
@@ -454,3 +454,88 @@ async def test_multi_turn_conversation_translates_each_role(
     )
     sent_messages: list[dict[str, Any]] = fake_bedrock.calls[0]["messages"]
     assert [m["role"] for m in sent_messages] == ["user", "assistant", "user"]
+
+
+# ---- enh-004: STS assume-role ----
+
+
+class _FakeSTS:
+    """Records `assume_role` calls and returns scripted temp credentials."""
+
+    def __init__(self) -> None:
+        self.assume_calls: list[dict[str, Any]] = []
+
+    async def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+        self.assume_calls.append(kwargs)
+        return {
+            "Credentials": {
+                "AccessKeyId": "AK-TEMP",
+                "SecretAccessKey": "SK-TEMP",
+                "SessionToken": "TOKEN-TEMP",
+            }
+        }
+
+
+class _AssumeRoleSession:
+    """Fake session: routes `sts` to `_FakeSTS`, records the kwargs the
+    `bedrock-runtime` client is built with (so the test can assert the
+    temp credentials were threaded in)."""
+
+    def __init__(self, bedrock: _FakeBedrockClient, sts: _FakeSTS) -> None:
+        self._bedrock = bedrock
+        self._sts = sts
+        self.runtime_kwargs: dict[str, Any] = {}
+
+    def client(self, service: str, **kwargs: Any) -> Any:
+        from collections.abc import AsyncIterator  # noqa: PLC0415
+        from contextlib import asynccontextmanager  # noqa: PLC0415
+
+        target = self._sts if service == "sts" else self._bedrock
+        if service != "sts":
+            self.runtime_kwargs = kwargs
+
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[Any]:
+            yield target
+
+        return _cm()
+
+
+@pytest.mark.asyncio
+async def test_assume_role_drives_bedrock_with_temp_credentials() -> None:
+    """When `role_arn` is set, the client assumes the role via STS and
+    builds `bedrock-runtime` with the returned temporary credentials."""
+    bedrock = _FakeBedrockClient()
+    bedrock.responses.append(converse_response(text="ok"))
+    sts = _FakeSTS()
+    session = _AssumeRoleSession(bedrock, sts)
+
+    client = BedrockClient(
+        model_id="us.anthropic.claude-3-haiku-20240307-v1:0",
+        role_arn="arn:aws:iam::123456789012:role/bedrock-invoke",
+        session=session,
+    )
+    resp = await client.call("sys", [Message(role="user", content="hi")])
+
+    assert resp.content == "ok"
+    assert sts.assume_calls == [
+        {
+            "RoleArn": "arn:aws:iam::123456789012:role/bedrock-invoke",
+            "RoleSessionName": "agentforge",
+        }
+    ]
+    assert session.runtime_kwargs["aws_access_key_id"] == "AK-TEMP"
+    assert session.runtime_kwargs["aws_secret_access_key"] == "SK-TEMP"
+    assert session.runtime_kwargs["aws_session_token"] == "TOKEN-TEMP"
+
+
+@pytest.mark.asyncio
+async def test_no_role_arn_skips_sts_and_uses_ambient_credentials(
+    fake_bedrock: _FakeBedrockClient, fake_session: _FakeSession
+) -> None:
+    """Without `role_arn`, no STS call happens and bedrock-runtime is built
+    with no explicit credential kwargs (ambient chain)."""
+    fake_bedrock.responses.append(converse_response(text="ok"))
+    client = BedrockClient(model_id="anthropic.claude-3-haiku-20240307-v1:0", session=fake_session)
+    resp = await client.call("sys", [Message(role="user", content="hi")])
+    assert resp.content == "ok"

--- a/packages/agentforge-bedrock/tests/unit/test_embedding.py
+++ b/packages/agentforge-bedrock/tests/unit/test_embedding.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json as _json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 from agentforge_bedrock import _retry as retry_mod
@@ -257,3 +260,56 @@ def test_default_capabilities_empty() -> None:
     client = BedrockEmbeddingClient(model_id=_TITAN)
     assert client.capabilities() == set()
     assert client.supports("multimodal") is False
+
+
+# ---- enh-004: STS assume-role ----
+
+
+@pytest.mark.asyncio
+async def test_embedding_assume_role_drives_runtime_with_temp_credentials() -> None:
+    """When `role_arn` is set, the embedding client assumes the role via STS
+    and builds `bedrock-runtime` with the returned temporary credentials."""
+    bedrock = _FakeBedrockClient()
+    bedrock.invoke_responses.append({"embedding": [0.1] * 1024, "inputTextTokenCount": 3})
+
+    assume_calls: list[dict[str, Any]] = []
+    runtime_kwargs: dict[str, Any] = {}
+
+    class _STS:
+        async def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AK-TEMP",
+                    "SecretAccessKey": "SK-TEMP",
+                    "SessionToken": "TOKEN-TEMP",
+                }
+            }
+
+    class _Session:
+        def client(self, service: str, **kwargs: Any) -> Any:
+            target: Any = _STS() if service == "sts" else bedrock
+            if service != "sts":
+                runtime_kwargs.update(kwargs)
+
+            @asynccontextmanager
+            async def _cm() -> AsyncIterator[Any]:
+                yield target
+
+            return _cm()
+
+    client = BedrockEmbeddingClient(
+        model_id=_TITAN,
+        role_arn="arn:aws:iam::123456789012:role/bedrock-embed",
+        session=_Session(),
+    )
+    resp = await client.embed(["hello"])
+
+    assert len(resp.vectors) == 1
+    assert assume_calls == [
+        {
+            "RoleArn": "arn:aws:iam::123456789012:role/bedrock-embed",
+            "RoleSessionName": "agentforge",
+        }
+    ]
+    assert runtime_kwargs["aws_session_token"] == "TOKEN-TEMP"

--- a/packages/agentforge/src/agentforge/cli/_build.py
+++ b/packages/agentforge/src/agentforge/cli/_build.py
@@ -369,8 +369,12 @@ def _resolve_llm(config: AgentForgeConfig) -> LLMClient | str | None:
     We hand a string back to `Agent.__init__` when the model is a
     plain `"<provider>:<model>"` string — `Agent` already knows how
     to resolve that. When `agent.model` is missing but
-    `providers["default"]` is present, we synthesize the string from
-    the named-provider record.
+    `providers["default"]` is present, the named-provider record is
+    used — and its `config:` block is **passed through to the provider
+    constructor** (enh-004): a plain `type:model` string can only carry
+    the model id, so provider settings (`region`, `aws_profile`,
+    `role_arn`, `timeout_seconds`, …) have to ride the `config` block.
+    Without this they were silently dropped.
     """
     raw = config.agent.model
     if isinstance(raw, str):
@@ -378,7 +382,25 @@ def _resolve_llm(config: AgentForgeConfig) -> LLMClient | str | None:
     default = config.providers.get("default")
     if default is None or default.model is None:
         return None
-    return f"{default.type}:{default.model}"
+    if not default.config:
+        return f"{default.type}:{default.model}"
+    # Construct the provider directly with `model_id` + the `config`
+    # kwargs — the same `cls(model_id=...)` contract `Agent` uses to
+    # resolve a model string (every provider's __init__ accepts
+    # `model_id`), extended with the per-provider settings.
+    cls = _resolve_class("providers", default.type)
+    try:
+        instance = cls(model_id=default.model, **default.config)
+    except TypeError as exc:
+        msg = (
+            f"Provider {default.type!r} ({cls.__name__}) rejected "
+            f"providers.default.config keys {sorted(default.config)}: {exc}"
+        )
+        raise ModuleError(msg) from exc
+    if not isinstance(instance, LLMClient):
+        msg = f"Resolved provider {default.type!r} ({cls.__name__}) does not implement LLMClient."
+        raise ModuleError(msg)
+    return instance
 
 
 def _resolve_class(category: str, name: str) -> type:

--- a/packages/agentforge/src/agentforge/templates/_shared/docs/runbooks/13-configure-multi-provider.md
+++ b/packages/agentforge/src/agentforge/templates/_shared/docs/runbooks/13-configure-multi-provider.md
@@ -59,6 +59,45 @@ modules:
 5. **Per-module overrides.** Any module that takes an LLM (
    guardrails / evaluators / etc.) can name a provider.
 
+## AWS Bedrock (Claude on Bedrock, IAM, assume-role)
+
+Run Claude (or Titan/Cohere embeddings) on **Bedrock** with IAM
+credentials instead of an Anthropic API key — the framework `Agent`
+runtime, `BudgetPolicy`, retries, and cost/provenance all apply unchanged.
+
+```yaml
+providers:
+  default:
+    type: bedrock
+    # Use the INFERENCE-PROFILE id (us./eu./apac./global. prefix).
+    # The bare id rejects on-demand throughput with
+    #   "… isn't supported. Retry … with an inference profile".
+    model: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    config:
+      region: us-east-1
+      # Optional: assume an IAM role via STS before calling Bedrock
+      # (cross-account / least-privilege). Omit to use the ambient
+      # credential chain (env vars, instance profile, IRSA, or an
+      # AWS_PROFILE configured with role_arn + source_profile).
+      role_arn: "arn:aws:iam::123456789012:role/bedrock-invoke"
+agent:
+  budget:
+    usd: 2.0
+```
+
+- **Model id:** the trailing `…-v1:0` is parsed safely — the
+  provider/model split is on the *first* `:` only.
+- **Credentials:** by default the standard AWS chain is used (env /
+  instance profile / IRSA / `AWS_PROFILE`). `role_arn` (+ optional
+  `role_session_name`, default `"agentforge"`) performs an explicit STS
+  assume-role and drives Bedrock with the temporary credentials.
+- **Settings ride the `config:` block.** A plain `agent.model:
+  "bedrock:…"` string can only carry the model id; `region` / `role_arn`
+  / `aws_profile` / `timeout_seconds` must go under `providers.<name>.config`.
+- **Embeddings:** `type: bedrock` also provides Titan / Cohere embeddings
+  (`amazon.titan-embed-text-v2:0`, `cohere.embed-english-v3`), with the
+  same `region` / `role_arn` config.
+
 ## Variations
 
 - **Fallback chain.** Use `agentforge_core.production.FallbackChain`

--- a/packages/agentforge/tests/unit/test_cli_build.py
+++ b/packages/agentforge/tests/unit/test_cli_build.py
@@ -240,6 +240,79 @@ def test_provider_config_synthesised_into_model_string() -> None:
     assert _resolve_llm(cfg) == "bedrock:my-id"
 
 
+class _RecordingProvider:
+    """Fake LLM provider that records the kwargs it was built with."""
+
+    last_kwargs: ClassVar[dict[str, Any]] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_kwargs = kwargs
+
+    async def call(self, *a: Any, **k: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover
+        return
+
+
+def test_provider_config_block_passed_to_constructor() -> None:
+    """enh-004: `providers.default.config` is passed through to the
+    provider constructor (region / role_arn / … reach the client),
+    instead of being silently dropped."""
+    from agentforge_core.contracts.llm import LLMClient  # noqa: PLC0415
+
+    LLMClient.register(_RecordingProvider)  # treat the fake as an LLMClient
+    register("providers", "rec-prov")(_RecordingProvider)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        providers={
+            "default": ProviderConfig(
+                type="rec-prov",
+                model="us.anthropic.claude-haiku-20251001-v1:0",
+                config={"region": "us-east-1", "role_arn": "arn:aws:iam::1:role/r"},
+            )
+        },
+        modules=ModulesConfig(),
+    )
+    from agentforge.cli._build import _resolve_llm  # noqa: PLC0415
+
+    instance = _resolve_llm(cfg)
+    assert isinstance(instance, _RecordingProvider)
+    assert _RecordingProvider.last_kwargs == {
+        "model_id": "us.anthropic.claude-haiku-20251001-v1:0",
+        "region": "us-east-1",
+        "role_arn": "arn:aws:iam::1:role/r",
+    }
+
+
+def test_provider_config_rejects_unknown_keys() -> None:
+    """A config key the provider can't accept surfaces a clear error."""
+
+    class _StrictProvider:
+        def __init__(self, *, model_id: str) -> None:
+            self._m = model_id
+
+        async def call(self, *a: Any, **k: Any) -> Any:  # pragma: no cover
+            raise NotImplementedError
+
+        async def close(self) -> None:  # pragma: no cover
+            return
+
+    from agentforge_core.contracts.llm import LLMClient  # noqa: PLC0415
+
+    LLMClient.register(_StrictProvider)
+    register("providers", "strict-prov")(_StrictProvider)
+    cfg = AgentForgeConfig(
+        agent=AgentConfig(),
+        providers={"default": ProviderConfig(type="strict-prov", model="m", config={"nope": 1})},
+        modules=ModulesConfig(),
+    )
+    from agentforge.cli._build import _resolve_llm  # noqa: PLC0415
+
+    with pytest.raises(ModuleError, match=r"rejected providers\.default\.config"):
+        _resolve_llm(cfg)
+
+
 @pytest.mark.asyncio
 async def test_in_memory_store_used_when_no_module_section() -> None:
     """Confirm the default path produces an `InMemoryStore`."""


### PR DESCRIPTION
## What

Closes #92. The issue reported "no AWS Bedrock provider" — but `agentforge-bedrock` already exists and is published (Converse, tools, streaming, retry, pricing, inference-profile ids; plus Titan/Cohere embeddings). The real blockers to *configuring* it:

1. **`providers.<name>.config` was silently dropped.** The schema documents it ("passed to the provider's constructor") and runbook 13 shows a `config:` block — but `_resolve_llm` collapsed the named provider to a bare `"type:model"` string, discarding `config`. So `region` / `aws_profile` / `role_arn` / `timeout_seconds` could not reach **any** provider (Bedrock/Anthropic/OpenAI) from YAML.
2. **No first-class STS assume-role** for cross-account / least-privilege Bedrock.

## How

- **Config passthrough** (`_resolve_llm`): when `providers.default.config` is non-empty, build the client as `cls(model_id=…, **config)` — the same `cls(model_id=…)` contract `Agent` uses for a model string, extended with the settings. An unknown key now raises a clear `ModuleError` (was: ignored).
- **Bedrock assume-role:** `BedrockClient` + `BedrockEmbeddingClient` gain `role_arn` (+ `role_session_name`). `_ensure_client` assumes the role via STS and drives `bedrock-runtime` with the temporary credentials when set; otherwise the ambient chain (env / instance profile / IRSA / `AWS_PROFILE`).
- **Runbook 13** gains an AWS Bedrock section: inference-profile ids (the `us.anthropic.…-v1:0` gotcha, already handled — now documented), IAM credential chain, assume-role, and that settings ride the `config:` block.

```yaml
providers:
  default:
    type: bedrock
    model: "us.anthropic.claude-haiku-4-5-20251001-v1:0"   # inference profile
    config:
      region: us-east-1
      role_arn: "arn:aws:iam::123456789012:role/bedrock-invoke"
agent:
  budget: { usd: 2.0 }
```

## Consumer benefit

An AWS agent configures Bedrock entirely in YAML and gets the `Agent` runtime + `BudgetPolicy` + provenance + retry/pricing — one IAM credential set, swap-by-config between the Anthropic API and Bedrock — instead of re-rolling boto3 `invoke_model`.

## Tests

- `test_provider_config_block_passed_to_constructor` + `test_provider_config_rejects_unknown_keys`.
- STS assume-role threads temp creds into `bedrock-runtime` for chat + embedding; the no-role path skips STS.
- `pre-commit run --all-files` green.

## Docs

`docs/enhancements/enh-004-…md` (incl. framework-vs-derived-agent section) + feat-003 status + CHANGELOG + runbook 13.

## Out of scope (backlog)

- `config:` on a plain `agent.model` string (settings still need the `providers.<name>` form).
- Generic "model-role" registry (judge/summarizer/classifier) from the issue's "related" list — its own feat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)