### PR TITLE
fix(bug-025): stop `agentforge upgrade` clobbering forked files and custom blocks

### DIFF
--- a/.claude/standards/git.md
+++ b/.claude/standards/git.md
@@ -108,6 +108,31 @@ Required PR contents:
 - Bugs carried section (per pipeline §5; "None" if no fix-while-feature)
 - Pre-commit hook output (✅ all green)
 
+## Changelog — issue traceability
+
+`CHANGELOG.md` is the user-facing record; a downstream consumer reads
+the slice between their old and new pin to learn what changed. To make
+that slice answer **"which of my filed issues does this version
+resolve?"** without re-reading source (issue #115):
+
+- **Every entry that closes a tracked GitHub issue ends with
+  `(closes #NN)`.** Multiple: `(closes #114, #116)`.
+- Entries that fix a catalogued framework bug/enh keep the
+  `bug-NNN` / `enh-NNN` reference in the lead, *and* add `(closes #NN)`
+  when an issue tracks it.
+- A consumer who worked around a now-fixed seam can `grep '(closes #'`
+  the `[Unreleased]`→latest range and see exactly which workarounds are
+  safe to delete.
+
+Example:
+
+```
+### Fixed
+
+- **bug-025 (P1) — `agentforge upgrade` overwrote forked files…** …
+  (closes #114)
+```
+
 ## Merging
 
 - **Squash merge** to main with the PR title as the squashed commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 The framework follows a coordinated release train (per ADR-0015): every
 release tag bumps every workspace member to the same minor version.
 
+Entries that resolve a tracked issue end with `(closes #NN)` — diff the
+slice between two versions to see which of your filed issues a bump fixes.
+
 ## [Unreleased]
 
 ### Changed
@@ -17,6 +20,20 @@ release tag bumps every workspace member to the same minor version.
   only `httpx` is installed. `httpx2 >= 2.4` is now in the dev dependency
   group so the a2a / chat-http / mcp test suites import `TestClient` cleanly;
   runtime HTTP clients are unchanged (still `httpx`). Unblocks dependabot #105.
