### PR TITLE
chore(release): prep v0.4.0 (version bump + release notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ slice between two versions to see which of your filed issues a bump fixes.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-23
+
+"Graph + governance foundation." Embedded zero-ops graph storage and
+directional GraphRAG; an offline upgrade-drift report; the first governance
+pillar (identity); and the `agentforge upgrade` data-loss fix. Two new
+packages — `agentforge-memory-kuzu` and `agentforge-governance`. Every
+workspace member bumped to `0.4.0`.
+
 ### Added
 
 - **feat-029 — governance: identity (pillar 1).** First pillar of the governance

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,76 @@
+# AgentForge v0.4.0 — Graph + governance foundation
+
+> Released 2026-06-23. Coordinated release train (ADR-0015): every
+> workspace package bumps to `0.4.0` in lockstep.
+
+The 0.4 train lands embedded, zero-ops graph storage and sharper GraphRAG;
+an offline upgrade-drift report so consumers can see what a version bump
+fixed; the first pillar of a governance spine (identity); and a data-loss
+fix in `agentforge upgrade`. Two new packages ship: **`agentforge-memory-kuzu`**
+and **`agentforge-governance`**. Additive and backward compatible — safe to
+upgrade from 0.3.x.
+
+---
+
+## Highlights
+
+- **feat-027 — embedded `KuzuGraphStore`.** A zero-ops, file-backed,
+  in-process graph store — `path: .ckg` and the store exists, no server (the
+  graph analogue of the SQLite `MemoryStore`). It implements the locked
+  `GraphStore` contract and passes `run_graph_conformance`, so it is
+  swap-compatible with the Neo4j / SurrealDB drivers — and makes the whole
+  graph + GraphRAG path testable **offline**. New `agentforge-memory-kuzu`
+  package (`driver: kuzu`).
+
+- **enh-005 — directional GraphRAG expansion.** `retrieval.graph_expansion`
+  gains `direction: in | out | any`, so expansion follows **asymmetric** edges
+  the right way — `in` for callers / who-cites-X / dependents, `out` for
+  callees / what-X-cites. Defaults to `any` (the original behaviour), so
+  existing agents are byte-for-byte unchanged. No ABC change.
+
+- **enh-006 — upgrade drift report.** `agentforge upgrade --notes [FROM..TO]`
+  prints which fixes — and the issues they close — a version range shipped, so
+  a consumer can clean up workarounds a bump made removable instead of letting
+  them linger. Works offline from a `release_notes.json` shipped in the wheel;
+  a real `agentforge upgrade` also prints the summary for the range it crossed.
+  Plus a `@deprecated` registry that warns and feeds the report.
+
+- **feat-029 — governance: identity (pillar 1).** The foundation of a
+  governance spine (ADR-0023): every agent gets a stable, portable `Principal`
+  so every action has a name. New `IdentityProvider` contract + conformance in
+  core; the existing `Principal` is widened additively (`kind` / `owner`) so
+  one principal serves both `auth` and identity. New `agentforge-governance`
+  package ships the offline `local` driver (HMAC-signed credentials, URN ids).
+  `governance.identity` config. Registry / policy / audit pillars follow on
+  the 0.5 train.
+
+- **bug-025 — `agentforge upgrade` data-loss fix.** Upgrade was overwriting
+  forked files and erasing `agentforge:custom` blocks; it now skips forked
+  files and preserves the custom region via the three-section merge, and
+  `--dry-run` prints a per-file plan. The `(closes #NN)` CHANGELOG convention
+  was adopted in the same change.
+
+## Designs landed (build on the 0.5 train)
+
+- **feat-028 — durable execution + human-in-the-loop** (spec): checkpoint-and-
+  resume so a run survives process death, plus approval gates that suspend
+  before irreversible tool calls — promoting the record/replay seam into a
+  checkpoint seam.
+- **ADR-0023 + the governance epic** architecture (identity shipped; registry /
+  policy / audit specced).
+
+## Upgrade notes
+
+- Additive across the board; no breaking changes from 0.3.x. The new packages
+  (`agentforge-memory-kuzu`, `agentforge-governance`) are opt-in — installing
+  the base `agentforge-py` is unaffected.
+- After upgrading, run `agentforge upgrade --notes 0.3.1..0.4.0` to see the
+  resolved issues for the range.
+
+## Packaging
+
+- Every workspace member (now **36** packages, incl. the two new ones) bumped
+  to `0.4.0`; cross-package pins refreshed to `~= 0.4.0`.
+- The packaged-wheel release gate now also exercises the Kùzu graph store, the
+  governance identity provider, and the `upgrade --notes` artifact from the
+  built wheels before publish.

--- a/packages/agentforge-a2a/pyproject.toml
+++ b/packages/agentforge-a2a/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-a2a"
-version = "0.3.1"
+version = "0.4.0"
 description = "A2A (Agent-to-Agent) protocol client + server for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-py ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-py ~= 0.4.0",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-anthropic/pyproject.toml
+++ b/packages/agentforge-anthropic/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-anthropic"
-version = "0.3.1"
+version = "0.4.0"
 description = "Anthropic native LLM provider for AgentForge — Claude with caching, extended thinking, streaming"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-bedrock/pyproject.toml
+++ b/packages/agentforge-bedrock/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-bedrock"
-version = "0.3.1"
+version = "0.4.0"
 description = "AWS Bedrock provider for AgentForge — Anthropic, Titan, Cohere on Bedrock"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "aioboto3>=13.0",
     "botocore>=1.35",
 ]

