### PR TITLE
feat(enh-006): upgrade drift report — `agentforge upgrade --notes` + deprecations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,3 +112,14 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
+
+      # enh-006: `release_notes.json` is generated from CHANGELOG.md and
+      # shipped in the wheel. Catch a stale artifact at commit time (the
+      # `test_committed_release_notes_is_current` unit test is the CI
+      # mirror). Triggers only when the changelog or notes machinery moves.
+      - id: release-notes-current
+        name: release_notes.json matches CHANGELOG
+        entry: uv run python scripts/gen_release_notes.py --check
+        language: system
+        pass_filenames: false
+        files: '^(CHANGELOG\.md|scripts/gen_release_notes\.py|packages/agentforge/src/agentforge/cli/(_notes\.py|release_notes\.json))$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ slice between two versions to see which of your filed issues a bump fixes.
 
 ## [Unreleased]
 
+### Added
+
+- **enh-006 — upgrade drift report (`agentforge upgrade --notes`).** After
+  bumping the framework pin, a consumer can now see which fixes (and the
+  issues they close) the bump shipped, so dead workarounds get cleaned up
+  instead of lingering. `agentforge upgrade --notes [FROM..TO]` prints the
+  drift report for a version range (bare `--notes` = your current pin → the
+  installed version); a real `agentforge upgrade` also prints the summary for
+  the range it just crossed. Works offline from a `release_notes.json`
+  generated from this changelog at build time (`scripts/gen_release_notes.py`)
+  and shipped in the wheel. Ships the deprecation machinery too — a
+  `@deprecated(since=, replacement=, ref=)` decorator that warns at runtime
+  and feeds the report (no framework seams are deprecated yet). Builds on the
+  `(closes #NN)` convention. (refs #115)
+
 ### Changed
 
 - **starlette 1.0.1 → 1.3.1** (transitive, via fastapi / arize-phoenix).

--- a/docs/enhancements/enh-006-upgrade-drift-report.md
+++ b/docs/enhancements/enh-006-upgrade-drift-report.md
@@ -1,0 +1,215 @@
+# enh-006: Upgrade drift report — surface which workarounds a bump made removable
+
+> Improves a *shipped* feature (feat-011, scaffolding-and-upgrade). Filed
+> as issue [#115](https://github.com/Scaffoldic/agentforge-py/issues/115)
+> by a consumer agent (`agentforge-graph`) building on agentforge-py.
+> Not a defect — the version bump works — this adds the missing *signal*
+> that tells a consumer which of their framework workarounds a bump just
+> made removable. Sibling of [bug-025](../bugs/bug-025-upgrade-overwrites-forked-and-custom.md)
+> (the `agentforge upgrade` data-loss fix), filed together.
+
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **ID** | enh-006 |
+| **Title** | Upgrade drift report (`agentforge upgrade --notes` + deprecation registry) |
+| **Status** | `proposed` |
+| **Owner** | kjoshi |
+| **Created** | 2026-06-22 |
+| **Target version** | 0.4 |
+| **Languages** | `python` |
+| **Improves** | feat-011 (scaffolding-and-upgrade) |
+
+---
+
+## 1. Summary
+
+After a consumer bumps their `agentforge-py` pin, nothing tells them
+*"these two things you worked around upstream are now fixed — delete your
+workarounds."* This enhancement gives the framework a **drift report**:
+
+1. **CHANGELOG issue traceability** — every entry that resolves a tracked
+   issue ends with `(closes #NN)`, so the slice between two pins answers
+   "which of my filed issues does this version fix?" *(Shipped already in
+   bug-025 / PR #116; recorded here as part 1 because it's the floor of
+   this enhancement and the rest builds on it.)*
+2. **`agentforge upgrade --notes [<from>..<to>]`** (and an end-of-upgrade
+   summary) — prints the CHANGELOG slice + active deprecations between two
+   versions, offline, from data shipped in the wheel.
+3. **A deprecation registry** — superseded seams emit a `DeprecationWarning`
+   naming the replacement API, and that same registry feeds the notes
+   report so a consumer sees retired workarounds without reading source.
+
+## 2. Motivation
+
+A disciplined consumer logs every framework workaround against a baseline
+version, intending to remove it once the framework fixes it upstream. But
+the cleanup is easy to miss: bumping the pin and running the test suite
+verifies *"nothing broke"* (compatibility) — nothing reports *"these
+seams changed; your workarounds are now dead code."*
+
+Concretely, the reporter's 0.2.4 → 0.3.x bump silently retired two
+workarounds, discovered only by re-reading framework source:
+
+- the strict config validator began accepting an `app:` passthrough
+  (enh-002) — they had kept a whole second config file to avoid it;
+- `MCPServer.from_http` grew a `middleware=` hook (enh-003) — they had
+  re-implemented ~60 lines of HTTP-serve internals to add auth.
+
+Both shipped in 0.3.x. A consumer without re-reading discipline keeps the
+dead workarounds indefinitely. The framework already *has* the
+information (CHANGELOG, the enh/bug specs); it just never surfaces it at
+the one moment a consumer needs it — right after the bump.
+
+## 2.5 Framework-level vs derived-agent-level
+
+**Framework.** The data a drift report needs — the CHANGELOG, the
+`(closes #NN)` mapping, the set of deprecated seams and their
+replacements — lives in the framework package and changes every release.
+A consumer cannot derive *"which of my filed issues this version fixed"*
+or *"which seam I worked around is now deprecated"* from their own agent
+code; only the framework knows what it changed.
+
+- **Derived-agent test:** the workaround (a human re-reading framework
+  source after every bump, or hand-maintaining a per-version "what got
+  fixed" list) re-derives information the framework owns and must track
+  it across versions — fails the test → framework work.
+- **How it helps derived agents:** a consumer runs one command after
+  bumping the pin and gets the list of resolved issues + retired seams
+  for the exact version range — no source reading, no guesswork. Every
+  org agent on the framework benefits identically; nothing here is
+  specific to one agent's domain.
+
+## 3. Before / after
+
+| Aspect | Before | After |
+|---|---|---|
+| "Which of my issues did this bump fix?" | re-read framework source / CHANGELOG by hand | `grep '(closes #'` the range, or `agentforge upgrade --notes` |
+| "Which seams I worked around changed?" | discovered by accident, months later | listed in the drift report; `DeprecationWarning` at runtime |
+| Notes available offline | no (CHANGELOG is a GitHub URL, not in the wheel) | yes — notes data ships in the package |
+| After a normal `agentforge upgrade` | one-line "complete" | + a drift summary for the version range upgraded |
+
+```console
+$ agentforge upgrade --notes
+  → drift from 0.2.4 → 0.3.1 (your scaffold pin → installed):
+
+  Fixed (resolves issues you may have filed/worked around):
+    - enh-002  config validator accepts `app:` passthrough        (closes #86)
+    - enh-003  MCPServer.from_http(middleware=…) auth seam         (closes #93)
+    - bug-025  upgrade no longer clobbers forked/custom files      (closes #114)
+
+  Deprecated (workarounds you can retire):
+    - MCPServer.from_http(runner=…) for auth → use middleware=     (since 0.3.0)
+
+  3 fixes, 1 deprecation in this range.
+```
+
+## 4. Design
+
+### 4.1 Shipping notes offline (the load-bearing decision)
+
+`agentforge upgrade --notes` must work **offline** (per the framework's
+offline-determinism principle) and against the *installed* version, so it
+cannot fetch from GitHub. Today the wheel does **not** ship `CHANGELOG.md`
+(`packages/agentforge/pyproject.toml` sets `readme = "README.md"`; the
+changelog is only a `[project.urls]` link). Two options:
+
+- **(A) Force-include `CHANGELOG.md` in the wheel** and parse the
+  Keep-a-Changelog format (`## [x.y.z]` headers, `### Fixed` blocks,
+  `(closes #NN)` tails) at runtime.
+- **(B) Generate a structured `agentforge/_notes/changelog.json`** at
+  build time from `CHANGELOG.md` (version → {fixed, deprecated, closes}).
+
+**Recommendation: (B).** A parser over free-form markdown is fragile and
+re-runs on every invocation; a build-time structured artifact is parsed
+once into a stable schema, is trivially version-sliceable, and keeps the
+deprecation registry (4.3) in the same shape. (A) is the cheaper fallback
+if we want zero build tooling. Either way the `(closes #NN)` convention
+(part 1) is the parse anchor.
+
+### 4.2 Version range defaults
+
+The "from" version is already recorded: the managed-files lock entries
+carry `source_version`, and `answers.yml` carries `_template_version` —
+the framework version at the consumer's last scaffold/upgrade. The "to"
+is the installed framework version (`version("agentforge-py")`). So:
+
+- `agentforge upgrade --notes` (no arg) → from = lock version, to =
+  installed.
+- `agentforge upgrade --notes 0.2.4..0.3.1` → explicit range.
+- A drift summary also prints automatically at the **end of a normal
+  `agentforge upgrade`**, for the range it just moved across — the single
+  most useful moment.
+
+Open question (§7): standalone `agentforge notes` / `agentforge doctor`
+vs. only the `upgrade --notes` flag. Leaning `upgrade --notes` + the
+auto-summary to keep the command surface small; a `doctor` umbrella can
+absorb it later.
+
+### 4.3 Deprecation registry (part 3)
+
+A single source of truth for retired seams:
+
+```python
+@deprecated(since="0.3.0", replacement="MCPServer.from_http(middleware=…)",
+            ref="enh-003")
+def _legacy_auth_runner_seam(...): ...
+```
+
+The `@deprecated` decorator (a) emits `warnings.warn(..., DeprecationWarning)`
+at runtime naming the replacement, and (b) registers the entry in a
+module-level table the notes report reads. `DeprecationWarning` is silent
+by default for end users but visible under `-W` / pytest, so it's
+non-breaking. The registry — not scraped warnings — is what the offline
+notes command lists, so it works without exercising the deprecated path.
+
+## 5. Backward compatibility
+
+Fully additive.
+
+- Part 1 (`closes #NN`) is a docs convention — already shipped.
+- `--notes` is a new flag + new auto-summary output; no change to what
+  `upgrade` writes.
+- `DeprecationWarning`s are non-fatal by default; consumers who run
+  `filterwarnings=error` opt into seeing them (which is the point).
+- Packaging `CHANGELOG.md` / a notes artifact only *adds* a file to the
+  wheel.
+
+## 6. Implementation sketch
+
+- `packages/agentforge/pyproject.toml`: ship the notes artifact (4.1).
+- `agentforge/cli/_notes.py`: load the notes artifact, slice by
+  `from..to`, merge in the deprecation registry, format the report.
+- `agentforge/cli/upgrade_cmd.py`: add `--notes` (range optional);
+  call the formatter at the end of a successful `_do_upgrade` for the
+  range upgraded.
+- `agentforge/_deprecation.py`: `@deprecated` decorator + registry; wire
+  the first real entries (the enh-002 / enh-003 superseded seams, if any
+  remain) as the seed set.
+- Build step (if 4.1-B): a `scripts/` generator + a CI check that the
+  structured notes match `CHANGELOG.md` (same drift-guard pattern as the
+  spec-status / changelog cross-checks).
+
+## 7. Risks / open questions
+
+| Risk / question | Note |
+|---|---|
+| Markdown CHANGELOG parsing is brittle | prefer the build-time structured artifact (4.1-B); pin the format with the existing CHANGELOG drift-check |
+| Command surface creep (`--notes` vs `doctor`) | start with `upgrade --notes` + auto-summary; defer a `doctor` umbrella |
+| Deprecation registry drift from reality | the registry *is* the source of truth (decorator-driven), and the notes report reads it — not scraped warnings |
+| "from" version missing (hand-edited state) | fall back to requiring an explicit `<from>..<to>` and printing a hint, mirroring the existing `_template_version` guards in `upgrade` |
+| Sister-package versions | the train bumps all packages in lockstep (ADR-0015), so a single version range is correct for the whole install |
+
+## 8. References
+
+- Improved feature: feat-011 (scaffolding-and-upgrade)
+- Issue: #115
+- Sibling: bug-025 (upgrade data-loss) — filed together by the same consumer
+- Precedent for surfaced fixes: the `(closes #NN)` convention in
+  `.claude/standards/git.md` (shipped in bug-025)
+- Examples of retired workarounds this would have surfaced: enh-002
+  (`app:` passthrough), enh-003 (`from_http(middleware=…)`)
+</content>

--- a/docs/enhancements/enh-006-upgrade-drift-report.md
+++ b/docs/enhancements/enh-006-upgrade-drift-report.md
@@ -16,7 +16,7 @@
 |---|---|
 | **ID** | enh-006 |
 | **Title** | Upgrade drift report (`agentforge upgrade --notes` + deprecation registry) |
-| **Status** | `proposed` |
+| **Status** | `in-progress` (part 1 shipped in bug-025; parts 2-3 implemented, targeting 0.4) |
 | **Owner** | kjoshi |
 | **Created** | 2026-06-22 |
 | **Target version** | 0.4 |
@@ -177,6 +177,29 @@ Fully additive.
   `filterwarnings=error` opt into seeing them (which is the point).
 - Packaging `CHANGELOG.md` / a notes artifact only *adds* a file to the
   wheel.
+
+## 5.5 Implementation status
+
+Parts 2 and 3 are implemented (part 1 — the `(closes #NN)` convention —
+shipped in bug-025):
+
+- **§4.1 decision: option (B) taken.** `scripts/gen_release_notes.py`
+  parses `CHANGELOG.md` → committed `agentforge/cli/release_notes.json`
+  (hatchling ships it; no force-include). A source-tree drift test
+  (`test_notes.py::test_committed_release_notes_is_current`) fails if the
+  JSON is stale; the parser is reused by the generator and the test.
+- **§4.2 decision: `upgrade --notes` + auto-summary, no `doctor`.**
+  `agentforge upgrade --notes [FROM..TO]` is report-only (prints, doesn't
+  upgrade); a real upgrade prints the summary for the range it crossed.
+  The "from" defaults to the lock/answers `_template_version`.
+- **Part 3:** `agentforge/_deprecation.py` ships the `@deprecated` decorator
+  + registry + `iter_deprecations()`, wired into the report. No real
+  framework seam is deprecated yet — `test_deprecation.py` guards that an
+  empty default registry ships (a real deprecation must come with a note).
+- **Known limitation:** a deprecation appears in the offline report only
+  once its defining module is imported; when the first real seam is
+  deprecated, import it from `agentforge/__init__.py` so the registry is
+  complete. The CHANGELOG slice is fully offline regardless.
 
 ## 6. Implementation sketch
 

--- a/packages/agentforge/src/agentforge/_deprecation.py
+++ b/packages/agentforge/src/agentforge/_deprecation.py
@@ -1,0 +1,89 @@
+"""Deprecation registry (enh-006 part 3).
+
+`@deprecated` marks a superseded framework seam: it emits a
+`DeprecationWarning` naming the replacement at call time, **and** records
+the deprecation in a process-wide registry that the upgrade drift report
+(`agentforge upgrade --notes`) reads. So a consumer learns which seam they
+worked around is now retired without having to exercise it or re-read
+source.
+
+No framework seams are deprecated yet — this ships the machinery and the
+report seam. When a real seam is deprecated, decorate it with
+`@deprecated(...)` and make sure its defining module is imported (e.g.
+from `agentforge/__init__.py`) so the registry is complete for an offline
+report.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+_F = TypeVar("_F", bound=Callable[..., object])
+
+
+@dataclass(frozen=True)
+class Deprecation:
+    """A retired seam and the API that replaces it."""
+
+    qualname: str
+    since: str
+    replacement: str
+    ref: str
+
+    def message(self) -> str:
+        return (
+            f"{self.qualname} is deprecated since {self.since}; "
+            f"use {self.replacement} instead ({self.ref})."
+        )
+
+
+_REGISTRY: dict[str, Deprecation] = {}
+
+
+def deprecated(*, since: str, replacement: str, ref: str) -> Callable[[_F], _F]:
+    """Mark a callable deprecated — warn at call time, register for the report.
+
+    Args:
+        since: version the deprecation took effect (e.g. ``"0.4"``).
+        replacement: the API to use instead (human-readable).
+        ref: the spec / issue id that justifies it (e.g. ``"enh-006"``).
+
+    The wrapped callable behaves identically except it raises a
+    `DeprecationWarning` (silent for end users by default; visible under
+    `-W` / pytest) before delegating.
+    """
+
+    def decorate(func: _F) -> _F:
+        dep = Deprecation(
+            qualname=func.__qualname__,
+            since=since,
+            replacement=replacement,
+            ref=ref,
+        )
+        _REGISTRY[dep.qualname] = dep
+
+        @functools.wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            warnings.warn(dep.message(), DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return cast("_F", wrapper)
+
+    return decorate
+
+
+def iter_deprecations() -> list[Deprecation]:
+    """Every registered deprecation, sorted by ``(since, qualname)``.
+
+    A deprecation is present only once its defining module has been
+    imported; the offline notes report imports the framework first so the
+    list reflects every seam decorated at import time.
+    """
+    return sorted(_REGISTRY.values(), key=lambda d: (d.since, d.qualname))
+
+
+__all__ = ["Deprecation", "deprecated", "iter_deprecations"]

--- a/packages/agentforge/src/agentforge/cli/_notes.py
+++ b/packages/agentforge/src/agentforge/cli/_notes.py
@@ -1,0 +1,223 @@
+"""Release-notes model + drift report (enh-006 part 2).
+
+Parses the Keep-a-Changelog `CHANGELOG.md` into a structured model, slices
+it by a version range, and formats the **drift report** that
+`agentforge upgrade --notes` prints — the list of fixes (and the issues
+they close) plus the deprecations between a consumer's old pin and the
+version they just moved to.
+
+The parse runs at build time (`scripts/gen_release_notes.py`) and the
+result is committed to `release_notes.json` next to this module, so the
+report works **offline** against the installed wheel — `CHANGELOG.md`
+itself is not shipped. `parse_changelog` is re-used by the generator and
+by a source-tree drift test that asserts the committed JSON is current.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from importlib import resources
+from typing import Any
+
+from agentforge._deprecation import Deprecation, iter_deprecations
+
+_VERSION_RE = re.compile(r"^##\s+\[([^\]]+)\](?:\s*[—-]+\s*(.+?))?\s*$")
+_SECTION_RE = re.compile(r"^###\s+(.+?)\s*$")
+_BULLET_RE = re.compile(r"^-\s+(.*)$")
+_FENCE_RE = re.compile(r"^\s*```")
+_BOLD_RE = re.compile(r"^\*\*(.+?)\*\*")
+# A "closes" clause + any comma-separated #NN that follow it, so
+# `(closes #114, #116)` yields both. Historical phrasings vary, hence the
+# alternation (closes / closed / resolves / resolved / fixes / fixed).
+_CLOSES_CLAUSE_RE = re.compile(
+    r"(?i)\b(?:closes?|closed|resolves?|resolved|fixes?|fixed)\b\s+"
+    r"(?:issue\s+)?((?:#\d+(?:\s*,\s*)?)+)"
+)
+_HASHNUM_RE = re.compile(r"#(\d+)")
+_REF_RE = re.compile(r"\b((?:bug|enh|feat)-\d+)\b")
+
+_NOTES_RESOURCE = "release_notes.json"
+_LABEL_MAX = 140
+
+
+# ----------------------------------------------------------------------
+# Parsing
+# ----------------------------------------------------------------------
+
+
+def parse_changelog(md: str) -> dict[str, Any]:
+    """Parse Keep-a-Changelog markdown into a structured notes model.
+
+    Shape: ``{"generated_from": "CHANGELOG.md", "versions": [
+    {"version", "date", "entries": {<section>: [<entry>, ...]}}]}`` where
+    each entry is ``{"label", "closes": [int], "refs": [str]}``. Only
+    bulleted entries under a `### Section` are captured; prose paragraphs
+    and fenced code blocks are ignored for structure (but code inside a
+    bullet stays part of that bullet's text).
+    """
+    versions: list[dict[str, Any]] = []
+    cur_version: dict[str, Any] | None = None
+    cur_section: str | None = None
+    bullet: list[str] | None = None
+    in_fence = False
+
+    def flush() -> None:
+        nonlocal bullet
+        if bullet is not None and cur_version is not None and cur_section is not None:
+            text = re.sub(r"\s+", " ", " ".join(bullet)).strip()
+            if text:
+                cur_version["entries"].setdefault(cur_section, []).append(_make_entry(text))
+        bullet = None
+
+    for raw in md.splitlines():
+        if _FENCE_RE.match(raw):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            # Fenced code never contributes a label or an issue ref — a
+            # `#123` or a `- ` in an example must not leak into the entry.
+            # The open bullet stays open so post-fence prose still attaches.
+            continue
+
+        mv = _VERSION_RE.match(raw)
+        if mv:
+            flush()
+            cur_version = {
+                "version": mv.group(1).strip(),
+                "date": (mv.group(2) or "").strip() or None,
+                "entries": {},
+            }
+            versions.append(cur_version)
+            cur_section = None
+            continue
+
+        ms = _SECTION_RE.match(raw)
+        if ms:
+            flush()
+            cur_section = ms.group(1).strip()
+            continue
+
+        mb = _BULLET_RE.match(raw)
+        if mb:
+            flush()
+            bullet = [mb.group(1)]
+            continue
+
+        if bullet is not None:
+            bullet.append(raw)
+
+    flush()
+    return {"generated_from": "CHANGELOG.md", "versions": versions}
+
+
+def _make_entry(text: str) -> dict[str, Any]:
+    closes: set[int] = set()
+    for clause in _CLOSES_CLAUSE_RE.findall(text):
+        closes.update(int(n) for n in _HASHNUM_RE.findall(clause))
+    refs = sorted(set(_REF_RE.findall(text)))
+    m = _BOLD_RE.match(text)
+    label = (m.group(1) if m else text).strip()
+    if len(label) > _LABEL_MAX:
+        label = label[: _LABEL_MAX - 1] + "…"
+    return {"label": label, "closes": sorted(closes), "refs": refs}
+
+
+# ----------------------------------------------------------------------
+# Loading + slicing
+# ----------------------------------------------------------------------
+
+
+def load_notes() -> dict[str, Any]:
+    """Load the committed `release_notes.json` shipped in the wheel.
+
+    Returns an empty model if the resource is missing (e.g. a partial
+    checkout before the generator has run).
+    """
+    try:
+        raw = resources.files("agentforge.cli").joinpath(_NOTES_RESOURCE).read_text("utf-8")
+    except (FileNotFoundError, ModuleNotFoundError):  # pragma: no cover - packaging guard
+        return {"generated_from": "CHANGELOG.md", "versions": []}
+    parsed: dict[str, Any] = json.loads(raw)
+    return parsed
+
+
+def _vkey(version: str) -> tuple[int, tuple[int, ...]]:
+    """Sort key for a version string. `Unreleased` sorts above all releases."""
+    if version.lower() == "unreleased":
+        return (1, ())
+    parts: list[int] = []
+    for piece in version.split("."):
+        try:
+            parts.append(int(piece))
+        except ValueError:
+            parts.append(0)
+    return (0, tuple(parts))
+
+
+def slice_versions(notes: dict[str, Any], frm: str, to: str) -> list[dict[str, Any]]:
+    """Versions in the half-open range ``(frm, to]`` — newer than the
+    consumer's old pin, up to and including the one they moved to."""
+    fk, tk = _vkey(frm), _vkey(to)
+    return [v for v in notes["versions"] if fk < _vkey(v["version"]) <= tk]
+
+
+def slice_deprecations(deprecations: list[Deprecation], frm: str, to: str) -> list[Deprecation]:
+    fk, tk = _vkey(frm), _vkey(to)
+    return [d for d in deprecations if fk < _vkey(d.since) <= tk]
+
+
+# ----------------------------------------------------------------------
+# Report
+# ----------------------------------------------------------------------
+
+
+def format_drift_report(notes: dict[str, Any], frm: str, to: str) -> str:
+    """Format the drift report for the range ``(frm, to]``.
+
+    Lists fixes that close an issue or carry a bug/enh/feat ref, then any
+    deprecations whose `since` falls in range, then a one-line summary.
+    """
+    versions = slice_versions(notes, frm, to)
+    deprecations = slice_deprecations(iter_deprecations(), frm, to)
+
+    fixes: list[dict[str, Any]] = [
+        entry
+        for ver in versions
+        for entries in ver["entries"].values()
+        for entry in entries
+        if entry["closes"] or entry["refs"]
+    ]
+
+    out: list[str] = [f"  → drift from {frm} → {to}:", ""]
+
+    if fixes:
+        out.append("  Fixed (resolves issues you may have filed / worked around):")
+        for entry in fixes:
+            closes = entry["closes"]
+            suffix = f"  (closes {', '.join(f'#{n}' for n in closes)})" if closes else ""
+            out.append(f"    - {entry['label']}{suffix}")
+        out.append("")
+    else:
+        out.append("  No tracked fixes in this range.")
+        out.append("")
+
+    if deprecations:
+        out.append("  Deprecated (workarounds you can retire):")
+        out.extend(
+            f"    - {dep.qualname} → use {dep.replacement}  (since {dep.since}, {dep.ref})"
+            for dep in deprecations
+        )
+        out.append("")
+
+    out.append(f"  {len(fixes)} fix(es), {len(deprecations)} deprecation(s) in this range.")
+    return "\n".join(out) + "\n"
+
+
+__all__ = [
+    "format_drift_report",
+    "load_notes",
+    "parse_changelog",
+    "slice_deprecations",
+    "slice_versions",
+]

--- a/packages/agentforge/src/agentforge/cli/release_notes.json
+++ b/packages/agentforge/src/agentforge/cli/release_notes.json
@@ -1,0 +1,1111 @@
+{
+  "generated_from": "CHANGELOG.md",
+  "versions": [
+    {
+      "version": "Unreleased",
+      "date": null,
+      "entries": {
+        "Added": [
+          {
+            "label": "enh-006 — upgrade drift report (`agentforge upgrade --notes`).",
+            "closes": [],
+            "refs": [
+              "enh-006"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "starlette 1.0.1 → 1.3.1",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Fixed": [
+          {
+            "label": "bug-025 (P1) — `agentforge upgrade` overwrote forked files and erased `agentforge:custom` blocks",
+            "closes": [
+              114
+            ],
+            "refs": [
+              "bug-025"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.3.1",
+      "date": "2026-06-17",
+      "entries": {
+        "Fixed": [
+          {
+            "label": "bug-024 (P3) — version reporting.",
+            "closes": [],
+            "refs": [
+              "bug-024"
+            ]
+          }
+        ],
+        "Security": [
+          {
+            "label": "pyjwt 2.12.1 → 2.13.0",
+            "closes": [],
+            "refs": [
+              "enh-003"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "Dependency bumps",
+            "closes": [],
+            "refs": []
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.3.0",
+      "date": "2026-06-16",
+      "entries": {
+        "Added": [
+          {
+            "label": "enh-004 — provider `config:` passthrough + Bedrock STS assume-role.",
+            "closes": [
+              92
+            ],
+            "refs": [
+              "enh-004"
+            ]
+          },
+          {
+            "label": "enh-003 — MCP HTTP transport middleware seam.",
+            "closes": [
+              93
+            ],
+            "refs": [
+              "enh-003"
+            ]
+          },
+          {
+            "label": "feat-026 Phase 3 — `imports:` config directive (multi-file config).",
+            "closes": [],
+            "refs": [
+              "feat-026"
+            ]
+          },
+          {
+            "label": "enh-002 / feat-026 Phase 1 — reserved `app:` namespace.",
+            "closes": [
+              86
+            ],
+            "refs": [
+              "enh-002",
+              "feat-026"
+            ]
+          },
+          {
+            "label": "feat-026 Phase 2 — registered, validated `app:` sections.",
+            "closes": [],
+            "refs": [
+              "feat-026"
+            ]
+          }
+        ],
+        "Fixed": [
+          {
+            "label": "bug-023 (P2):",
+            "closes": [],
+            "refs": [
+              "bug-022",
+              "bug-023"
+            ]
+          },
+          {
+            "label": "bug-022 (P2):",
+            "closes": [],
+            "refs": [
+              "bug-022"
+            ]
+          },
+          {
+            "label": "bug-021 (P1):",
+            "closes": [],
+            "refs": [
+              "bug-021"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.2.4",
+      "date": "2026-06-03",
+      "entries": {
+        "Added": [
+          {
+            "label": "`agentforge_core.contracts.protocol_bridge.ProtocolBridge`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`Agent(protocol_bridges=...)`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`MCPBridge.attach_local_tools(tools)` + `MCPServer.set_tools(tools)`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`agentforge_core.contracts.tool.validate_tool_name` + `ToolNameInvalidError`",
+            "closes": [],
+            "refs": [
+              "bug-017"
+            ]
+          },
+          {
+            "label": "`ChatHistoryStore.create_session(session_id, *, owner=None, metadata=None)`",
+            "closes": [],
+            "refs": [
+              "bug-018"
+            ]
+          },
+          {
+            "label": "MCP server-side HTTP transport (enh-001).",
+            "closes": [],
+            "refs": [
+              "enh-001"
+            ]
+          },
+          {
+            "label": "bug-011 (filed, not fixed)",
+            "closes": [],
+            "refs": [
+              "bug-011"
+            ]
+          }
+        ],
+        "Fixed": [
+          {
+            "label": "bug-008 — scaffolds recorded `_template_version: 0.0.0+unknown`.",
+            "closes": [],
+            "refs": [
+              "bug-008"
+            ]
+          },
+          {
+            "label": "bug-013 — `MCPServer.from_stdio` / `from_http` served an empty tool list.",
+            "closes": [],
+            "refs": [
+              "bug-013"
+            ]
+          },
+          {
+            "label": "bug-018 — `POST /sessions` 500'd on a fresh SQLite/Postgres/Redis store.",
+            "closes": [],
+            "refs": [
+              "bug-018"
+            ]
+          },
+          {
+            "label": "bug-019 — documented terse config syntax for evaluators/guardrails was rejected.",
+            "closes": [],
+            "refs": [
+              "bug-019"
+            ]
+          },
+          {
+            "label": "bug-015 — `agentforge-py` extras didn't pull their vendor SDKs.",
+            "closes": [],
+            "refs": [
+              "bug-015"
+            ]
+          },
+          {
+            "label": "bug-017 — provider tool-name charset was undocumented and unchecked.",
+            "closes": [],
+            "refs": [
+              "bug-017",
+              "feat-003"
+            ]
+          },
+          {
+            "label": "bug-012 — MCP tool names used a `.` separator, which every provider rejected.",
+            "closes": [],
+            "refs": [
+              "bug-012"
+            ]
+          },
+          {
+            "label": "bug-020 — runtime never wired `modules.protocols.mcp`.",
+            "closes": [],
+            "refs": [
+              "bug-020"
+            ]
+          },
+          {
+            "label": "bug-014 — `MCPBridge.from_config` raised inside a running event loop.",
+            "closes": [],
+            "refs": [
+              "bug-014"
+            ]
+          },
+          {
+            "label": "bug-010 — `ChatSession` dropped intermediate tool steps from persisted history.",
+            "closes": [],
+            "refs": [
+              "bug-010"
+            ]
+          },
+          {
+            "label": "bug-009 — ReAct dropped `tool_calls` on assistant turns; Bedrock rejected every tool-using prompt on iteration 2.",
+            "closes": [],
+            "refs": [
+              "bug-009"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.2.3",
+      "date": "2026-05-21",
+      "entries": {
+        "Fixed": [
+          {
+            "label": "bug-007 — `agentforge upgrade` was non-functional.",
+            "closes": [],
+            "refs": [
+              "bug-007"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "34 workspace packages bumped to `0.2.3`.",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Added": [
+          {
+            "label": "`docs/bugs/bug-007-upgrade-non-functional.md` — full reproduction + root-cause analysis for both halves of the bug.",
+            "closes": [],
+            "refs": [
+              "bug-007"
+            ]
+          },
+          {
+            "label": "Three new regression tests in `packages/agentforge/tests/unit/test_scaffold_state.py`: `test_new_writes_answers_yml`, `test_upgrade_refresh…",
+            "closes": [],
+            "refs": []
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.2.2",
+      "date": "2026-05-21",
+      "entries": {
+        "Fixed": [
+          {
+            "label": "bug-001 — Scaffolded `pyproject.toml` missing provider package + SDK extra.",
+            "closes": [],
+            "refs": [
+              "bug-001"
+            ]
+          },
+          {
+            "label": "bug-002 — Scaffolded `agentforge.yaml` missing required `agent.strategy`.",
+            "closes": [],
+            "refs": [
+              "bug-002"
+            ]
+          },
+          {
+            "label": "bug-003 — Scaffold README documented `python -m <pkg>` but no `__main__.py` shipped.",
+            "closes": [],
+            "refs": [
+              "bug-003"
+            ]
+          },
+          {
+            "label": "bug-004 — Stale `(when feat-002 ships)` parenthetical",
+            "closes": [],
+            "refs": [
+              "bug-004",
+              "feat-002"
+            ]
+          },
+          {
+            "label": "bug-005 — Install hints referenced `agentforge[<extra>]` but the PyPI distribution is `agentforge-py`.",
+            "closes": [],
+            "refs": [
+              "bug-005"
+            ]
+          },
+          {
+            "label": "bug-006 — Scaffolded `.env.example` → `.env` never loaded.",
+            "closes": [],
+            "refs": [
+              "bug-006"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "`agentforge-py[<provider>]` extras chain to provider SDK extras.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "All 34 workspace members bumped to `0.2.2`.",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Added": [
+          {
+            "label": "`docs/bugs/` directory",
+            "closes": [],
+            "refs": [
+              "bug-001"
+            ]
+          },
+          {
+            "label": "`test_scaffold_resolves_runnable_end_to_end`",
+            "closes": [],
+            "refs": [
+              "bug-001"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.2.1",
+      "date": "2026-05-15",
+      "entries": {
+        "Changed": [
+          {
+            "label": "Distribution rename.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "Cross-package deps pinned.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "All 34 workspace members bumped to `0.2.1`.",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Added": [
+          {
+            "label": "PyPI release workflow",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`scripts/testpypi_dry_run.py`",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Fixed": [
+          {
+            "label": "Wheel build duplicate-file bug",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "Missing optional-dependencies declarations on `agentforge-py`.",
+            "closes": [],
+            "refs": []
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.2.0",
+      "date": "2026-05-14",
+      "entries": {
+        "Highlights": [
+          {
+            "label": "5 first-party LLM provider sister packages",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "5 new runbooks",
+            "closes": [],
+            "refs": [
+              "feat-019"
+            ]
+          },
+          {
+            "label": "Sentence-window streaming guardrails",
+            "closes": [],
+            "refs": [
+              "feat-020"
+            ]
+          },
+          {
+            "label": "Native lexical paths on every shipped vector store",
+            "closes": [],
+            "refs": [
+              "feat-022",
+              "feat-025"
+            ]
+          },
+          {
+            "label": "Schema migrations framework",
+            "closes": [],
+            "refs": [
+              "feat-024"
+            ]
+          },
+          {
+            "label": "GraphRAG retrieval",
+            "closes": [],
+            "refs": [
+              "feat-023"
+            ]
+          },
+          {
+            "label": "Reranker ABC + 4 vendor sister packages",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "Production protocol runners",
+            "closes": [],
+            "refs": [
+              "feat-013",
+              "feat-014"
+            ]
+          },
+          {
+            "label": "Vendor observability backends",
+            "closes": [],
+            "refs": [
+              "feat-009"
+            ]
+          },
+          {
+            "label": "All 34 workspace members",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "v0.2.0 → v0.3.0": [
+          {
+            "label": "`down` migrations / schema rollback (feat-024 v0.3+).",
+            "closes": [],
+            "refs": [
+              "feat-024"
+            ]
+          },
+          {
+            "label": "Native single-Cypher / SurrealQL graph-augmented retrieval (feat-023 sister-package follow-ups).",
+            "closes": [],
+            "refs": [
+              "feat-023"
+            ]
+          },
+          {
+            "label": "Multi-cluster Redlock for `RedisSessionLock` (feat-020 v0.3+).",
+            "closes": [],
+            "refs": [
+              "feat-020"
+            ]
+          },
+          {
+            "label": "True streaming-aware `stream-then-redact` (feat-020 v0.3+).",
+            "closes": [],
+            "refs": [
+              "feat-020"
+            ]
+          },
+          {
+            "label": "Evidently real-time drift dashboards via Cloud (feat-009 v0.3+).",
+            "closes": [],
+            "refs": [
+              "feat-009"
+            ]
+          },
+          {
+            "label": "Optional eval adapters (`agentforge-eval-ragas` / `-deepeval` / `-toxicity` / `-codeexec`).",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "TypeScript port of the v0.2 surface.",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Added": [
+          {
+            "label": "feat-003 v0.2 — first-party LLM provider sister packages.",
+            "closes": [],
+            "refs": [
+              "feat-003"
+            ]
+          },
+          {
+            "label": "feat-019 v0.2 — GitHub Copilot scaffold support.",
+            "closes": [],
+            "refs": [
+              "feat-019"
+            ]
+          },
+          {
+            "label": "README + release notes",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-019 v0.2 polish — 5 new runbooks",
+            "closes": [],
+            "refs": [
+              "feat-019"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "All workspace members bumped to `0.2.0`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`agentforge.providers` resolver category",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`ChatSessionConfig.safety_mode`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-025 — Neo4jVectorStore + SurrealDB native `lexical_search`.",
+            "closes": [],
+            "refs": [
+              "feat-024",
+              "feat-025"
+            ]
+          },
+          {
+            "label": "`SurrealVectorStore.capabilities()`",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-024 v0.3 polish — parameterized migrations.",
+            "closes": [],
+            "refs": [
+              "feat-024"
+            ]
+          },
+          {
+            "label": "All four per-driver migrators",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-024 — Schema migrations framework.",
+            "closes": [],
+            "refs": [
+              "feat-022",
+              "feat-024"
+            ]
+          },
+          {
+            "label": "`init_schema()` on every persistent-store driver now delegates to the migration framework's `apply_pending()`.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-023 — GraphRAG hybrid retrieval.",
+            "closes": [],
+            "refs": [
+              "feat-023"
+            ]
+          },
+          {
+            "label": "`RetrievalConfig` gains `graph_expansion: GraphExpansionConfig | None = None` (additive — existing YAML keeps working unchanged).",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-022 v0.2 follow-up — native hybrid for Postgres + SQLite.",
+            "closes": [],
+            "refs": [
+              "feat-022"
+            ]
+          },
+          {
+            "label": "feat-022 — BM25 + vector hybrid search.",
+            "closes": [],
+            "refs": [
+              "feat-022"
+            ]
+          },
+          {
+            "label": "feat-002 + feat-009 v0.3.x strategy follow-ups bundle.",
+            "closes": [],
+            "refs": [
+              "feat-002",
+              "feat-009"
+            ]
+          },
+          {
+            "label": "feat-002 + feat-009 v0.3 polish + feat-021 follow-up bundle.",
+            "closes": [],
+            "refs": [
+              "feat-002",
+              "feat-009",
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-021 v0.2 follow-up — vendor reranker sister packages.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "Three new `agentforge.rerankers` entry-points:",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-021 v0.2 follow-up — `retrieval:` YAML block + builder.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-021 — Reranker ABC + SentenceTransformers default + Retriever integration.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-009 v0.2 — vendor observability backends.",
+            "closes": [],
+            "refs": [
+              "feat-009",
+              "feat-020"
+            ]
+          },
+          {
+            "label": "Four new `agentforge.hooks` entry-points:",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-014 v0.3 — A2A per-token streaming.",
+            "closes": [],
+            "refs": [
+              "feat-014",
+              "feat-020"
+            ]
+          },
+          {
+            "label": "feat-014 v0.3 — unified `StreamingChunkKind`.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "feat-013 v0.2 — production MCP runner.",
+            "closes": [],
+            "refs": [
+              "feat-013"
+            ]
+          },
+          {
+            "label": "`agentforge-mcp[mcp]` optional extra.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`live` pytest marker description",
+            "closes": [],
+            "refs": [
+              "feat-013"
+            ]
+          },
+          {
+            "label": "feat-014 v0.2 — production A2A runner.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "feat-014 v0.2 — A2A discovery.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "feat-014 v0.2 — A2A bi-directional streaming.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "Three new live integration tests",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-020 v0.2 — chat agents follow-ups.",
+            "closes": [],
+            "refs": [
+              "feat-020"
+            ]
+          },
+          {
+            "label": "feat-021 v0.2 follow-up — `_instantiate()` factory helper.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-021 v0.2 follow-up — `modules.retriever` legacy block.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-021 — `Retriever.__init__` signature.",
+            "closes": [],
+            "refs": [
+              "feat-021"
+            ]
+          },
+          {
+            "label": "feat-014 v0.3 — `A2AChunkKind` aliased to `StreamingChunkKind`.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "feat-014 v0.3 — A2A streaming chunk shape.",
+            "closes": [],
+            "refs": [
+              "feat-014"
+            ]
+          },
+          {
+            "label": "CI: new non-gating `live` job.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`A2AResponse.findings` model config drops `strict=True`.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "`ReasoningStrategy` ABC gains a non-abstract `stream()` default.",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "CI: live job extended with Postgres + Redis services.",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Added (accumulated during the v0.2 cycle)": [
+          {
+            "label": "feat-020 v0.3 polish — sentence-window streaming output guardrails.",
+            "closes": [],
+            "refs": [
+              "feat-020"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "0.1.0",
+      "date": "2026-05-12",
+      "entries": {
+        "Added": [
+          {
+            "label": "feat-014 — A2A protocol (full spec).",
+            "closes": [],
+            "refs": [
+              "feat-013",
+              "feat-014",
+              "feat-020"
+            ]
+          },
+          {
+            "label": "feat-020 — Chat agents (Python v0.2 scope).",
+            "closes": [],
+            "refs": [
+              "feat-014",
+              "feat-020"
+            ]
+          },
+          {
+            "label": "feat-015 — Pipeline & deterministic tasks (full spec).",
+            "closes": [],
+            "refs": [
+              "feat-015"
+            ]
+          },
+          {
+            "label": "feat-013 — MCP integration (full spec).",
+            "closes": [],
+            "refs": [
+              "feat-013"
+            ]
+          },
+          {
+            "label": "feat-019 — Developer experience + AI rules.",
+            "closes": [],
+            "refs": [
+              "feat-019"
+            ]
+          },
+          {
+            "label": "feat-018 — Safety & security guardrails (full surface).",
+            "closes": [],
+            "refs": [
+              "feat-018"
+            ]
+          },
+          {
+            "label": "feat-016 — Testing framework (full surface).",
+            "closes": [],
+            "refs": [
+              "feat-016"
+            ]
+          },
+          {
+            "label": "feat-017 — CLI runtime (full operator surface).",
+            "closes": [],
+            "refs": [
+              "feat-010",
+              "feat-011",
+              "feat-017"
+            ]
+          },
+          {
+            "label": "feat-011 — Scaffolding & upgrade.",
+            "closes": [],
+            "refs": [
+              "feat-011"
+            ]
+          },
+          {
+            "label": "feat-010 destructive CLI (sub-feat completion).",
+            "closes": [],
+            "refs": [
+              "feat-010",
+              "feat-012"
+            ]
+          },
+          {
+            "label": "feat-012 — Configuration system.",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-003",
+              "feat-004",
+              "feat-006",
+              "feat-010",
+              "feat-012"
+            ]
+          },
+          {
+            "label": "feat-010 — Module discovery & resolution (runtime + read-only CLI).",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-003",
+              "feat-004",
+              "feat-006",
+              "feat-010",
+              "feat-012"
+            ]
+          },
+          {
+            "label": "feat-009 — Observability (OTel only).",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-004",
+              "feat-009",
+              "feat-010"
+            ]
+          },
+          {
+            "label": "feat-006 — Evaluators & benchmarks.",
+            "closes": [],
+            "refs": [
+              "feat-002",
+              "feat-006",
+              "feat-010",
+              "feat-012",
+              "feat-017"
+            ]
+          },
+          {
+            "label": "feat-008 — Findings & output shapes.",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-008"
+            ]
+          },
+          {
+            "label": "feat-007 — Production rails (`FallbackChain` only).",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-007",
+              "feat-011",
+              "feat-019"
+            ]
+          },
+          {
+            "label": "feat-004 — Tools system.",
+            "closes": [],
+            "refs": [
+              "feat-004",
+              "feat-018"
+            ]
+          },
+          {
+            "label": "feat-008 — `agentforge-memory-postgres` (production persistence).",
+            "closes": [],
+            "refs": [
+              "feat-007",
+              "feat-008",
+              "feat-009"
+            ]
+          },
+          {
+            "label": "feat-009 — `GraphStore` ABC + Neo4j and SurrealDB drivers.",
+            "closes": [],
+            "refs": [
+              "feat-009"
+            ]
+          },
+          {
+            "label": "feat-007 — Persistent memory + vector search + RAG.",
+            "closes": [],
+            "refs": [
+              "feat-007",
+              "feat-008"
+            ]
+          },
+          {
+            "label": "feat-003 — `agentforge-bedrock` provider + capability extensions.",
+            "closes": [],
+            "refs": [
+              "feat-003"
+            ]
+          },
+          {
+            "label": "feat-002 — Reasoning strategies (all four stable).",
+            "closes": [],
+            "refs": [
+              "feat-002",
+              "feat-006"
+            ]
+          },
+          {
+            "label": "Repository bootstrap: uv workspace, ruff/mypy/pytest/coverage tooling, GitHub Actions CI, pre-commit hook, Apache 2.0 license, AGENTS.md, R…",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "feat-001 — Core contracts & `Agent` orchestrator.",
+            "closes": [],
+            "refs": [
+              "feat-001"
+            ]
+          }
+        ],
+        "Changed": [
+          {
+            "label": "Project structure made self-contained for AI assistants.",
+            "closes": [],
+            "refs": [
+              "feat-005"
+            ]
+          },
+          {
+            "label": "Documentation made self-contained for the public OSS repo: removed `../../` references to a private design workspace from `AGENTS.md`, `REA…",
+            "closes": [],
+            "refs": []
+          }
+        ],
+        "Docs": [
+          {
+            "label": "Runbook sections backfilled for shipped features.",
+            "closes": [],
+            "refs": [
+              "feat-001",
+              "feat-002",
+              "feat-003",
+              "feat-004",
+              "feat-005",
+              "feat-006",
+              "feat-007",
+              "feat-011",
+              "feat-012",
+              "feat-018",
+              "feat-020"
+            ]
+          }
+        ],
+        "Fixed": [
+          {
+            "label": "Repository placeholder URLs replaced with the live remote (`github.com/Scaffoldic/agentforge-py`).",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "Workspace `pyproject.toml` migrated from deprecated `[tool.uv] dev-dependencies` to `[dependency-groups] dev`; root declares workspace memb…",
+            "closes": [],
+            "refs": []
+          },
+          {
+            "label": "Pre-commit `bandit` hook now passes `-c pyproject.toml` so it reads `[tool.bandit]` (skips B101 — assert is the legitimate conformance-suit…",
+            "closes": [],
+            "refs": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
+++ b/packages/agentforge/src/agentforge/cli/upgrade_cmd.py
@@ -50,6 +50,18 @@ def register_upgrade_cmds(sub: argparse._SubParsersAction) -> None:  # type: ign
         action="store_true",
         help="Show what would change without writing.",
     )
+    upgrade.add_argument(
+        "--notes",
+        nargs="?",
+        const="AUTO",
+        default=None,
+        metavar="FROM..TO",
+        help=(
+            "Print the drift report (fixes + deprecations) for a version range "
+            "instead of upgrading. Bare `--notes` uses your current pin → the "
+            "installed version; or pass an explicit `FROM..TO`."
+        ),
+    )
     upgrade.set_defaults(_handler=_run_upgrade)
 
     fork = sub.add_parser("fork", help="Claim a managed file — future upgrades skip it.")
@@ -123,8 +135,19 @@ def _run_upgrade(
         return 1
 
     template_version = args.to if args.to else _template_version()
+    # The version this agent was last scaffolded/upgraded to — the "from"
+    # for the drift report (enh-006). `_template_version` survives the
+    # earlier `_template_name` pop.
+    from_version = str(answers.get("_template_version") or "")
+
+    # `--notes` is a report-only query: print the drift report, don't upgrade.
+    # `getattr` keeps the handler callable from a partial Namespace.
+    notes_arg = getattr(args, "notes", None)
+    if notes_arg is not None:
+        return _run_notes_query(notes_arg, from_version=from_version, installed=template_version)
+
     try:
-        return _do_upgrade(
+        rc = _do_upgrade(
             work_dir,
             template_name=template_name,
             template_root=template_root,
@@ -135,6 +158,49 @@ def _run_upgrade(
     except ModuleError as exc:
         sys.stderr.write(f"upgrade failed: {exc}\n")
         return 1
+
+    # After a real upgrade that moved versions, show the drift report for
+    # the range just crossed (enh-006) — the moment a consumer learns which
+    # workarounds the bump retired.
+    if rc == 0 and not args.dry_run and from_version and from_version != template_version:
+        sys.stdout.write("\n")
+        _emit_drift_report(from_version, template_version)
+    return rc
+
+
+def _run_notes_query(spec: str, *, from_version: str, installed: str) -> int:
+    """Handle `agentforge upgrade --notes` — print the drift report for the
+    resolved range, or error if the range can't be determined."""
+    rng = _resolve_notes_range(spec, from_version=from_version, installed=installed)
+    if rng is None:
+        sys.stderr.write(
+            "Could not determine a version range for --notes. Pass an explicit "
+            "range, e.g. `agentforge upgrade --notes 0.2.4..0.3.1`.\n"
+        )
+        return 1
+    _emit_drift_report(*rng)
+    return 0
+
+
+def _resolve_notes_range(spec: str, *, from_version: str, installed: str) -> tuple[str, str] | None:
+    """Resolve the `--notes` argument to a `(from, to)` version range.
+
+    `"AUTO"` (bare `--notes`) → current pin → installed version; an
+    explicit `"FROM..TO"` is split. Returns `None` when the range can't be
+    determined (e.g. AUTO with no recorded pin, or a malformed spec).
+    """
+    if spec == "AUTO":
+        return (from_version, installed) if from_version else None
+    frm, sep, to = spec.partition("..")
+    if not sep or not frm.strip() or not to.strip():
+        return None
+    return (frm.strip(), to.strip())
+
+
+def _emit_drift_report(frm: str, to: str) -> None:
+    from agentforge.cli._notes import format_drift_report, load_notes  # noqa: PLC0415
+
+    sys.stdout.write(format_drift_report(load_notes(), frm, to))
 
 
 def _read_answers(work_dir: Path) -> dict[str, object]:

--- a/packages/agentforge/tests/unit/test_deprecation.py
+++ b/packages/agentforge/tests/unit/test_deprecation.py
@@ -1,0 +1,64 @@
+"""Tests for the deprecation registry (enh-006 part 3)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from agentforge import _deprecation
+from agentforge._deprecation import Deprecation, deprecated, iter_deprecations
+
+
+@pytest.fixture
+def clean_registry() -> Iterator[None]:
+    """Snapshot + restore the global registry so tests don't leak."""
+    saved = dict(_deprecation._REGISTRY)
+    try:
+        yield
+    finally:
+        _deprecation._REGISTRY.clear()
+        _deprecation._REGISTRY.update(saved)
+
+
+def test_deprecated_warns_and_delegates(clean_registry: None) -> None:
+    @deprecated(since="0.4", replacement="new_thing()", ref="enh-006")
+    def old_thing(x: int) -> int:
+        return x + 1
+
+    with pytest.warns(DeprecationWarning, match=r"use new_thing\(\) instead \(enh-006\)"):
+        assert old_thing(41) == 42
+
+
+def test_deprecated_registers_entry(clean_registry: None) -> None:
+    @deprecated(since="0.4", replacement="new_api", ref="enh-006")
+    def some_seam() -> None: ...
+
+    match = [d for d in iter_deprecations() if d.qualname.endswith("some_seam")]
+    assert len(match) == 1
+    dep = match[0]
+    assert dep.since == "0.4"
+    assert dep.replacement == "new_api"
+    assert dep.ref == "enh-006"
+
+
+def test_iter_deprecations_sorted_by_since_then_qualname(clean_registry: None) -> None:
+    _deprecation._REGISTRY.clear()
+    _deprecation._REGISTRY.update(
+        {
+            "b": Deprecation("b", since="0.5", replacement="x", ref="r"),
+            "a": Deprecation("a", since="0.4", replacement="x", ref="r"),
+            "c": Deprecation("c", since="0.4", replacement="x", ref="r"),
+        }
+    )
+    assert [d.qualname for d in iter_deprecations()] == ["a", "c", "b"]
+
+
+def test_message_format() -> None:
+    dep = Deprecation("Foo.bar", since="0.4", replacement="Foo.baz", ref="enh-006")
+    assert dep.message() == "Foo.bar is deprecated since 0.4; use Foo.baz instead (enh-006)."
+
+
+def test_registry_empty_of_real_seams_by_default() -> None:
+    """The framework ships no real deprecations yet — just the machinery.
+    Guards against accidentally shipping one without a CHANGELOG note."""
+    assert iter_deprecations() == []

--- a/packages/agentforge/tests/unit/test_notes.py
+++ b/packages/agentforge/tests/unit/test_notes.py
@@ -1,0 +1,135 @@
+"""Tests for the release-notes model + drift report (enh-006 part 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentforge.cli._notes import (
+    format_drift_report,
+    load_notes,
+    parse_changelog,
+    slice_versions,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+
+_SAMPLE = """\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- **bug-025 (P1) — upgrade clobbered files** something something.
+  Continues on a second line. (closes #114)
+
+## [0.3.0] — 2026-06-16
+
+### Added
+
+- **enh-003 — middleware seam.** Adds it. Closes #93.
+- **enh-009 — multi close.** (closes #200, #201)
+
+### Changed
+
+- A plain entry with no refs or issues.
+
+```yaml
+- this is a yaml bullet inside a fence, not a changelog entry (closes #999)
+```
+
+## [0.2.4] — 2026-06-03
+
+### Fixed
+
+- **bug-001 — old fix.** Resolves issue #5.
+"""
+
+
+def test_parse_versions_and_dates() -> None:
+    notes = parse_changelog(_SAMPLE)
+    vs = {v["version"]: v for v in notes["versions"]}
+    assert list(vs) == ["Unreleased", "0.3.0", "0.2.4"]
+    assert vs["0.3.0"]["date"] == "2026-06-16"
+    assert vs["Unreleased"]["date"] is None
+
+
+def test_parse_extracts_closes_and_refs() -> None:
+    notes = parse_changelog(_SAMPLE)
+    fixed = {v["version"]: v for v in notes["versions"]}["Unreleased"]["entries"]["Fixed"]
+    assert fixed[0]["closes"] == [114]
+    assert fixed[0]["refs"] == ["bug-025"]
+    assert fixed[0]["label"] == "bug-025 (P1) — upgrade clobbered files"  # bold lead only
+
+
+def test_parse_handles_comma_separated_closes() -> None:
+    notes = parse_changelog(_SAMPLE)
+    added = {v["version"]: v for v in notes["versions"]}["0.3.0"]["entries"]["Added"]
+    multi = next(e for e in added if "multi close" in e["label"])
+    assert multi["closes"] == [200, 201]
+
+
+def test_parse_ignores_bullets_inside_code_fence() -> None:
+    notes = parse_changelog(_SAMPLE)
+    changed = {v["version"]: v for v in notes["versions"]}["0.3.0"]["entries"]["Changed"]
+    # The yaml bullet (closes #999) inside the fence must not become an entry.
+    assert all(999 not in e["closes"] for e in changed)
+    assert len(changed) == 1
+
+
+def test_parse_alternate_resolves_phrasing() -> None:
+    notes = parse_changelog(_SAMPLE)
+    fixed = {v["version"]: v for v in notes["versions"]}["0.2.4"]["entries"]["Fixed"]
+    assert fixed[0]["closes"] == [5]
+
+
+def test_slice_versions_is_half_open_newer_than_from() -> None:
+    notes = parse_changelog(_SAMPLE)
+    sliced = [v["version"] for v in slice_versions(notes, "0.2.4", "0.3.0")]
+    assert sliced == ["0.3.0"]  # excludes 0.2.4 (already have it), includes 0.3.0
+
+
+def test_slice_includes_unreleased_only_when_targeted() -> None:
+    notes = parse_changelog(_SAMPLE)
+    assert "Unreleased" not in [v["version"] for v in slice_versions(notes, "0.2.4", "0.3.0")]
+    assert "Unreleased" in [v["version"] for v in slice_versions(notes, "0.2.4", "Unreleased")]
+
+
+def test_format_drift_report_lists_fixes_and_summary() -> None:
+    notes = parse_changelog(_SAMPLE)
+    report = format_drift_report(notes, "0.2.4", "Unreleased")
+    assert "drift from 0.2.4 → Unreleased" in report
+    assert "bug-025" in report
+    assert "(closes #114)" in report
+    assert "enh-003" in report  # 0.3.0 is in (0.2.4, Unreleased]
+    assert "fix(es)" in report
+
+
+def test_format_drift_report_empty_range() -> None:
+    notes = parse_changelog(_SAMPLE)
+    report = format_drift_report(notes, "0.3.0", "0.3.0")
+    assert "No tracked fixes in this range." in report
+    assert "0 fix(es), 0 deprecation(s)" in report
+
+
+# ----------------------------------------------------------------------
+# Drift guard — the committed JSON must match a fresh parse of CHANGELOG.
+# ----------------------------------------------------------------------
+
+
+def test_committed_release_notes_is_current() -> None:
+    """`release_notes.json` is generated from `CHANGELOG.md`. If this
+    fails, run `python scripts/gen_release_notes.py`."""
+    fresh = parse_changelog(_CHANGELOG.read_text(encoding="utf-8"))
+    committed = load_notes()
+    assert committed == fresh, "release_notes.json is stale — regenerate it."
+
+
+def test_real_notes_capture_known_issue_closures() -> None:
+    """The real CHANGELOG's varied phrasings resolve to the right issues —
+    the scenario from #115 (a 0.2.4→latest bump retires #86 / #93)."""
+    notes = load_notes()
+    by_ver = {v["version"]: v for v in notes["versions"]}
+    closes_030 = {n for es in by_ver["0.3.0"]["entries"].values() for e in es for n in e["closes"]}
+    assert {86, 92, 93} <= closes_030

--- a/packages/agentforge/tests/unit/test_notes.py
+++ b/packages/agentforge/tests/unit/test_notes.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from agentforge import _deprecation
+from agentforge._deprecation import Deprecation
 from agentforge.cli._notes import (
     format_drift_report,
     load_notes,
@@ -111,6 +114,50 @@ def test_format_drift_report_empty_range() -> None:
     report = format_drift_report(notes, "0.3.0", "0.3.0")
     assert "No tracked fixes in this range." in report
     assert "0 fix(es), 0 deprecation(s)" in report
+
+
+def test_format_report_lists_deprecations_in_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _deprecation,
+        "_REGISTRY",
+        {"Old.api": Deprecation("Old.api", since="0.3.0", replacement="New.api", ref="enh-006")},
+    )
+    notes = parse_changelog(_SAMPLE)
+    report = format_drift_report(notes, "0.2.4", "Unreleased")
+    assert "Deprecated (workarounds you can retire):" in report
+    assert "Old.api → use New.api  (since 0.3.0, enh-006)" in report
+    assert "1 deprecation(s)" in report
+
+
+def test_format_report_excludes_out_of_range_deprecation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _deprecation,
+        "_REGISTRY",
+        {"Future.api": Deprecation("Future.api", since="9.9.9", replacement="x", ref="enh-006")},
+    )
+    notes = parse_changelog(_SAMPLE)
+    report = format_drift_report(notes, "0.2.4", "0.3.0")
+    assert "Deprecated" not in report
+    assert "0 deprecation(s)" in report
+
+
+def test_slice_tolerates_non_numeric_version_segment() -> None:
+    notes = {
+        "versions": [
+            {"version": "0.3.0rc1", "date": None, "entries": {}},
+            {"version": "0.2.4", "date": None, "entries": {}},
+        ]
+    }
+    # `0rc1` isn't an int — _vkey degrades it to 0 rather than raising.
+    sliced = [v["version"] for v in slice_versions(notes, "0.2.4", "0.4.0")]
+    assert sliced == ["0.3.0rc1"]
+
+
+def test_parse_skips_whitespace_only_bullet() -> None:
+    md = "## [0.1.0]\n\n### Fixed\n\n-  \n- real entry\n"
+    notes = parse_changelog(md)
+    fixed = notes["versions"][0]["entries"]["Fixed"]
+    assert [e["label"] for e in fixed] == ["real entry"]
 
 
 # ----------------------------------------------------------------------

--- a/packages/agentforge/tests/unit/test_upgrade_cmd.py
+++ b/packages/agentforge/tests/unit/test_upgrade_cmd.py
@@ -50,7 +50,7 @@ def test_upgrade_preserves_custom_block_in_shared_file(tmp_path: Path) -> None:
     agents_md = dst / "AGENTS.md"
     _put_custom_note(agents_md, SENTINEL)
 
-    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False, notes=None), cwd=dst)
 
     assert code == 0
     out = agents_md.read_text(encoding="utf-8")
@@ -67,7 +67,7 @@ def test_upgrade_skips_forked_file(tmp_path: Path) -> None:
     assert _run_fork(argparse.Namespace(path="docs/runbooks/02-add-a-tool.md"), cwd=dst) == 0
     runbook.write_text("# Completely my own runbook now\n", encoding="utf-8")
 
-    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False), cwd=dst)
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=False, notes=None), cwd=dst)
 
     assert code == 0
     assert runbook.read_text(encoding="utf-8") == "# Completely my own runbook now\n"
@@ -81,7 +81,7 @@ def test_upgrade_dry_run_writes_nothing_and_lists_files(
     _put_custom_note(agents_md, SENTINEL)
     before = agents_md.read_text(encoding="utf-8")
 
-    code = _run_upgrade(argparse.Namespace(to=None, dry_run=True), cwd=dst)
+    code = _run_upgrade(argparse.Namespace(to=None, dry_run=True, notes=None), cwd=dst)
 
     assert code == 0
     # Nothing written.

--- a/packages/agentforge/tests/unit/test_upgrade_notes.py
+++ b/packages/agentforge/tests/unit/test_upgrade_notes.py
@@ -86,6 +86,23 @@ def test_notes_malformed_range_errors(tmp_path: Path, capsys: pytest.CaptureFixt
     assert "Could not determine a version range" in capsys.readouterr().err
 
 
+def test_notes_auto_without_recorded_pin_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dst = _scaffold(tmp_path)
+    # Drop the recorded pin so AUTO can't resolve a "from".
+    path = dst / ".agentforge-state" / "answers.yml"
+    answers = yaml.safe_load(path.read_text(encoding="utf-8"))
+    answers.pop("_template_version", None)
+    path.write_text(yaml.safe_dump(answers), encoding="utf-8")
+    capsys.readouterr()
+
+    rc = _run_upgrade(_upgrade_args(notes="AUTO"), cwd=dst)
+
+    assert rc == 1
+    assert "Could not determine a version range" in capsys.readouterr().err
+
+
 def test_auto_drift_summary_after_real_upgrade(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/packages/agentforge/tests/unit/test_upgrade_notes.py
+++ b/packages/agentforge/tests/unit/test_upgrade_notes.py
@@ -1,0 +1,101 @@
+"""Integration tests for `agentforge upgrade --notes` (enh-006 part 2).
+
+Scaffolds a real agent, then drives the drift-report paths: the
+report-only `--notes` query, the auto range, malformed input, and the
+auto-summary printed at the end of a real upgrade.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+import yaml
+from agentforge.cli.new_cmd import _run_new
+from agentforge.cli.upgrade_cmd import _run_upgrade
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    dst = tmp_path / "agent"
+    assert (
+        _run_new(
+            argparse.Namespace(
+                project_slug="agent",
+                template="minimal",
+                provider="bedrock",
+                no_prompts=True,
+                dst=dst,
+            )
+        )
+        == 0
+    )
+    return dst
+
+
+def _set_pin(dst: Path, version: str) -> None:
+    """Rewrite the recorded scaffold version (the drift report's 'from')."""
+    path = dst / ".agentforge-state" / "answers.yml"
+    answers = yaml.safe_load(path.read_text(encoding="utf-8"))
+    answers["_template_version"] = version
+    path.write_text(yaml.safe_dump(answers), encoding="utf-8")
+
+
+def _upgrade_args(**kw: object) -> argparse.Namespace:
+    base: dict[str, object] = {"to": None, "dry_run": False, "notes": None}
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_notes_report_only_does_not_upgrade(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dst = _scaffold(tmp_path)
+    capsys.readouterr()  # drop scaffold output
+
+    rc = _run_upgrade(_upgrade_args(notes="0.2.4..0.3.0"), cwd=dst)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "drift from 0.2.4 → 0.3.0" in out
+    assert "(closes #92)" in out  # enh-004 landed in 0.3.0
+    assert "upgrade complete" not in out  # report-only — no upgrade ran
+
+
+def test_notes_auto_range_uses_pin_and_installed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dst = _scaffold(tmp_path)
+    _set_pin(dst, "0.2.4")
+    capsys.readouterr()
+
+    rc = _run_upgrade(_upgrade_args(notes="AUTO"), cwd=dst)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "drift from 0.2.4 →" in out  # from = the recorded pin
+
+
+def test_notes_malformed_range_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    dst = _scaffold(tmp_path)
+    capsys.readouterr()
+
+    rc = _run_upgrade(_upgrade_args(notes="not-a-range"), cwd=dst)
+
+    assert rc == 1
+    assert "Could not determine a version range" in capsys.readouterr().err
+
+
+def test_auto_drift_summary_after_real_upgrade(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dst = _scaffold(tmp_path)
+    _set_pin(dst, "0.2.4")  # pretend this agent was scaffolded under 0.2.4
+    capsys.readouterr()
+
+    rc = _run_upgrade(_upgrade_args(), cwd=dst)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "upgrade complete" in out  # the upgrade ran
+    assert "drift from 0.2.4 →" in out  # and the drift summary followed

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -1,0 +1,67 @@
+"""Generate the packaged release-notes data from `CHANGELOG.md` (enh-006).
+
+`agentforge upgrade --notes` prints a drift report offline against the
+installed wheel, but the wheel does not ship `CHANGELOG.md`. This script
+parses the repo-root `CHANGELOG.md` into the structured model
+(`agentforge.cli._notes.parse_changelog`) and writes it to the committed
+`release_notes.json` next to that module, which hatchling packages.
+
+Run it whenever `CHANGELOG.md` changes; `--check` verifies the committed
+JSON is current (used by the source-tree drift test / CI) without writing.
+
+Usage:
+
+    python scripts/gen_release_notes.py            # regenerate + write
+    python scripts/gen_release_notes.py --check     # exit 1 if stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make `agentforge` importable when run from a plain checkout.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "packages" / "agentforge" / "src"))
+
+from agentforge.cli._notes import parse_changelog  # noqa: E402
+
+_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+_OUT = _REPO_ROOT / "packages" / "agentforge" / "src" / "agentforge" / "cli" / "release_notes.json"
+
+
+def _render() -> str:
+    notes = parse_changelog(_CHANGELOG.read_text(encoding="utf-8"))
+    return json.dumps(notes, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the committed JSON is stale (no write).",
+    )
+    args = parser.parse_args(argv)
+
+    rendered = _render()
+
+    if args.check:
+        current = _OUT.read_text(encoding="utf-8") if _OUT.exists() else ""
+        if current != rendered:
+            sys.stderr.write(
+                "release_notes.json is stale — run `python scripts/gen_release_notes.py`.\n"
+            )
+            return 1
+        sys.stdout.write("release_notes.json is up to date.\n")
+        return 0
+
+    _OUT.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(f"wrote {_OUT.relative_to(_REPO_ROOT)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements parts 2–3 of **enh-006** (#115). After bumping the framework pin, a consumer can now see which fixes — and the issues they close — the bump shipped, so dead workarounds get cleaned up instead of lingering. (Part 1, the `(closes #NN)` CHANGELOG convention, shipped in bug-025 / #116.)

A real 0.2.4→latest report surfaces exactly the two workarounds the reporter only found by reading source: enh-002 (closes #86, the `app:` config passthrough) and enh-003 (closes #93, the `from_http(middleware=…)` seam).

## Changes

**Part 2 — offline drift report**
- `agentforge/cli/_notes.py` — parse Keep-a-Changelog markdown → structured model → slice `(from, to]` → format the report. Handles varied historical phrasings (`closes`/`Closes`/`Resolves issue`/comma lists) and skips fenced code.
- `scripts/gen_release_notes.py` — generates the committed `agentforge/cli/release_notes.json` from `CHANGELOG.md` (hatchling auto-ships any file under `src/agentforge`; the wheel doesn't carry the markdown). `--check` mode verifies freshness.
- `agentforge upgrade --notes [FROM..TO]` — report-only (bare `--notes` = current pin → installed version); a real `upgrade` prints the summary for the range it crossed. "from" defaults to the lock/answers `_template_version`.

**Part 3 — deprecation machinery**
- `agentforge/_deprecation.py` — `@deprecated(since, replacement, ref)` warns at call time and registers for the report; `iter_deprecations()`. No real seam is deprecated yet — the empty default is test-guarded.

## Never-drift + coverage

- **Drift guard, two layers:** `test_committed_release_notes_is_current` (CI) + a `release-notes-current` pre-commit hook running `gen_release_notes.py --check` (commit-time). A stale `release_notes.json` can't slip through.
- **Coverage:** `_notes.py` and `_deprecation.py` at **100%** line+branch; global gate ≥90%.

## Tests

Notes parser/slice/format + drift guard + deprecation-in/out-of-range + non-numeric version + whitespace bullet; deprecation decorator (warn + register + sorting); CLI report-only / auto-range / auto-without-pin / malformed / post-upgrade summary. `uv run pre-commit run --all-files` green (mypy `--strict`, bandit, unit + integration, coverage, drift hook).

Refs #115
Spec: `docs/enhancements/enh-006-upgrade-drift-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)