+
+### Fixed
+
+- **bug-025 (P1) — `agentforge upgrade` overwrote forked files and erased
+  `agentforge:custom` blocks** (data loss). The shared-scaffold re-injection
+  pass (`AGENTS.md` / `CLAUDE.md` / `.cursorrules` / copilot-instructions /
+  the runbooks) wrote every file wholesale, ignoring fork status and replacing
+  the developer-owned custom section — which the runbooks promise survives an
+  upgrade — with the template default. Re-injection (and the Pass-1 managed
+  refresh) now skip forked files and preserve the `agentforge:custom` tail via
+  the existing three-section merge. `agentforge upgrade --dry-run` now prints a
+  per-file plan instead of a one-line summary, so the changes are visible
+  before any write. Found by a downstream consumer on a real 0.2.4 → 0.3.1
+  upgrade. (closes #114)
 
 ## [0.3.1] — 2026-06-17
 

--- a/docs/bugs/bug-025-upgrade-overwrites-forked-and-custom.md
+++ b/docs/bugs/bug-025-upgrade-overwrites-forked-and-custom.md
@@ -1,0 +1,101 @@
+---
+status: open
+severity: P1
+found-in: 0.3.1
+found-via: downstream consumer (agentforge-graph) on a real 0.2.4 → 0.3.1 upgrade
+---
+
+# bug-025 — `agentforge upgrade` overwrites forked files and erases `agentforge:custom` blocks
+
+## Symptom
+
+Data loss, silent on an unattended upgrade. Against template `minimal`,
+framework 0.2.4 → 0.3.1:
+
+```
+$ agentforge fork AGENTS.md
+  → forked AGENTS.md. Future upgrades will skip it.
+$ agentforge upgrade
+  → re-injected 27 shared scaffold files.
+```
+
+After the upgrade, `AGENTS.md` (and every `docs/runbooks/*.md`) is
+rewritten **wholesale**: the fork is ignored and the developer-owned
+`<!-- agentforge:custom -->` block — which the runbook README promises
+"survives `agentforge upgrade`" — is gone. The consumer had to
+hand-recover `AGENTS.md` plus three runbook custom sections.
+
+## Reproduction
+
+1. Scaffold an agent (`agentforge new …`).
+2. Edit a managed three-section file's `agentforge:custom` block (e.g.
+   `AGENTS.md`), and/or `agentforge fork <file>` and hand-edit it.
+3. `agentforge upgrade`.
+4. The custom block is erased; the forked file is overwritten.
+
+## Root cause
+
+`agentforge upgrade` refreshes files in three passes
+(`cli/upgrade_cmd.py::_do_upgrade`). Passes 1–2 handle Copier-template
+files and *do* honour fork status — but the **shared scaffold**
+(`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, copilot-instructions, the 24
+runbooks) is owned by **Pass 3**, `inject_shared_scaffold`, which ran
+independently of the per-file managed/forked/custom resolution:
+
+- `cli/_shared_scaffold.py` walked `_shared/` and did
+  `target.write_text(body)` **unconditionally** for every file — no
+  fork check — then reset the lock entry to `forked: False`, silently
+  un-forking it.
+- It never preserved the custom tail. The three-section helpers
+  (`split_three_section` / `merge_three_section` in `_scaffold_state.py`,
+  feat-019) existed and were unit-tested, but **nothing in the upgrade
+  path ever called them** — so the rendered template (managed region +
+  the template's *default* custom block) replaced the file whole,
+  discarding the consumer's edits.
+
+A secondary gap: `agentforge upgrade --dry-run` printed only a one-line
+summary, so none of this destruction was visible before the write.
+
+## Fix
+
+Route every upgrade write through fork-skip + custom-block preservation:
+
+- New `_scaffold_state.preserve_custom_section(new_content, existing)`:
+  when both the freshly rendered content and the on-disk file are
+  three-section files, it keeps the **new managed region** and the
+  **existing custom tail** (via `split`/`merge_three_section`). When
+  either side lacks the `end-managed` marker (a plain config file, or a
+  file whose markers were stripped without forking) it falls back to the
+  previous whole-file write — `agentforge fork` remains the supported way
+  to protect a fully hand-edited file.
+- `inject_shared_scaffold` now: (a) skips any file the lock marks
+  `forked`, leaving its file and lock entry untouched; (b) preserves the
+  custom block on still-managed files; (c) takes a `dry_run` flag and
+  returns a `SharedScaffoldResult` (`written` / `skipped_forked` /
+  `preserved_custom`) instead of a bare count.
+- `_do_upgrade` Pass 1 also runs `preserve_custom_section`, threads
+  `dry_run` through (writing nothing), and prints a **per-file plan**
+  with the action per path (`refresh` / `refresh (preserve custom block)`
+  / `skip (forked)` / `add (new)` / `refresh shared …`).
+
+## Verification
+
+- `packages/agentforge/tests/unit/test_shared_scaffold.py` — re-injection
+  skips a forked file (file + lock entry preserved); preserves a custom
+  block while refreshing the managed region; `dry_run` writes neither
+  file nor lock.
+- `packages/agentforge/tests/unit/test_three_section_format.py` —
+  `preserve_custom_section` keeps new managed + existing custom, returns
+  new verbatim when there's no existing file, and falls back to whole
+  overwrite when markers are absent.
+- `packages/agentforge/tests/unit/test_upgrade_cmd.py` — end-to-end via
+  `agentforge new` → edit custom / fork → `agentforge upgrade`: the
+  custom sentinel survives, the forked file is untouched, and
+  `--dry-run` writes nothing while listing per-file actions.
+- `uv run pre-commit run --all-files` green.
+
+## Notes
+
+- Related: issue #115 (surface upgrade drift) — separate, additive.
+- Closes #114.
+</content>

--- a/packages/agentforge/src/agentforge/cli/_scaffold_state.py
+++ b/packages/agentforge/src/agentforge/cli/_scaffold_state.py
@@ -248,3 +248,53 @@ def merge_three_section(new_managed: str, existing_custom: str) -> str:
     if END_MANAGED_MARKER not in managed:
         managed = managed.rstrip() + "\n\n" + END_MANAGED_MARKER + "\n"
     return managed.rstrip() + "\n" + existing_custom.lstrip("\n")
+
+
+def preserve_custom_section(new_content: str, existing_content: str | None) -> str:
+    """Carry a developer-owned custom section across an upgrade.
+
+    Given freshly rendered `new_content` and the file's current
+    on-disk `existing_content`, return the body to write so that the
+    custom section (everything after `END_MANAGED_MARKER`) is taken
+    from the existing file rather than the template default. This is
+    the bug-025 guard: it stops `agentforge upgrade` from clobbering
+    the `<!-- agentforge:custom -->` block consumers are promised will
+    "survive upgrade".
+
+    The merge only runs when **both** sides are three-section files
+    (each carries the end-managed marker). When either side lacks the
+    marker — a plain config/yaml file, or a file whose markers a
+    consumer stripped without forking — we cannot tell managed from
+    custom, so we fall back to the previous whole-file behaviour and
+    return `new_content` unchanged. (The supported way to protect a
+    fully hand-edited file is `agentforge fork`.)
+    """
+    if existing_content is None:
+        return new_content
+    if END_MANAGED_MARKER not in new_content or END_MANAGED_MARKER not in existing_content:
+        return new_content
+    new_managed, _ = split_three_section(new_content)
+    _, existing_custom = split_three_section(existing_content)
+    if not existing_custom.strip():
+        # Existing file has the marker but an empty custom tail — nothing
+        # to preserve; the new template default (if any) is fine.
+        return new_content
+    return merge_three_section(new_managed, existing_custom)
+
+
+def custom_section_diverged(new_content: str, existing_content: str | None) -> bool:
+    """Report whether the on-disk custom section actually differs from
+    the freshly rendered template's custom section.
+
+    Used to label `agentforge upgrade` output: `preserve_custom_section`
+    always carries the on-disk tail (safe even when identical), but only
+    a *diverged* tail is worth flagging to the user as "custom block
+    preserved". Comparison ignores surrounding whitespace.
+    """
+    if existing_content is None:
+        return False
+    if END_MANAGED_MARKER not in new_content or END_MANAGED_MARKER not in existing_content:
+        return False
+    _, new_custom = split_three_section(new_content)
+    _, existing_custom = split_three_section(existing_content)
+    return existing_custom.strip() != new_custom.strip()

--- a/packages/agentforge/src/agentforge/cli/_shared_scaffold.py
+++ b/packages/agentforge/src/agentforge/cli/_shared_scaffold.py
@@ -21,6 +21,7 @@ verbatim (apart from the marker header prepend).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -31,12 +32,28 @@ from jinja2 import Environment
 from agentforge.cli._scaffold_state import (
     END_MANAGED_MARKER,
     answers_path,
+    custom_section_diverged,
     hash_content,
     lock_path,
     marker_for,
+    preserve_custom_section,
     read_lock,
     write_lock,
 )
+
+
+@dataclass
+class SharedScaffoldResult:
+    """Outcome of `inject_shared_scaffold`, broken down per file.
+
+    `written` is the list of files (re)written; the other lists record
+    files left untouched so callers can report — and `--dry-run` can
+    preview — exactly what an upgrade would do (bug-025).
+    """
+
+    written: list[str] = field(default_factory=list)
+    skipped_forked: list[str] = field(default_factory=list)
+    preserved_custom: list[str] = field(default_factory=list)
 
 
 def inject_shared_scaffold(
@@ -44,14 +61,26 @@ def inject_shared_scaffold(
     *,
     template_name: str,
     template_version: str,
-) -> int:
+    dry_run: bool = False,
+) -> SharedScaffoldResult:
     """Copy `_shared/` into the destination after Copier rendered.
 
-    Returns the count of files written.
+    Re-injection is fork- and custom-block aware (bug-025):
+
+    - a file the lock marks ``forked`` is **never** rewritten — its
+      lock entry is left exactly as-is;
+    - for a still-managed three-section file, the developer-owned
+      ``<!-- agentforge:custom -->`` tail on disk is preserved while
+      the managed region is refreshed from the template.
+
+    When `dry_run` is set, nothing is written (neither files nor the
+    lock); the returned result still classifies every file so callers
+    can preview the plan.
     """
+    result = SharedScaffoldResult()
     shared_root = _shared_root()
     if shared_root is None:
-        return 0
+        return result
 
     context = _build_context(dst, template_name=template_name)
     # The shared payload is markdown / YAML / plain text — never HTML
@@ -63,31 +92,48 @@ def inject_shared_scaffold(
     )
 
     lock = read_lock(dst)
-    count = 0
     for src_path in _walk(shared_root):
         rel_path = src_path.relative_to(shared_root)
         out_rel, content = _render_one(src_path, rel_path, env, context)
+        rel_key = str(out_rel)
         target = dst / out_rel
-        target.parent.mkdir(parents=True, exist_ok=True)
 
-        marker = marker_for(
-            target.suffix, f"template:{template_name}", template_version, hash_content(content)[:12]
-        )
-        body = content
-        if marker is not None and not content.lstrip().startswith(marker.strip()):
-            body = marker + "\n" + content
-        target.write_text(body, encoding="utf-8")
+        # Respect fork status: a forked file is owned by the consumer.
+        # Leave both the file and its lock entry untouched.
+        existing_entry = lock.get(rel_key)
+        if existing_entry and existing_entry.get("forked"):
+            result.skipped_forked.append(rel_key)
+            continue
 
-        lock[str(out_rel)] = {
-            "hash": hash_content(content),
-            "source_module": f"template:{template_name}:_shared",
-            "source_version": template_version,
-            "forked": False,
-        }
-        count += 1
+        existing = target.read_text(encoding="utf-8") if target.exists() else None
+        body_content = preserve_custom_section(content, existing)
+        if custom_section_diverged(content, existing):
+            result.preserved_custom.append(rel_key)
 
-    write_lock(dst, lock)
-    return count
+        if not dry_run:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            marker = marker_for(
+                target.suffix,
+                f"template:{template_name}",
+                template_version,
+                hash_content(body_content)[:12],
+            )
+            body = body_content
+            if marker is not None and not body_content.lstrip().startswith(marker.strip()):
+                body = marker + "\n" + body_content
+            target.write_text(body, encoding="utf-8")
+
+            lock[rel_key] = {
+                "hash": hash_content(body_content),
+                "source_module": f"template:{template_name}:_shared",
+                "source_version": template_version,
+                "forked": False,
+            }
+        result.written.append(rel_key)
+
+    if not dry_run:
+        write_lock(dst, lock)
+    return result
 
 
 def _walk(root: Path) -> list[Path]:
@@ -173,4 +219,4 @@ def _shared_root() -> Path | None:
 _ = (lock_path,)
 
 
-__all__ = ["inject_shared_scaffold"]
+__all__ = ["SharedScaffoldResult", "inject_shared_scaffold"]

--- a/packages/agentforge/src/agentforge/cli/new_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/new_cmd.py
@@ -116,10 +116,12 @@ def _run_new(args: argparse.Namespace) -> int:
     # feat-019: inject shared runbooks + AGENTS.md / CLAUDE.md /
     # .cursorrules / .github/copilot-instructions.md into every
     # scaffolded agent.
-    shared_count = inject_shared_scaffold(
-        dst,
-        template_name=args.template,
-        template_version=template_version,
+    shared_count = len(
+        inject_shared_scaffold(
+            dst,
+            template_name=args.template,
+            template_version=template_version,
+        ).written
     )
     if shared_count:
         sys.stdout.write(f"  → wrote {shared_count} shared scaffold files (runbooks + AI rules)\n")

--- a/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
@@ -16,9 +16,13 @@ import argparse
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from agentforge_core.production.exceptions import ModuleError
+
+if TYPE_CHECKING:
+    from agentforge.cli._shared_scaffold import SharedScaffoldResult
 
 from agentforge.cli._scaffold_state import (
     _HASH_PREFIX_LEN,
@@ -118,13 +122,6 @@ def _run_upgrade(
         )
         return 1
 
-    if args.dry_run:
-        sys.stdout.write(
-            f"  → dry-run: would re-render template {template_name!r} into this "
-            f"directory and refresh every non-forked managed file.\n"
-        )
-        return 0
-
     template_version = args.to if args.to else _template_version()
     try:
         return _do_upgrade(
@@ -133,6 +130,7 @@ def _run_upgrade(
             template_root=template_root,
             template_version=template_version,
             answers=answers,
+            dry_run=args.dry_run,
         )
     except ModuleError as exc:
         sys.stderr.write(f"upgrade failed: {exc}\n")
@@ -153,9 +151,20 @@ def _do_upgrade(
     template_root: Path,
     template_version: str,
     answers: dict[str, object],
+    dry_run: bool = False,
 ) -> int:
     """Render template → temp; copy each non-forked managed file
-    into work_dir; refresh lock; re-inject shared scaffold."""
+    into work_dir; refresh lock; re-inject shared scaffold.
+
+    Forked files are never rewritten and the developer-owned
+    ``agentforge:custom`` block of three-section files is preserved
+    across the refresh (bug-025). With `dry_run`, nothing is written —
+    a per-file plan is printed instead.
+    """
+    from agentforge.cli._scaffold_state import (  # noqa: PLC0415
+        custom_section_diverged,
+        preserve_custom_section,
+    )
     from agentforge.cli._shared_scaffold import inject_shared_scaffold  # noqa: PLC0415
     from agentforge.cli.new_cmd import _run_copier  # noqa: PLC0415
 
@@ -170,6 +179,8 @@ def _do_upgrade(
     refreshed: list[str] = []
     forked_kept: list[str] = []
     new_files: list[str] = []
+    # rel → human-readable action, used for the --dry-run plan.
+    actions: dict[str, str] = {}
 
     with tempfile.TemporaryDirectory(prefix="agentforge-upgrade-") as temp_str:
         temp = Path(temp_str)
@@ -180,6 +191,7 @@ def _do_upgrade(
             if entry.get("forked"):
                 new_lock[rel] = entry
                 forked_kept.append(rel)
+                actions[rel] = "skip (forked)"
                 continue
             src = temp / rel
             dst = work_dir / rel
@@ -187,18 +199,26 @@ def _do_upgrade(
                 # File was in scaffold but isn't in current template.
                 # Drop it from the new lock — `agentforge upgrade`
                 # treats template removals as "no longer managed".
+                # (Shared-scaffold files live here too; Pass 3 re-adds
+                # them.)
                 continue
-            _write_with_marker(
-                dst,
-                src.read_text(encoding="utf-8"),
-                source_module=str(entry.get("source_module", f"template:{template_name}")),
-                source_version=template_version,
-            )
-            new_lock[rel] = {
-                **entry,
-                "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
-                "source_version": template_version,
-            }
+            new_content = src.read_text(encoding="utf-8")
+            existing = dst.read_text(encoding="utf-8") if dst.exists() else None
+            merged = preserve_custom_section(new_content, existing)
+            kept_custom = custom_section_diverged(new_content, existing)
+            actions[rel] = "refresh (preserve custom block)" if kept_custom else "refresh"
+            if not dry_run:
+                _write_with_marker(
+                    dst,
+                    merged,
+                    source_module=str(entry.get("source_module", f"template:{template_name}")),
+                    source_version=template_version,
+                )
+                new_lock[rel] = {
+                    **entry,
+                    "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
+                    "source_version": template_version,
+                }
             refreshed.append(rel)
 
         # Pass 2: add files in the new template that weren't in the
@@ -212,33 +232,85 @@ def _do_upgrade(
             if rel.startswith(".agentforge-state/"):
                 continue
             dst = work_dir / rel
-            _write_with_marker(
-                dst,
-                src.read_text(encoding="utf-8"),
-                source_module=f"template:{template_name}",
-                source_version=template_version,
-            )
-            new_lock[rel] = {
-                "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
-                "source_module": f"template:{template_name}",
-                "source_version": template_version,
-                "forked": False,
-            }
+            actions[rel] = "add (new)"
+            if not dry_run:
+                _write_with_marker(
+                    dst,
+                    src.read_text(encoding="utf-8"),
+                    source_module=f"template:{template_name}",
+                    source_version=template_version,
+                )
+                new_lock[rel] = {
+                    "hash": hash_content(_strip_marker_for_hash(dst.read_text(encoding="utf-8"))),
+                    "source_module": f"template:{template_name}",
+                    "source_version": template_version,
+                    "forked": False,
+                }
             new_files.append(rel)
 
-    write_lock(work_dir, new_lock)
+    if not dry_run:
+        write_lock(work_dir, new_lock)
 
     # Re-inject the shared scaffold (runbooks + AGENTS.md / CLAUDE.md /
     # .cursorrules / copilot-instructions) so they track the new
-    # framework version.
+    # framework version. Fork- and custom-block-aware (bug-025).
     shared = inject_shared_scaffold(
         work_dir,
         template_name=template_name,
         template_version=template_version,
+        dry_run=dry_run,
+    )
+    return _report_upgrade(
+        actions=actions,
+        refreshed=refreshed,
+        new_files=new_files,
+        forked_kept=forked_kept,
+        shared=shared,
+        dry_run=dry_run,
     )
 
+
+def _report_upgrade(
+    *,
+    actions: dict[str, str],
+    refreshed: list[str],
+    new_files: list[str],
+    forked_kept: list[str],
+    shared: SharedScaffoldResult,
+    dry_run: bool,
+) -> int:
+    """Merge Pass-3 shared verdicts into the action map, then print the
+    dry-run plan or the post-upgrade summary."""
+    # Shared files are owned by Pass 3; let its verdict win over the
+    # Pass-1 "dropped/forked" bookkeeping for the same paths.
+    for rel in shared.skipped_forked:
+        actions[rel] = "skip (forked)"
+    for rel in shared.written:
+        actions[rel] = (
+            "refresh shared (preserve custom block)"
+            if rel in shared.preserved_custom
+            else "refresh shared"
+        )
+
+    forked_total = sorted(set(forked_kept) | set(shared.skipped_forked))
+    custom_preserved = sorted(
+        {rel for rel in refreshed if actions.get(rel, "").startswith("refresh (preserve")}
+        | set(shared.preserved_custom)
+    )
+
+    if dry_run:
+        sys.stdout.write("  → dry-run: no files written. Planned changes:\n")
+        for rel in sorted(actions):
+            sys.stdout.write(f"      {rel}: {actions[rel]}\n")
+        sys.stdout.write(
+            f"  → summary: {len(actions)} files; "
+            f"{len(forked_total)} forked (skipped), "
+            f"{len(custom_preserved)} with custom blocks preserved.\n"
+        )
+        return 0
+
     sys.stdout.write(
-        f"  → refreshed {len(refreshed)} managed files; preserved {len(forked_kept)} forked.\n"
+        f"  → refreshed {len(refreshed)} managed files; preserved {len(forked_total)} forked.\n"
     )
     if new_files:
         max_preview = 3
@@ -246,7 +318,9 @@ def _do_upgrade(
         if len(new_files) > max_preview:
             preview += "…"
         sys.stdout.write(f"  → added {len(new_files)} new managed files: {preview}\n")
-    sys.stdout.write(f"  → re-injected {shared} shared scaffold files.\n")
+    sys.stdout.write(f"  → re-injected {len(shared.written)} shared scaffold files.\n")
+    if custom_preserved:
+        sys.stdout.write(f"  → preserved custom blocks in {len(custom_preserved)} files.\n")
     sys.stdout.write("  → upgrade complete; lock refreshed.\n")
     return 0
 

--- a/packages/agentforge/tests/unit/test_shared_scaffold.py
+++ b/packages/agentforge/tests/unit/test_shared_scaffold.py
@@ -36,10 +36,10 @@ def test_injection_copies_verbatim_files(stub_shared_dir: Path, tmp_path: Path) 
     (stub_shared_dir / "RAW.txt").write_text("hello world", encoding="utf-8")
     dst = _write_destination(tmp_path)
 
-    count = _shared_scaffold.inject_shared_scaffold(
+    result = _shared_scaffold.inject_shared_scaffold(
         dst, template_name="minimal", template_version="0.0.1"
     )
-    assert count == 1
+    assert len(result.written) == 1
     content = (dst / "RAW.txt").read_text(encoding="utf-8")
     assert "hello world" in content
 
@@ -51,10 +51,10 @@ def test_injection_renders_tmpl_through_jinja(stub_shared_dir: Path, tmp_path: P
     )
     dst = _write_destination(tmp_path)
 
-    count = _shared_scaffold.inject_shared_scaffold(
+    result = _shared_scaffold.inject_shared_scaffold(
         dst, template_name="minimal", template_version="0.0.1"
     )
-    assert count == 1
+    assert len(result.written) == 1
     content = (dst / "README.md").read_text(encoding="utf-8")
     assert "# Stub Agent" in content
     assert "slug: stub-agent" in content
@@ -86,7 +86,86 @@ def test_injection_returns_zero_when_shared_root_missing(
 ) -> None:
     monkeypatch.setattr(_shared_scaffold, "_shared_root", lambda: None)
     dst = _write_destination(tmp_path)
-    count = _shared_scaffold.inject_shared_scaffold(
+    result = _shared_scaffold.inject_shared_scaffold(
         dst, template_name="minimal", template_version="0.0.1"
     )
-    assert count == 0
+    assert result.written == []
+
+
+# ----------------------------------------------------------------------
+# bug-025: re-injection must respect fork status + custom blocks
+# ----------------------------------------------------------------------
+
+
+def test_reinjection_skips_forked_file(stub_shared_dir: Path, tmp_path: Path) -> None:
+    """A file the lock marks `forked` is never rewritten and its lock
+    entry is left untouched."""
+    from agentforge.cli._scaffold_state import read_lock, write_lock  # noqa: PLC0415
+
+    (stub_shared_dir / "AGENTS.md").write_text("# template v2 rules\n", encoding="utf-8")
+    dst = _write_destination(tmp_path)
+    # Consumer forked AGENTS.md and hand-wrote it.
+    (dst / "AGENTS.md").write_text("# MY forked rules — do not touch\n", encoding="utf-8")
+    write_lock(
+        dst,
+        {"AGENTS.md": {"hash": "x", "source_module": "s", "source_version": "0", "forked": True}},
+    )
+
+    result = _shared_scaffold.inject_shared_scaffold(
+        dst, template_name="minimal", template_version="0.0.2"
+    )
+
+    assert "AGENTS.md" in result.skipped_forked
+    assert "AGENTS.md" not in result.written
+    # File and lock entry both preserved verbatim.
+    assert (dst / "AGENTS.md").read_text(encoding="utf-8") == "# MY forked rules — do not touch\n"
+    assert read_lock(dst)["AGENTS.md"]["forked"] is True
+
+
+def test_reinjection_preserves_custom_block(stub_shared_dir: Path, tmp_path: Path) -> None:
+    """The developer-owned `agentforge:custom` tail survives while the
+    managed region is refreshed from the template."""
+    end = "<!-- agentforge:end-managed -->"
+    start = "<!-- agentforge:custom -->"
+    custom_end = "<!-- agentforge:end-custom -->"
+
+    (stub_shared_dir / "AGENTS.md").write_text(
+        f"# Rules v2\n\nrefreshed managed body\n\n{end}\n\n"
+        f"{start}\nTEMPLATE default custom\n{custom_end}\n",
+        encoding="utf-8",
+    )
+    dst = _write_destination(tmp_path)
+    # Existing on-disk file: old managed region + the consumer's edits
+    # inside the custom block.
+    (dst / "AGENTS.md").write_text(
+        f"# AGENTFORGE-MANAGED: x\n# Rules v1\n\nold managed body\n\n{end}\n\n"
+        f"{start}\nOUR team notes — keep me\n{custom_end}\n",
+        encoding="utf-8",
+    )
+
+    result = _shared_scaffold.inject_shared_scaffold(
+        dst, template_name="minimal", template_version="0.0.2"
+    )
+
+    out = (dst / "AGENTS.md").read_text(encoding="utf-8")
+    assert "AGENTS.md" in result.preserved_custom
+    assert "refreshed managed body" in out  # managed region updated
+    assert "OUR team notes — keep me" in out  # consumer custom preserved
+    assert "TEMPLATE default custom" not in out  # template default NOT forced back
+    assert "old managed body" not in out
+
+
+def test_reinjection_dry_run_writes_nothing(stub_shared_dir: Path, tmp_path: Path) -> None:
+    """`dry_run` classifies every file but touches neither disk nor lock."""
+    from agentforge.cli._scaffold_state import read_lock  # noqa: PLC0415
+
+    (stub_shared_dir / "RAW.txt").write_text("template content\n", encoding="utf-8")
+    dst = _write_destination(tmp_path)
+
+    result = _shared_scaffold.inject_shared_scaffold(
+        dst, template_name="minimal", template_version="0.0.1", dry_run=True
+    )
+
+    assert result.written == ["RAW.txt"]
+    assert not (dst / "RAW.txt").exists()
+    assert read_lock(dst) == {}

--- a/packages/agentforge/tests/unit/test_three_section_format.py
+++ b/packages/agentforge/tests/unit/test_three_section_format.py
@@ -6,7 +6,9 @@ from agentforge.cli._scaffold_state import (
     CUSTOM_END_MARKER,
     CUSTOM_START_MARKER,
     END_MANAGED_MARKER,
+    custom_section_diverged,
     merge_three_section,
+    preserve_custom_section,
     split_three_section,
 )
 
@@ -64,3 +66,71 @@ def test_roundtrip_preserves_content() -> None:
     re_merged = merge_three_section(managed, custom)
     assert "Step 1..." in re_merged
     assert "Our team prefers X over Y." in re_merged
+
+
+# ----------------------------------------------------------------------
+# preserve_custom_section — the bug-025 upgrade guard
+# ----------------------------------------------------------------------
+
+
+def test_preserve_takes_new_managed_and_existing_custom() -> None:
+    new = (
+        f"new managed\n\n{END_MANAGED_MARKER}\n\n"
+        f"{CUSTOM_START_MARKER}\ntemplate default\n{CUSTOM_END_MARKER}\n"
+    )
+    existing = (
+        f"old managed\n\n{END_MANAGED_MARKER}\n\n"
+        f"{CUSTOM_START_MARKER}\nMY notes\n{CUSTOM_END_MARKER}\n"
+    )
+    out = preserve_custom_section(new, existing)
+    assert "new managed" in out
+    assert "MY notes" in out
+    assert "template default" not in out
+    assert "old managed" not in out
+
+
+def test_preserve_none_existing_returns_new_verbatim() -> None:
+    """A brand-new file (no existing on disk) is written whole."""
+    new = f"managed\n\n{END_MANAGED_MARKER}\n\ncustom\n"
+    assert preserve_custom_section(new, None) == new
+
+
+def test_preserve_falls_back_when_no_markers() -> None:
+    """Plain files (no end-managed marker) overwrite wholesale —
+    there's no managed/custom boundary to honour."""
+    new = "fresh config\n"
+    existing = "stale config with local edits\n"
+    assert preserve_custom_section(new, existing) == new
+
+
+def test_preserve_empty_custom_uses_new_template_default() -> None:
+    """When the existing custom tail is blank, the new template's
+    content (including any default custom block) is used as-is."""
+    new = (
+        f"managed\n\n{END_MANAGED_MARKER}\n\n{CUSTOM_START_MARKER}\ndefault\n{CUSTOM_END_MARKER}\n"
+    )
+    existing = f"old\n\n{END_MANAGED_MARKER}\n"
+    assert preserve_custom_section(new, existing) == new
+
+
+def test_diverged_true_when_custom_edited() -> None:
+    new = f"m\n\n{END_MANAGED_MARKER}\n\n{CUSTOM_START_MARKER}\ndefault\n{CUSTOM_END_MARKER}\n"
+    existing = f"m\n\n{END_MANAGED_MARKER}\n\n{CUSTOM_START_MARKER}\nMY edit\n{CUSTOM_END_MARKER}\n"
+    assert custom_section_diverged(new, existing) is True
+
+
+def test_diverged_false_when_custom_matches_template() -> None:
+    """An unedited file (custom tail == template default) is not flagged,
+    even if managed-region whitespace differs."""
+    new = (
+        f"managed v2\n\n{END_MANAGED_MARKER}\n\n{CUSTOM_START_MARKER}\nsame\n{CUSTOM_END_MARKER}\n"
+    )
+    existing = (
+        f"managed v1\n\n{END_MANAGED_MARKER}\n\n{CUSTOM_START_MARKER}\nsame\n{CUSTOM_END_MARKER}\n"
+    )
+    assert custom_section_diverged(new, existing) is False
+
+
+def test_diverged_false_without_existing_or_markers() -> None:
+    assert custom_section_diverged("x", None) is False
+    assert custom_section_diverged("plain", "also plain") is False

--- a/packages/agentforge/tests/unit/test_upgrade_cmd.py
+++ b/packages/agentforge/tests/unit/test_upgrade_cmd.py
@@ -1,0 +1,93 @@
+"""End-to-end tests for `agentforge upgrade` (bug-025).
+
+The data-loss bug: `agentforge upgrade` re-injected the shared
+scaffold (AGENTS.md / CLAUDE.md / runbooks) wholesale, ignoring fork
+status and erasing the developer-owned ``agentforge:custom`` block
+these files promise will "survive upgrade". These tests scaffold a
+real agent with `agentforge new`, mutate it the way a consumer would,
+then run `agentforge upgrade` and assert nothing is clobbered.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+from agentforge.cli.new_cmd import _run_new
+from agentforge.cli.upgrade_cmd import _run_fork, _run_upgrade
+
+CUSTOM_START = "<!-- agentforge:custom -->"
+CUSTOM_END = "<!-- agentforge:end-custom -->"
+SENTINEL = "OUR-TEAM-CUSTOM-NOTE — must survive upgrade"
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    dst = tmp_path / "agent"
+    code = _run_new(
+        argparse.Namespace(
+            project_slug="agent",
+            template="minimal",
+            provider="bedrock",
+            no_prompts=True,
+            dst=dst,
+        )
+    )
+    assert code == 0
+    return dst
+
+
+def _put_custom_note(path: Path, note: str) -> None:
+    """Drop a sentinel line inside the file's custom block."""
+    text = path.read_text(encoding="utf-8")
+    assert CUSTOM_START in text, f"{path} is not a three-section file"
+    head, _, tail = text.partition(CUSTOM_START)
+    path.write_text(f"{head}{CUSTOM_START}\n{note}\n{tail.split(CUSTOM_START, 1)[-1]}", "utf-8")
+
+
+def test_upgrade_preserves_custom_block_in_shared_file(tmp_path: Path) -> None:
+    dst = _scaffold(tmp_path)
+    agents_md = dst / "AGENTS.md"
+    _put_custom_note(agents_md, SENTINEL)
+
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+
+    assert code == 0
+    out = agents_md.read_text(encoding="utf-8")
+    assert SENTINEL in out, "custom block erased by upgrade (bug-025)"
+    # Managed region is still there (file wasn't truncated to just custom).
+    assert "agentforge:end-managed" in out
+
+
+def test_upgrade_skips_forked_file(tmp_path: Path) -> None:
+    dst = _scaffold(tmp_path)
+    runbook = dst / "docs" / "runbooks" / "02-add-a-tool.md"
+    assert runbook.exists()
+    # Fork it, then hand-rewrite it entirely.
+    assert _run_fork(argparse.Namespace(path="docs/runbooks/02-add-a-tool.md"), cwd=dst) == 0
+    runbook.write_text("# Completely my own runbook now\n", encoding="utf-8")
+
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+
+    assert code == 0
+    assert runbook.read_text(encoding="utf-8") == "# Completely my own runbook now\n"
+
+
+def test_upgrade_dry_run_writes_nothing_and_lists_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dst = _scaffold(tmp_path)
+    agents_md = dst / "AGENTS.md"
+    _put_custom_note(agents_md, SENTINEL)
+    before = agents_md.read_text(encoding="utf-8")
+
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=True), cwd=dst)
+
+    assert code == 0
+    # Nothing written.
+    assert agents_md.read_text(encoding="utf-8") == before
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    # Per-file plan, not just a one-line summary (issue #114 ask 3).
+    assert "AGENTS.md" in out
+    assert "preserve custom block" in out


### PR DESCRIPTION
## Summary

`agentforge upgrade` re-injected the shared scaffold (`AGENTS.md` / `CLAUDE.md` / `.cursorrules` / copilot-instructions / the runbooks) **wholesale** — the re-injection pass wrote every file unconditionally, ignoring fork status and replacing the developer-owned `agentforge:custom` block (which the runbooks promise survives an upgrade) with the template default. Silent data loss on an unattended upgrade. Reported by a downstream consumer (`agentforge-graph`) on a real 0.2.4 → 0.3.1 upgrade.

The three-section `split`/`merge` helpers existed (feat-019) but were **never wired into the upgrade path**. This routes both write sites through them.

## Changes

- **`preserve_custom_section()`** + **`custom_section_diverged()`** (`_scaffold_state.py`) — carry the on-disk custom tail across a refresh; fall back to a whole-file write when markers are absent (`agentforge fork` remains the way to protect a fully hand-edited file).
- **`inject_shared_scaffold`** now skips forked files (file + lock entry left intact), preserves custom blocks, takes a `dry_run` flag, and returns a structured `SharedScaffoldResult` (`written` / `skipped_forked` / `preserved_custom`).
- **`_do_upgrade`** Pass 1 applies the same preservation; **`--dry-run` now prints a per-file plan** instead of a one-line summary (issue #114 ask 3).
- Adopts the **`(closes #NN)` CHANGELOG convention** (issue #115 item 1); documented in `.claude/standards/git.md`.

## Dry-run, after the fix

```
AGENTS.md: refresh shared (preserve custom block)
docs/runbooks/02-add-a-tool.md: skip (forked)
→ summary: 34 files; 1 forked (skipped), 1 with custom blocks preserved.
```

## Tests

- **Integration** (`test_upgrade_cmd.py`, 3): real `agentforge new` → edit custom / fork → `agentforge upgrade` — custom sentinel survives, forked file untouched, `--dry-run` writes nothing while listing per-file actions.
- **Unit**: re-injection fork-skip / custom-preserve / dry-run (`test_shared_scaffold.py`); `preserve_custom_section` + `custom_section_diverged` (`test_three_section_format.py`).
- `uv run pre-commit run --all-files` green — mypy `--strict`, bandit, unit + integration, coverage ≥ 90%.

## Docs

- `docs/bugs/bug-025-upgrade-overwrites-forked-and-custom.md` (P1).
- `CHANGELOG.md` under `[Unreleased] → Fixed`.

Closes #114
Refs #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)