--- a/packages/agentforge-chat-history-postgres/pyproject.toml
+++ b/packages/agentforge-chat-history-postgres/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-history-postgres"
-version = "0.3.1"
+version = "0.4.0"
 description = "Postgres-backed ChatHistoryStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "asyncpg>=0.30",
 ]
 

--- a/packages/agentforge-chat-history-redis/pyproject.toml
+++ b/packages/agentforge-chat-history-redis/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-chat-history-redis"
-version = "0.3.1"
+version = "0.4.0"
 description = "Redis-backed ChatHistoryStore and SessionLock for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-chat ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-chat ~= 0.4.0",
     "redis>=5.0",
 ]
 

--- a/packages/agentforge-chat-http/pyproject.toml
+++ b/packages/agentforge-chat-http/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-chat-http"
-version = "0.3.1"
+version = "0.4.0"
 description = "FastAPI HTTP + WebSocket + SSE server for AgentForge chat sessions"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -24,9 +24,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-py ~= 0.3.1",
-    "agentforge-chat ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-py ~= 0.4.0",
+    "agentforge-chat ~= 0.4.0",
     "fastapi>=0.115",
     "uvicorn>=0.32",
     "httpx>=0.27",

--- a/packages/agentforge-chat-slack/pyproject.toml
+++ b/packages/agentforge-chat-slack/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-chat-slack"
-version = "0.3.1"
+version = "0.4.0"
 description = "Slack reference channel adapter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-chat ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-chat ~= 0.4.0",
     "slack-bolt>=1.20",
     "slack-sdk>=3.30",
 ]

--- a/packages/agentforge-chat/pyproject.toml
+++ b/packages/agentforge-chat/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-chat"
-version = "0.3.1"
+version = "0.4.0"
 description = "Chat-agent runtime (ChatSession + history drivers + truncation) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-py ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-py ~= 0.4.0",
     # aiosqlite is a hard dependency, not an optional extra: the package
     # eagerly imports SqliteChatHistory (agentforge_chat/__init__.py ->
     # sqlite.py -> `import aiosqlite`), so `import agentforge_chat` fails

--- a/packages/agentforge-core/pyproject.toml
+++ b/packages/agentforge-core/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-core"
-version = "0.3.1"
+version = "0.4.0"
 description = "AgentForge core — stable contracts (ABCs, value types) for the agentic framework"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/agentforge-eval-geval/pyproject.toml
+++ b/packages/agentforge-eval-geval/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "agentforge-eval-geval"
-version = "0.3.1"
+version = "0.4.0"
 description = "LLM-judge evaluators (G-Eval) for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "PyYAML>=6.0",
 ]
 

--- a/packages/agentforge-evidently/pyproject.toml
+++ b/packages/agentforge-evidently/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-evidently"
-version = "0.3.1"
+version = "0.4.0"
 description = "Evidently AI metrics + drift hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-governance/pyproject.toml
