### PR TITLE
docs(bugs): close bug-021/022/023 (fixed in 0.3.0)

### DIFF
--- a/docs/bugs/bug-021-add-module-uv-pip.md
+++ b/docs/bugs/bug-021-add-module-uv-pip.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.3.0
 severity: P1
 found-in: 0.2.4
 found-via: agentforge-graph

--- a/docs/bugs/bug-022-memory-from-config.md
+++ b/docs/bugs/bug-022-memory-from-config.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.3.0
 severity: P2
 found-in: 0.2.4
 found-via: dogfooding (README demo gif)

--- a/docs/bugs/bug-023-replay-drops-strategy.md
+++ b/docs/bugs/bug-023-replay-drops-strategy.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: fixed in 0.3.0
 severity: P2
 found-in: 0.2.4
 found-via: dogfooding (README demo gif)


### PR DESCRIPTION
Post-release housekeeping — v0.3.0 is live on PyPI with these fixes, so their catalogue `status:` flips `open` → `fixed in 0.3.0` (per the bugs README convention).

- bug-021 — uv-aware `add module`
- bug-022 — memory-from-config
- bug-023 — replay strategy reconstruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)