+++ b/packages/agentforge-governance/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentforge-governance"
-version = "0.3.1"
+version = "0.4.0"
 description = "Governance spine for AgentForge — identity (feat-029) and, as they land, registry / policy / audit drivers"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.urls]

--- a/packages/agentforge-guard-llamaguard/pyproject.toml
+++ b/packages/agentforge-guard-llamaguard/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-llamaguard"
-version = "0.3.1"
+version = "0.4.0"
 description = "Llama Guard 3 classifier for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.3.1"]
+dependencies = ["agentforge-core ~= 0.4.0"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-llmguard/pyproject.toml
+++ b/packages/agentforge-guard-llmguard/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-llmguard"
-version = "0.3.1"
+version = "0.4.0"
 description = "LLM Guard scanners for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.urls]

--- a/packages/agentforge-guard-nemo/pyproject.toml
+++ b/packages/agentforge-guard-nemo/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-guard-nemo"
-version = "0.3.1"
+version = "0.4.0"
 description = "NeMo Guardrails programmable rails for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["agentforge-core ~= 0.3.1"]
+dependencies = ["agentforge-core ~= 0.4.0"]
 
 [project.urls]
 Homepage = "https://github.com/Scaffoldic/agentforge-py"

--- a/packages/agentforge-guard-presidio/pyproject.toml
+++ b/packages/agentforge-guard-presidio/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-guard-presidio"
-version = "0.3.1"
+version = "0.4.0"
 description = "Microsoft Presidio PII detector for AgentForge guardrails"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.urls]

--- a/packages/agentforge-langfuse/pyproject.toml
+++ b/packages/agentforge-langfuse/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-langfuse"
-version = "0.3.1"
+version = "0.4.0"
 description = "Langfuse trace dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-litellm/pyproject.toml
+++ b/packages/agentforge-litellm/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-litellm"
-version = "0.3.1"
+version = "0.4.0"
 description = "LiteLLM router-based LLM provider for AgentForge — 100+ underlying providers through one interface"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-mcp/pyproject.toml
+++ b/packages/agentforge-mcp/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-mcp"
-version = "0.3.1"
+version = "0.4.0"
 description = "Model Context Protocol integration for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 # feat-013 v0.2: the `mcp` SDK is required only for the production

--- a/packages/agentforge-memory-kuzu/pyproject.toml
+++ b/packages/agentforge-memory-kuzu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentforge-memory-kuzu"
-version = "0.3.1"
+version = "0.4.0"
 description = "Embedded, file-backed GraphStore for AgentForge (Kùzu)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "kuzu>=0.11.3",
 ]
 

--- a/packages/agentforge-memory-neo4j/pyproject.toml
+++ b/packages/agentforge-memory-neo4j/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "agentforge-memory-neo4j"
-version = "0.3.1"
+version = "0.4.0"
 description = "Neo4j-backed MemoryStore and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "neo4j>=5.20",
 ]
 

--- a/packages/agentforge-memory-postgres/pyproject.toml
+++ b/packages/agentforge-memory-postgres/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "agentforge-memory-postgres"
-version = "0.3.1"
+version = "0.4.0"
 description = "Postgres + pgvector-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "asyncpg>=0.30",
     "pgvector>=0.3",
 ]

--- a/packages/agentforge-memory-sqlite/pyproject.toml
+++ b/packages/agentforge-memory-sqlite/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "agentforge-memory-sqlite"
-version = "0.3.1"
+version = "0.4.0"
 description = "SQLite-backed MemoryStore and VectorStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "aiosqlite>=0.20",
 ]
 

--- a/packages/agentforge-memory-surrealdb/pyproject.toml
+++ b/packages/agentforge-memory-surrealdb/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "agentforge-memory-surrealdb"
-version = "0.3.1"
+version = "0.4.0"
 description = "SurrealDB-backed MemoryStore, VectorStore, and GraphStore for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "surrealdb>=1.0",
 ]
 

--- a/packages/agentforge-ollama/pyproject.toml
+++ b/packages/agentforge-ollama/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-ollama"
-version = "0.3.1"
+version = "0.4.0"
 description = "Ollama local LLM + embedding provider for AgentForge — llama / mistral / qwen / mxbai-embed on localhost"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-openai/pyproject.toml
+++ b/packages/agentforge-openai/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-openai"
-version = "0.3.1"
+version = "0.4.0"
 description = "OpenAI LLM + embeddings provider for AgentForge — gpt-4o / o-series + text-embedding-3-*"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-otel/pyproject.toml
+++ b/packages/agentforge-otel/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-otel"
-version = "0.3.1"
+version = "0.4.0"
 description = "OpenTelemetry tracing + metrics emitter for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-grpc>=1.27",
 ]

--- a/packages/agentforge-phoenix/pyproject.toml
+++ b/packages/agentforge-phoenix/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "agentforge-phoenix"
-version = "0.3.1"
+version = "0.4.0"
 description = "Arize Phoenix dashboard hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-cohere/pyproject.toml
+++ b/packages/agentforge-reranker-cohere/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-reranker-cohere"
-version = "0.3.1"
+version = "0.4.0"
 description = "Cohere managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-mixedbread/pyproject.toml
+++ b/packages/agentforge-reranker-mixedbread/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-mixedbread"
-version = "0.3.1"
+version = "0.4.0"
 description = "Mixedbread AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-sentence-transformers/pyproject.toml
+++ b/packages/agentforge-reranker-sentence-transformers/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.3.1"
+version = "0.4.0"
 description = "SentenceTransformers cross-encoder reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-reranker-voyage/pyproject.toml
+++ b/packages/agentforge-reranker-voyage/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "agentforge-reranker-voyage"
-version = "0.3.1"
+version = "0.4.0"
 description = "Voyage AI managed-API reranker for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-statsd/pyproject.toml
+++ b/packages/agentforge-statsd/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-statsd"
-version = "0.3.1"
+version = "0.4.0"
 description = "StatsD metrics emitter hook for AgentForge"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge-testing/pyproject.toml
+++ b/packages/agentforge-testing/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "agentforge-testing"
-version = "0.3.1"
+version = "0.4.0"
 description = "Richer test helpers for AgentForge (golden-set runner, snapshot, recording analysis)"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,8 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
-    "agentforge-py ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
+    "agentforge-py ~= 0.4.0",
 ]
 
 [project.urls]

--- a/packages/agentforge-voyage/pyproject.toml
+++ b/packages/agentforge-voyage/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "agentforge-voyage"
-version = "0.3.1"
+version = "0.4.0"
 description = "Voyage AI embedding provider for AgentForge — voyage-3 / voyage-large / voyage-code"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentforge/pyproject.toml
+++ b/packages/agentforge/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "agentforge-py"
-version = "0.3.1"
+version = "0.4.0"
 description = "AgentForge — open-source plug-and-play framework for production AI agents"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "agentforge-core ~= 0.3.1",
+    "agentforge-core ~= 0.4.0",
     "pydantic>=2.10",
     "pyyaml>=6.0",
     "typer>=0.15",
@@ -61,94 +61,94 @@ dependencies = [
 # installs the wrapper but not the SDK and the first call raises a
 # ModuleError (bug-015). bedrock hard-deps its SDK (aioboto3/botocore),
 # so it requests no extra — and must NOT request a phantom `[bedrock]`.
-anthropic = ["agentforge-anthropic[anthropic] ~= 0.3.1"]
-openai = ["agentforge-openai[openai] ~= 0.3.1"]
-bedrock = ["agentforge-bedrock ~= 0.3.1"]
-ollama = ["agentforge-ollama[ollama] ~= 0.3.1"]
-litellm = ["agentforge-litellm[litellm] ~= 0.3.1"]
+anthropic = ["agentforge-anthropic[anthropic] ~= 0.4.0"]
+openai = ["agentforge-openai[openai] ~= 0.4.0"]
+bedrock = ["agentforge-bedrock ~= 0.4.0"]
+ollama = ["agentforge-ollama[ollama] ~= 0.4.0"]
+litellm = ["agentforge-litellm[litellm] ~= 0.4.0"]
 
 # Embeddings
-voyage = ["agentforge-voyage[voyage] ~= 0.3.1"]
+voyage = ["agentforge-voyage[voyage] ~= 0.4.0"]
 
 # Memory backends (each hard-deps its driver SDK — no extra to chain)
-memory-sqlite = ["agentforge-memory-sqlite ~= 0.3.1"]
-memory-postgres = ["agentforge-memory-postgres ~= 0.3.1"]
-memory-neo4j = ["agentforge-memory-neo4j ~= 0.3.1"]
-memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.3.1"]
+memory-sqlite = ["agentforge-memory-sqlite ~= 0.4.0"]
+memory-postgres = ["agentforge-memory-postgres ~= 0.4.0"]
+memory-neo4j = ["agentforge-memory-neo4j ~= 0.4.0"]
+memory-surrealdb = ["agentforge-memory-surrealdb ~= 0.4.0"]
 
 # Chat surface (chat hard-deps aiosqlite; history backends hard-dep their SDK)
-chat = ["agentforge-chat ~= 0.3.1"]
-chat-http = ["agentforge-chat-http ~= 0.3.1"]
-chat-slack = ["agentforge-chat-slack ~= 0.3.1"]
-chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.3.1"]
-chat-history-redis = ["agentforge-chat-history-redis ~= 0.3.1"]
+chat = ["agentforge-chat ~= 0.4.0"]
+chat-http = ["agentforge-chat-http ~= 0.4.0"]
+chat-slack = ["agentforge-chat-slack ~= 0.4.0"]
+chat-history-postgres = ["agentforge-chat-history-postgres ~= 0.4.0"]
+chat-history-redis = ["agentforge-chat-history-redis ~= 0.4.0"]
 
 # Rerankers
-reranker-cohere = ["agentforge-reranker-cohere[cohere] ~= 0.3.1"]
-reranker-voyage = ["agentforge-reranker-voyage[voyage] ~= 0.3.1"]
-reranker-mixedbread = ["agentforge-reranker-mixedbread[mixedbread] ~= 0.3.1"]
-reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.3.1"]
+reranker-cohere = ["agentforge-reranker-cohere[cohere] ~= 0.4.0"]
+reranker-voyage = ["agentforge-reranker-voyage[voyage] ~= 0.4.0"]
+reranker-mixedbread = ["agentforge-reranker-mixedbread[mixedbread] ~= 0.4.0"]
+reranker-sentence-transformers = ["agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.4.0"]
 
 # Guardrails (each hard-deps its SDK — no extra to chain)
-guard-llmguard = ["agentforge-guard-llmguard ~= 0.3.1"]
-guard-presidio = ["agentforge-guard-presidio ~= 0.3.1"]
-guard-nemo = ["agentforge-guard-nemo ~= 0.3.1"]
-guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.3.1"]
+guard-llmguard = ["agentforge-guard-llmguard ~= 0.4.0"]
+guard-presidio = ["agentforge-guard-presidio ~= 0.4.0"]
+guard-nemo = ["agentforge-guard-nemo ~= 0.4.0"]
+guard-llamaguard = ["agentforge-guard-llamaguard ~= 0.4.0"]
 
 # Observability
-langfuse = ["agentforge-langfuse[langfuse] ~= 0.3.1"]
-phoenix = ["agentforge-phoenix[phoenix] ~= 0.3.1"]
-otel = ["agentforge-otel ~= 0.3.1"]
-statsd = ["agentforge-statsd[statsd] ~= 0.3.1"]
-evidently = ["agentforge-evidently[evidently] ~= 0.3.1"]
+langfuse = ["agentforge-langfuse[langfuse] ~= 0.4.0"]
+phoenix = ["agentforge-phoenix[phoenix] ~= 0.4.0"]
+otel = ["agentforge-otel ~= 0.4.0"]
+statsd = ["agentforge-statsd[statsd] ~= 0.4.0"]
+evidently = ["agentforge-evidently[evidently] ~= 0.4.0"]
 
 # Protocols
-mcp = ["agentforge-mcp[mcp] ~= 0.3.1"]
-a2a = ["agentforge-a2a ~= 0.3.1"]
+mcp = ["agentforge-mcp[mcp] ~= 0.4.0"]
+a2a = ["agentforge-a2a ~= 0.4.0"]
 
 # Eval
-eval = ["agentforge-eval-geval ~= 0.3.1"]
+eval = ["agentforge-eval-geval ~= 0.4.0"]
 
 # Testing
-testing = ["agentforge-testing ~= 0.3.1"]
+testing = ["agentforge-testing ~= 0.4.0"]
 
 # Everything (development / docs / smoke-test convenience — not
 # recommended for production deploys; pick the actual integrations
 # you use to keep the dependency tree small). Vendor-SDK extras are
 # chained here too so `[all]` actually installs every SDK.
 all = [
-    "agentforge-anthropic[anthropic] ~= 0.3.1",
-    "agentforge-openai[openai] ~= 0.3.1",
-    "agentforge-bedrock ~= 0.3.1",
-    "agentforge-ollama[ollama] ~= 0.3.1",
-    "agentforge-litellm[litellm] ~= 0.3.1",
-    "agentforge-voyage[voyage] ~= 0.3.1",
-    "agentforge-memory-sqlite ~= 0.3.1",
-    "agentforge-memory-postgres ~= 0.3.1",
-    "agentforge-memory-neo4j ~= 0.3.1",
-    "agentforge-memory-surrealdb ~= 0.3.1",
-    "agentforge-chat ~= 0.3.1",
-    "agentforge-chat-http ~= 0.3.1",
-    "agentforge-chat-slack ~= 0.3.1",
-    "agentforge-chat-history-postgres ~= 0.3.1",
-    "agentforge-chat-history-redis ~= 0.3.1",
-    "agentforge-reranker-cohere[cohere] ~= 0.3.1",
-    "agentforge-reranker-voyage[voyage] ~= 0.3.1",
-    "agentforge-reranker-mixedbread[mixedbread] ~= 0.3.1",
-    "agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.3.1",
-    "agentforge-guard-llmguard ~= 0.3.1",
-    "agentforge-guard-presidio ~= 0.3.1",
-    "agentforge-guard-nemo ~= 0.3.1",
-    "agentforge-guard-llamaguard ~= 0.3.1",
-    "agentforge-langfuse[langfuse] ~= 0.3.1",
-    "agentforge-phoenix[phoenix] ~= 0.3.1",
-    "agentforge-otel ~= 0.3.1",
-    "agentforge-statsd[statsd] ~= 0.3.1",
-    "agentforge-evidently[evidently] ~= 0.3.1",
-    "agentforge-mcp[mcp] ~= 0.3.1",
-    "agentforge-a2a ~= 0.3.1",
-    "agentforge-eval-geval ~= 0.3.1",
-    "agentforge-testing ~= 0.3.1",
+    "agentforge-anthropic[anthropic] ~= 0.4.0",
+    "agentforge-openai[openai] ~= 0.4.0",
+    "agentforge-bedrock ~= 0.4.0",
+    "agentforge-ollama[ollama] ~= 0.4.0",
+    "agentforge-litellm[litellm] ~= 0.4.0",
+    "agentforge-voyage[voyage] ~= 0.4.0",
+    "agentforge-memory-sqlite ~= 0.4.0",
+    "agentforge-memory-postgres ~= 0.4.0",
+    "agentforge-memory-neo4j ~= 0.4.0",
+    "agentforge-memory-surrealdb ~= 0.4.0",
+    "agentforge-chat ~= 0.4.0",
+    "agentforge-chat-http ~= 0.4.0",
+    "agentforge-chat-slack ~= 0.4.0",
+    "agentforge-chat-history-postgres ~= 0.4.0",
+    "agentforge-chat-history-redis ~= 0.4.0",
+    "agentforge-reranker-cohere[cohere] ~= 0.4.0",
+    "agentforge-reranker-voyage[voyage] ~= 0.4.0",
+    "agentforge-reranker-mixedbread[mixedbread] ~= 0.4.0",
+    "agentforge-reranker-sentence-transformers[sentence-transformers] ~= 0.4.0",
+    "agentforge-guard-llmguard ~= 0.4.0",
+    "agentforge-guard-presidio ~= 0.4.0",
+    "agentforge-guard-nemo ~= 0.4.0",
+    "agentforge-guard-llamaguard ~= 0.4.0",
+    "agentforge-langfuse[langfuse] ~= 0.4.0",
+    "agentforge-phoenix[phoenix] ~= 0.4.0",
+    "agentforge-otel ~= 0.4.0",
+    "agentforge-statsd[statsd] ~= 0.4.0",
+    "agentforge-evidently[evidently] ~= 0.4.0",
+    "agentforge-mcp[mcp] ~= 0.4.0",
+    "agentforge-a2a ~= 0.4.0",
+    "agentforge-eval-geval ~= 0.4.0",
+    "agentforge-testing ~= 0.4.0",
 ]
 
 [project.scripts]

--- a/packages/agentforge/src/agentforge/cli/release_notes.json
+++ b/packages/agentforge/src/agentforge/cli/release_notes.json
@@ -4,6 +4,11 @@
     {
       "version": "Unreleased",
       "date": null,
+      "entries": {}
+    },
+    {
+      "version": "0.4.0",
+      "date": "2026-06-23",
       "entries": {
         "Added": [
           {

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ members = [
 
 [[package]]
 name = "agentforge-a2a"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-a2a" }
 dependencies = [
     { name = "agentforge-core" },
@@ -74,7 +74,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-anthropic"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-anthropic" }
 dependencies = [
     { name = "agentforge-core" },
@@ -94,7 +94,7 @@ provides-extras = ["anthropic"]
 
 [[package]]
 name = "agentforge-bedrock"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-bedrock" }
 dependencies = [
     { name = "agentforge-core" },
@@ -111,7 +111,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-chat" }
 dependencies = [
     { name = "agentforge-core" },
@@ -128,7 +128,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-history-postgres"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-chat-history-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -143,7 +143,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-history-redis"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-chat-history-redis" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -160,7 +160,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-http"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-chat-http" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -183,7 +183,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-chat-slack"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-chat-slack" }
 dependencies = [
     { name = "agentforge-chat" },
@@ -202,7 +202,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-core"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-core" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -219,7 +219,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-eval-geval"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-eval-geval" }
 dependencies = [
     { name = "agentforge-core" },
@@ -234,7 +234,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-evidently"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-evidently" }
 dependencies = [
     { name = "agentforge-core" },
@@ -254,7 +254,7 @@ provides-extras = ["evidently"]
 
 [[package]]
 name = "agentforge-governance"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-governance" }
 dependencies = [
     { name = "agentforge-core" },
@@ -265,7 +265,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llamaguard"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-guard-llamaguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -276,7 +276,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-llmguard"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-guard-llmguard" }
 dependencies = [
     { name = "agentforge-core" },
@@ -287,7 +287,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-nemo"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-guard-nemo" }
 dependencies = [
     { name = "agentforge-core" },
@@ -298,7 +298,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-guard-presidio"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-guard-presidio" }
 dependencies = [
     { name = "agentforge-core" },
@@ -309,7 +309,7 @@ requires-dist = [{ name = "agentforge-core", editable = "packages/agentforge-cor
 
 [[package]]
 name = "agentforge-langfuse"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-langfuse" }
 dependencies = [
     { name = "agentforge-core" },
@@ -329,7 +329,7 @@ provides-extras = ["langfuse"]
 
 [[package]]
 name = "agentforge-litellm"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-litellm" }
 dependencies = [
     { name = "agentforge-core" },
@@ -349,7 +349,7 @@ provides-extras = ["litellm"]
 
 [[package]]
 name = "agentforge-mcp"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-mcp" }
 dependencies = [
     { name = "agentforge-core" },
@@ -369,7 +369,7 @@ provides-extras = ["mcp"]
 
 [[package]]
 name = "agentforge-memory-kuzu"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-memory-kuzu" }
 dependencies = [
     { name = "agentforge-core" },
@@ -384,7 +384,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-neo4j"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-memory-neo4j" }
 dependencies = [
     { name = "agentforge-core" },
@@ -399,7 +399,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-postgres"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-memory-postgres" }
 dependencies = [
     { name = "agentforge-core" },
@@ -416,7 +416,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-sqlite"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-memory-sqlite" }
 dependencies = [
     { name = "agentforge-core" },
@@ -431,7 +431,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-memory-surrealdb"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-memory-surrealdb" }
 dependencies = [
     { name = "agentforge-core" },
@@ -446,7 +446,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-ollama"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-ollama" }
 dependencies = [
     { name = "agentforge-core" },
@@ -466,7 +466,7 @@ provides-extras = ["ollama"]
 
 [[package]]
 name = "agentforge-openai"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-openai" }
 dependencies = [
     { name = "agentforge-core" },
@@ -486,7 +486,7 @@ provides-extras = ["openai"]
 
 [[package]]
 name = "agentforge-otel"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-otel" }
 dependencies = [
     { name = "agentforge-core" },
@@ -503,7 +503,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-phoenix"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-phoenix" }
 dependencies = [
     { name = "agentforge-core" },
@@ -523,7 +523,7 @@ provides-extras = ["phoenix"]
 
 [[package]]
 name = "agentforge-py"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge" }
 dependencies = [
     { name = "agentforge-core" },
@@ -741,7 +741,7 @@ provides-extras = ["anthropic", "openai", "bedrock", "ollama", "litellm", "voyag
 
 [[package]]
 name = "agentforge-reranker-cohere"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-reranker-cohere" }
 dependencies = [
     { name = "agentforge-core" },
@@ -761,7 +761,7 @@ provides-extras = ["cohere"]
 
 [[package]]
 name = "agentforge-reranker-mixedbread"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-reranker-mixedbread" }
 dependencies = [
     { name = "agentforge-core" },
@@ -781,7 +781,7 @@ provides-extras = ["mixedbread"]
 
 [[package]]
 name = "agentforge-reranker-sentence-transformers"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-reranker-sentence-transformers" }
 dependencies = [
     { name = "agentforge-core" },
@@ -801,7 +801,7 @@ provides-extras = ["sentence-transformers"]
 
 [[package]]
 name = "agentforge-reranker-voyage"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-reranker-voyage" }
 dependencies = [
     { name = "agentforge-core" },
@@ -821,7 +821,7 @@ provides-extras = ["voyage"]
 
 [[package]]
 name = "agentforge-statsd"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-statsd" }
 dependencies = [
     { name = "agentforge-core" },
@@ -841,7 +841,7 @@ provides-extras = ["statsd"]
 
 [[package]]
 name = "agentforge-testing"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-testing" }
 dependencies = [
     { name = "agentforge-core" },
@@ -856,7 +856,7 @@ requires-dist = [
 
 [[package]]
 name = "agentforge-voyage"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/agentforge-voyage" }
 dependencies = [
     { name = "agentforge-core" },


### PR DESCRIPTION
## Summary

**Release prep only** — version bump + release notes. **Not** cutting the `release/0.4.0` branch or tag; that follows from `main` once this is merged + tested (per the release process).

## Changes

- **Version bump.** Every workspace package `0.3.1 → 0.4.0` — **36 packages**, including the two new ones (`agentforge-memory-kuzu`, `agentforge-governance`) — plus **106** cross-package `~= 0.4.0` pins. `uv.lock` regenerated. Root pyproject stays `0.0.0`. (`agentforge --version` → `0.4.0` verified.)
- **CHANGELOG.** The accumulated `[Unreleased]` section becomes `[0.4.0] — 2026-06-23` with a train summary; a fresh empty `[Unreleased]` on top. The packaged `release_notes.json` regenerated from it (drift guard green).
- **Release notes.** `docs/releases/v0.4.0.md` — "Graph + governance foundation": feat-027 Kùzu GraphStore, enh-005 directional GraphRAG, enh-006 drift report, feat-029 governance identity, the bug-025 fix; plus the feat-028 + ADR-0023 designs that landed.

## What's in v0.4.0

Shipped code: **feat-027** (Kùzu) · **enh-005** (directional GraphRAG) · **enh-006** (drift report) · **feat-029** (governance identity) · **bug-025** (upgrade data-loss fix) + the starlette/httpx2 bump. Designs: **feat-028** (durable exec) · **ADR-0023** + governance specs.

## Validation

Full packaged-wheel E2E passed (build all → scaffold → validate → add-module → replay → `upgrade --notes` → Kùzu round-trip → governance identity). Pre-commit green over the prep changeset (drift guard + full suite + coverage).

The date (2026-06-23) is the planned release day — adjust if it slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)